### PR TITLE
feat: 회원가입, 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,18 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/example/sharemind/SharemindApplication.java
+++ b/src/main/java/com/example/sharemind/SharemindApplication.java
@@ -2,7 +2,9 @@ package com.example.sharemind;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SharemindApplication {
 

--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -1,7 +1,10 @@
 package com.example.sharemind.auth.application;
 
+import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import com.example.sharemind.auth.dto.response.TokenDto;
 
 public interface AuthService {
     void signUp(AuthSignUpRequest authSignUpRequest);
+    TokenDto signIn(AuthSignInRequest authSignInRequest);
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -1,10 +1,13 @@
 package com.example.sharemind.auth.application;
 
+import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
 import com.example.sharemind.auth.dto.response.TokenDto;
+import com.example.sharemind.customer.domain.Customer;
 
 public interface AuthService {
     void signUp(AuthSignUpRequest authSignUpRequest);
     TokenDto signIn(AuthSignInRequest authSignInRequest);
+    TokenDto reissueToken(AuthReissueRequest authReissueRequest, Customer customer);
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -1,0 +1,7 @@
+package com.example.sharemind.auth.application;
+
+import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+
+public interface AuthService {
+    void signUp(AuthSignUpRequest authSignUpRequest);
+}

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.sharemind.auth.application;
+
+import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.customer.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final CustomerRepository customerRepository;
+
+    @Transactional
+    @Override
+    public void signUp(AuthSignUpRequest authSignUpRequest) {
+        Customer customer = authSignUpRequest.toEntity(passwordEncoder.encode(authSignUpRequest.getPassword()));
+        customerRepository.save(customer);
+    }
+}

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -2,6 +2,8 @@ package com.example.sharemind.auth.application;
 
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
 import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.customer.exception.CustomerErrorCode;
+import com.example.sharemind.customer.exception.CustomerException;
 import com.example.sharemind.customer.repository.CustomerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,6 +21,11 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     @Override
     public void signUp(AuthSignUpRequest authSignUpRequest) {
+
+        if (customerRepository.existsByEmail(authSignUpRequest.getEmail())) {
+            throw new CustomerException(CustomerErrorCode.EMAIL_ALREADY_EXIST, authSignUpRequest.getEmail());
+        }
+
         Customer customer = authSignUpRequest.toEntity(passwordEncoder.encode(authSignUpRequest.getPassword()));
         customerRepository.save(customer);
     }

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -1,11 +1,16 @@
 package com.example.sharemind.auth.application;
 
+import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import com.example.sharemind.auth.dto.response.TokenDto;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.customer.exception.CustomerErrorCode;
 import com.example.sharemind.customer.exception.CustomerException;
 import com.example.sharemind.customer.repository.CustomerRepository;
+import com.example.sharemind.global.common.BaseEntity;
+import com.example.sharemind.global.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
+    private final TokenProvider tokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final CustomerRepository customerRepository;
 
@@ -28,5 +34,23 @@ public class AuthServiceImpl implements AuthService {
 
         Customer customer = authSignUpRequest.toEntity(passwordEncoder.encode(authSignUpRequest.getPassword()));
         customerRepository.save(customer);
+    }
+
+    @Transactional
+    @Override
+    public TokenDto signIn(AuthSignInRequest authSignInRequest) {
+
+        Customer customer = customerRepository.findByEmail(authSignInRequest.getEmail())
+                .filter(BaseEntity::isActivated)
+                .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, authSignInRequest.getEmail()));
+
+        if (!passwordEncoder.matches(authSignInRequest.getPassword(), customer.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = tokenProvider.createAccessToken(customer.getEmail(), customer.getRoles());
+        String refreshToken = tokenProvider.createRefreshToken(customer.getEmail());
+
+        return TokenDto.of(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthReissueRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthReissueRequest.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.auth.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AuthReissueRequest {
+
+    private String refreshToken;
+}

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignInRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignInRequest.java
@@ -1,0 +1,10 @@
+package com.example.sharemind.auth.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AuthSignInRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
@@ -1,0 +1,25 @@
+package com.example.sharemind.auth.dto.request;
+
+import com.example.sharemind.customer.domain.Customer;
+import lombok.Getter;
+
+import java.util.Random;
+
+@Getter
+public class AuthSignUpRequest {
+
+    private String email;
+    private String password;
+    private String phoneNumber;
+    private String recoveryEmail;
+
+    public Customer toEntity(String password) {
+        return Customer.builder()
+                .nickname("사용자" + new Random().nextInt(999999))
+                .email(email)
+                .password(password)
+                .phoneNumber(phoneNumber)
+                .recoveryEmail(recoveryEmail)
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/auth/dto/response/TokenDto.java
+++ b/src/main/java/com/example/sharemind/auth/dto/response/TokenDto.java
@@ -1,0 +1,17 @@
+package com.example.sharemind.auth.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenDto {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    public static TokenDto of(String accessToken, String refreshToken) {
+        return new TokenDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.sharemind.auth.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthErrorCode {
+
+    ILLEGAL_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    ILLEGAL_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 올바르지 않습니다.");
+
+    private final HttpStatus errorHttpStatus;
+    private String errorMessage;
+
+    AuthErrorCode(HttpStatus errorHttpStatus, String errorMessage) {
+        this.errorHttpStatus = errorHttpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    public void updateErrorMessage(String wrongInput) {
+        this.errorMessage = this.errorMessage + " : " + wrongInput;
+    }
+}

--- a/src/main/java/com/example/sharemind/auth/exception/AuthException.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthException.java
@@ -1,0 +1,13 @@
+package com.example.sharemind.auth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+
+    private final AuthErrorCode errorCode;
+
+    public AuthException(AuthErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -1,0 +1,25 @@
+package com.example.sharemind.auth.presentation;
+
+import com.example.sharemind.auth.application.AuthService;
+import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signUp")
+    public ResponseEntity<Void> signUp(@RequestBody AuthSignUpRequest authSignUpRequest) {
+        authService.signUp(authSignUpRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -1,12 +1,15 @@
 package com.example.sharemind.auth.presentation;
 
 import com.example.sharemind.auth.application.AuthService;
+import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
 import com.example.sharemind.auth.dto.response.TokenDto;
+import com.example.sharemind.global.jwt.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +31,10 @@ public class AuthController {
     @PostMapping("/signIn")
     public ResponseEntity<TokenDto> signIn(@RequestBody AuthSignInRequest authSignInRequest) {
         return ResponseEntity.ok(authService.signIn(authSignInRequest));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissueToken(@RequestBody AuthReissueRequest authReissueRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(authService.reissueToken(authReissueRequest, customUserDetails.getCustomer()));
     }
 }

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -1,7 +1,9 @@
 package com.example.sharemind.auth.presentation;
 
 import com.example.sharemind.auth.application.AuthService;
+import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import com.example.sharemind.auth.dto.response.TokenDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,5 +23,10 @@ public class AuthController {
     public ResponseEntity<Void> signUp(@RequestBody AuthSignUpRequest authSignUpRequest) {
         authService.signUp(authSignUpRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/signIn")
+    public ResponseEntity<TokenDto> signIn(@RequestBody AuthSignInRequest authSignInRequest) {
+        return ResponseEntity.ok(authService.signIn(authSignInRequest));
     }
 }

--- a/src/main/java/com/example/sharemind/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/sharemind/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,31 @@
+package com.example.sharemind.auth.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+public class RefreshTokenRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RefreshTokenRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String key, String value, Duration duration) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value, duration);
+    }
+
+    public String findByKey(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteByKey(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -32,7 +32,7 @@ public class Customer extends BaseEntity {
     private String phoneNumber;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -4,7 +4,12 @@ import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.content.Bank;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -16,15 +21,21 @@ public class Customer extends BaseEntity {
     @Column(name = "customer_id")
     private Long customerId;
 
-    private String name;
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<Role> roles;
 
+    @Column(nullable = false)
     private String nickname;
 
-    @Column(name = "phone_number")
+    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 하이픈(-)을 포함한 10~11자리입니다.")
+    @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private String password;
 
     @Column(name = "optional_agreement")
@@ -37,10 +48,24 @@ public class Customer extends BaseEntity {
     @Column(name = "account_holder")
     private String accountHolder;
 
-    @Column(name = "recovery_email")
+    @Email(message = "복구 이메일 형식이 올바르지 않습니다.")
+    @Column(name = "recovery_email", nullable = false)
     private String recoveryEmail;
 
     @OneToOne
     @JoinColumn(name = "counselor_id", unique = true)
     private Counselor counselor;
+
+    @Builder
+    public Customer(String nickname, String email, String password, String phoneNumber, String recoveryEmail) {
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.recoveryEmail = recoveryEmail;
+
+        this.roles = new ArrayList<>() {{
+            add(Role.CUSTOMER);
+        }};
+    }
 }

--- a/src/main/java/com/example/sharemind/customer/domain/Role.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Role.java
@@ -1,0 +1,10 @@
+package com.example.sharemind.customer.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+
+    CUSTOMER,
+    COUNSELOR
+}

--- a/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CustomerErrorCode {
 
-    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 회원으로 등록된 이메일입니다.");
+    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 회원으로 등록된 이메일입니다."),
+    CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보가 존재하지 않습니다.");
 
     private final HttpStatus errorHttpStatus;
     private String errorMessage;

--- a/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.sharemind.customer.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CustomerErrorCode {
+
+    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 회원으로 등록된 이메일입니다.");
+
+    private final HttpStatus errorHttpStatus;
+    private String errorMessage;
+
+    CustomerErrorCode(HttpStatus errorHttpStatus, String errorMessage) {
+        this.errorHttpStatus = errorHttpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    public void updateErrorMessage(String wrongInput) {
+        this.errorMessage = this.errorMessage + " : " + wrongInput;
+    }
+}

--- a/src/main/java/com/example/sharemind/customer/exception/CustomerException.java
+++ b/src/main/java/com/example/sharemind/customer/exception/CustomerException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.customer.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomerException extends RuntimeException {
+
+    private final CustomerErrorCode errorCode;
+
+    public CustomerException(CustomerErrorCode errorCode, String message) {
+        this.errorCode = errorCode;
+        errorCode.updateErrorMessage(message);
+    }
+}

--- a/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.customer.repository;
+
+import com.example.sharemind.customer.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+}

--- a/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
@@ -4,7 +4,10 @@ import com.example.sharemind.customer.domain.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Boolean existsByEmail(String email);
+    Optional<Customer> findByEmail(String email);
 }

--- a/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/sharemind/global/common/BaseEntity.java
+++ b/src/main/java/com/example/sharemind/global/common/BaseEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @MappedSuperclass
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/com/example/sharemind/global/config/RedisConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.example.sharemind.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -1,0 +1,76 @@
+package com.example.sharemind.global.config;
+
+import com.example.sharemind.customer.domain.Role;
+import com.example.sharemind.global.jwt.JwtAccessDeniedHandler;
+import com.example.sharemind.global.jwt.JwtAuthenticationEntryPoint;
+import com.example.sharemind.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
+                .csrf(CsrfConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(HttpBasicConfigurer::disable)
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(
+                        requests -> requests.requestMatchers("/error", "/api/v1/auth/**").permitAll()
+                                .requestMatchers("/api/v1/customers/**").hasRole(Role.CUSTOMER.name())
+                                .anyRequest().authenticated()
+                )
+                .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler));
+
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOrigin("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.sharemind.global.exception;
 
 import com.example.sharemind.customer.exception.CustomerException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,5 +16,12 @@ public class GlobalExceptionHandler {
         log.error(e.getErrorCode().getErrorMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getErrorHttpStatus())
                 .body(GlobalExceptionResponse.of(e.getErrorCode().getErrorHttpStatus(), e.getErrorCode().getErrorMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<GlobalExceptionResponse> catchException(Exception e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(GlobalExceptionResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
     }
 }

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.global.exception;
 
+import com.example.sharemind.auth.exception.AuthException;
 import com.example.sharemind.customer.exception.CustomerException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<GlobalExceptionResponse> catchAuthException(AuthException e) {
+        log.error(e.getErrorCode().getErrorMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getErrorHttpStatus())
+                .body(GlobalExceptionResponse.of(e.getErrorCode().getErrorHttpStatus(), e.getErrorCode().getErrorMessage()));
+    }
 
     @ExceptionHandler(CustomerException.class)
     public ResponseEntity<GlobalExceptionResponse> catchCustomerException(CustomerException e) {

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.sharemind.global.exception;
+
+import com.example.sharemind.customer.exception.CustomerException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomerException.class)
+    public ResponseEntity<GlobalExceptionResponse> catchCustomerException(CustomerException e) {
+        log.error(e.getErrorCode().getErrorMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getErrorHttpStatus())
+                .body(GlobalExceptionResponse.of(e.getErrorCode().getErrorHttpStatus(), e.getErrorCode().getErrorMessage()));
+    }
+}

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionResponse.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionResponse.java
@@ -1,0 +1,21 @@
+package com.example.sharemind.global.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GlobalExceptionResponse {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final LocalDateTime timeStamp;
+
+    public static GlobalExceptionResponse of(HttpStatus httpStatus, String message) {
+        return new GlobalExceptionResponse(httpStatus, message, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/example/sharemind/global/jwt/CustomUserDetails.java
+++ b/src/main/java/com/example/sharemind/global/jwt/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.example.sharemind.global.jwt;
+
+import com.example.sharemind.customer.domain.Customer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Customer customer;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return customer.getRoles()
+                .stream()
+                .map(role -> new SimpleGrantedAuthority(role.toString()))
+                .toList();
+    }
+
+    @Override
+    public String getPassword() {
+        return customer.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return customer.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return customer.isActivated();
+    }
+}

--- a/src/main/java/com/example/sharemind/global/jwt/CustomUserDetails.java
+++ b/src/main/java/com/example/sharemind/global/jwt/CustomUserDetails.java
@@ -13,6 +13,10 @@ public class CustomUserDetails implements UserDetails {
 
     private final Customer customer;
 
+    public Customer getCustomer() {
+        return customer;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return customer.getRoles()

--- a/src/main/java/com/example/sharemind/global/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/example/sharemind/global/jwt/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.example.sharemind.global.jwt;
+
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.customer.exception.CustomerErrorCode;
+import com.example.sharemind.customer.exception.CustomerException;
+import com.example.sharemind.customer.repository.CustomerRepository;
+import com.example.sharemind.global.common.BaseEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final CustomerRepository customerRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Customer customer = customerRepository.findByEmail(username)
+                .filter(BaseEntity::isActivated)
+                .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, username));
+
+        return new CustomUserDetails(customer);
+    }
+}

--- a/src/main/java/com/example/sharemind/global/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/sharemind/global/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.example.sharemind.global.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("Forbidden Request : {}", request.getRequestURI());
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.example.sharemind.global.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.error("Unauthorized Request : {}", request.getRequestURI());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "사용자 인증이 필요합니다.");
+    }
+}

--- a/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.example.sharemind.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request){
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
+            return bearerToken.replace(TOKEN_PREFIX, "");
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
+++ b/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
@@ -90,7 +90,7 @@ public class TokenProvider implements InitializingBean {
         Duration duration = Duration.between(Instant.now(), expirationTime.toInstant());
         refreshTokenRepository.save(email, refreshToken, duration);
 
-        return "Bearer " + refreshToken;
+        return refreshToken;
     }
 
     public Authentication getAuthentication(String token) {

--- a/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
+++ b/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
@@ -1,0 +1,125 @@
+package com.example.sharemind.global.jwt;
+
+import com.example.sharemind.auth.repository.RefreshTokenRepository;
+import com.example.sharemind.customer.domain.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TokenProvider implements InitializingBean {
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final String secret;
+    private final Long accessExpirationTime;
+    private final Long refreshExpirationTime;
+    private Key key;
+
+    public TokenProvider(CustomUserDetailsService customUserDetailsService,
+                         RefreshTokenRepository refreshTokenRepository,
+                         @Value("${jwt.secret}") String secret,
+                         @Value("${jwt.access-expiration-time}") Long accessExpirationTime,
+                         @Value("${jwt.refresh-expiration-time}") Long refreshExpirationTime) {
+        this.customUserDetailsService = customUserDetailsService;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.secret = secret;
+        this.accessExpirationTime = accessExpirationTime;
+        this.refreshExpirationTime = refreshExpirationTime;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(String email, List<Role> roles) {
+
+        String authorities = roles.stream()
+                .map(Enum::name)
+                .collect(Collectors.joining(","));
+
+        Claims claims = Jwts.claims()
+                .setSubject(email);
+        claims.put("authorities", authorities);
+
+        Date expirationTime = getExpirationTime(accessExpirationTime);
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(expirationTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return "Bearer " + accessToken;
+    }
+
+    public String createRefreshToken(String email) {
+
+        Claims claims = Jwts.claims()
+                .setSubject(email);
+
+        Date expirationTime = getExpirationTime(refreshExpirationTime);
+
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(expirationTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        Duration duration = Duration.between(Instant.now(), expirationTime.toInstant());
+        refreshTokenRepository.save(email, refreshToken, duration);
+
+        return "Bearer " + refreshToken;
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        String email = parseClaims(token).getSubject();
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            log.warn(e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Date getExpirationTime(Long expirationTime) {
+        return new Date((new Date()).getTime() + expirationTime);
+    }
+}


### PR DESCRIPTION
## 📄구현 내용
- 회원가입 구현
- 로그인 구현
  - redis에 refresh token 저장
- 토큰 재발급 구현

## 📝기타 알림사항
- BaseEntity 추상 클래스로 변경 (단독으로 쓰이지 않아 추상 클래스가 더 맞는 것 같다는 생각이 들었습니다!)
- 이름 입력 필요없다는 기획 피드백에 따라 Customer 테이블에 name 필드 삭제
- v0에서는 mapper 사용했으나, mapper의 수가 늘어나면 관리가 어려운 것 같아 이번에는 dto에서 생성하는 방식으로 바꿔보았습니다. 특히, response에서는 정적 팩토리 메서드 사용하고 있습니다. 어떠신지 의견 부탁드립니다~
- 예외 처리 방식
  - 통일성 있는 형식으로 반환하고자 GlobalExceptionResponse를 만들었습니다.
  - 이전에는 각 커스텀 예외를 처리하는 ExceptionController들이 각각 존재했으나, 새로운 커스텀 예외를 만들 때마다 새로운 catch~~~Exception 메서드를 만들어주어야하는 부분이 번거롭다는 생각이 들어 예외를 나타내는 ErrorCode enum을 만들고, ErrorCode를 가지고 exception을 만드는 도메인별 exception들을 한꺼번에 GlobalExceptionHandler에서 관리하도록 바꿔보았습니다. 이것 또한 의견 부탁드립니다~
- 커밋 수가 너무 많아지는 것 같아 일단 인증 메일 발송은 제외하고 구현하였습니다.
- 일부 예외 처리가 미흡한 부분들이 있습니다. 인증 메일 발송과 함께 개선하도록 하겠습니다.