### PR TITLE
refactor: 회원가입, 로그인 리팩토링

### DIFF
--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -4,10 +4,9 @@ import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
 import com.example.sharemind.auth.dto.response.TokenDto;
-import com.example.sharemind.customer.domain.Customer;
 
 public interface AuthService {
     void signUp(AuthSignUpRequest authSignUpRequest);
     TokenDto signIn(AuthSignInRequest authSignInRequest);
-    TokenDto reissueToken(AuthReissueRequest authReissueRequest, Customer customer);
+    TokenDto reissueToken(AuthReissueRequest authReissueRequest);
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -30,7 +30,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public void signUp(AuthSignUpRequest authSignUpRequest) {
 
-        if (customerRepository.existsByEmail(authSignUpRequest.getEmail())) {
+        if (customerRepository.existsByEmailAndIsActivatedIsTrue(authSignUpRequest.getEmail())) {
             throw new CustomerException(CustomerErrorCode.EMAIL_ALREADY_EXIST, authSignUpRequest.getEmail());
         }
 

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -56,11 +56,15 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public TokenDto reissueToken(AuthReissueRequest authReissueRequest, Customer customer) {
+    public TokenDto reissueToken(AuthReissueRequest authReissueRequest) {
 
-        if(!tokenProvider.validateToken(authReissueRequest.getRefreshToken())) {
+        if(!tokenProvider.validateRefreshToken(authReissueRequest.getRefreshToken())) {
             throw new AuthException(AuthErrorCode.ILLEGAL_REFRESH_TOKEN);
         }
+
+        String email = tokenProvider.getEmail(authReissueRequest.getRefreshToken());
+        Customer customer = customerRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, email));
 
         String accessToken = tokenProvider.createAccessToken(customer.getEmail(), customer.getRoles());
         String refreshToken = tokenProvider.createRefreshToken(customer.getEmail());

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -10,7 +10,6 @@ import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.customer.exception.CustomerErrorCode;
 import com.example.sharemind.customer.exception.CustomerException;
 import com.example.sharemind.customer.repository.CustomerRepository;
-import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -41,8 +40,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public TokenDto signIn(AuthSignInRequest authSignInRequest) {
 
-        Customer customer = customerRepository.findByEmail(authSignInRequest.getEmail())
-                .filter(BaseEntity::isActivated)
+        Customer customer = customerRepository.findByEmailAndIsActivatedIsTrue(authSignInRequest.getEmail())
                 .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, authSignInRequest.getEmail()));
 
         if (!passwordEncoder.matches(authSignInRequest.getPassword(), customer.getPassword())) {
@@ -63,7 +61,7 @@ public class AuthServiceImpl implements AuthService {
         }
 
         String email = tokenProvider.getEmail(authReissueRequest.getRefreshToken());
-        Customer customer = customerRepository.findByEmail(email)
+        Customer customer = customerRepository.findByEmailAndIsActivatedIsTrue(email)
                 .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, email));
 
         String accessToken = tokenProvider.createAccessToken(customer.getEmail(), customer.getRoles());

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthReissueRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthReissueRequest.java
@@ -1,9 +1,11 @@
 package com.example.sharemind.auth.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class AuthReissueRequest {
 
+    @NotBlank(message = "refresh token은 공백일 수 없습니다.")
     private String refreshToken;
 }

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignInRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignInRequest.java
@@ -1,10 +1,14 @@
 package com.example.sharemind.auth.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class AuthSignInRequest {
 
+    @NotBlank(message = "이메일은 공백일 수 없습니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
     private String password;
 }

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
@@ -2,6 +2,7 @@ package com.example.sharemind.auth.dto.request;
 
 import com.example.sharemind.customer.domain.Customer;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 import java.util.Random;
@@ -13,6 +14,8 @@ public class AuthSignUpRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    @Pattern(regexp = "^(?!((?:[A-Za-z]+)|(?:[~!@#$%^&*()_+=]+)|(?:[0-9]+))$)[A-Za-z\\d~!@#$%^&*()_+=]{10,}$",
+            message = "비밀번호는 영문, 숫자, 특수문자 중 2가지 이상을 조합한 10자리 이상의 문자열이어야 합니다.")
     private String password;
 
     @NotBlank(message = "전화번호는 공백일 수 없습니다.")

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.auth.dto.request;
 
 import com.example.sharemind.customer.domain.Customer;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 import java.util.Random;
@@ -8,9 +9,16 @@ import java.util.Random;
 @Getter
 public class AuthSignUpRequest {
 
+    @NotBlank(message = "이메일은 공백일 수 없습니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
     private String password;
+
+    @NotBlank(message = "전화번호는 공백일 수 없습니다.")
     private String phoneNumber;
+
+    @NotBlank(message = "복구 이메일은 공백일 수 없습니다.")
     private String recoveryEmail;
 
     public Customer toEntity(String password) {

--- a/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode {
 
     ILLEGAL_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    ILLEGAL_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 올바르지 않습니다.");
+    ILLEGAL_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 이미 만료되었거나 올바르지 않습니다.");
 
     private final HttpStatus errorHttpStatus;
     private String errorMessage;

--- a/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
@@ -10,14 +10,10 @@ public enum AuthErrorCode {
     ILLEGAL_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 이미 만료되었거나 올바르지 않습니다.");
 
     private final HttpStatus errorHttpStatus;
-    private String errorMessage;
+    private final String errorMessage;
 
     AuthErrorCode(HttpStatus errorHttpStatus, String errorMessage) {
         this.errorHttpStatus = errorHttpStatus;
         this.errorMessage = errorMessage;
-    }
-
-    public void updateErrorMessage(String wrongInput) {
-        this.errorMessage = this.errorMessage + " : " + wrongInput;
     }
 }

--- a/src/main/java/com/example/sharemind/auth/exception/AuthException.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthException.java
@@ -1,13 +1,15 @@
 package com.example.sharemind.auth.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class AuthException extends RuntimeException {
 
-    private final AuthErrorCode errorCode;
+    private final HttpStatus errorCode;
 
     public AuthException(AuthErrorCode errorCode) {
-        this.errorCode = errorCode;
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode.getErrorHttpStatus();
     }
 }

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -5,11 +5,9 @@ import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
 import com.example.sharemind.auth.dto.response.TokenDto;
-import com.example.sharemind.global.jwt.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,7 +32,7 @@ public class AuthController {
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto> reissueToken(@RequestBody AuthReissueRequest authReissueRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.ok(authService.reissueToken(authReissueRequest, customUserDetails.getCustomer()));
+    public ResponseEntity<TokenDto> reissueToken(@RequestBody AuthReissueRequest authReissueRequest) {
+        return ResponseEntity.ok(authService.reissueToken(authReissueRequest));
     }
 }

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -5,6 +5,7 @@ import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
 import com.example.sharemind.auth.dto.response.TokenDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,18 +22,18 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signUp")
-    public ResponseEntity<Void> signUp(@RequestBody AuthSignUpRequest authSignUpRequest) {
+    public ResponseEntity<Void> signUp(@Valid @RequestBody AuthSignUpRequest authSignUpRequest) {
         authService.signUp(authSignUpRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/signIn")
-    public ResponseEntity<TokenDto> signIn(@RequestBody AuthSignInRequest authSignInRequest) {
+    public ResponseEntity<TokenDto> signIn(@Valid @RequestBody AuthSignInRequest authSignInRequest) {
         return ResponseEntity.ok(authService.signIn(authSignInRequest));
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto> reissueToken(@RequestBody AuthReissueRequest authReissueRequest) {
+    public ResponseEntity<TokenDto> reissueToken(@Valid @RequestBody AuthReissueRequest authReissueRequest) {
         return ResponseEntity.ok(authService.reissueToken(authReissueRequest));
     }
 }

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -32,7 +32,7 @@ public class Customer extends BaseEntity {
     private String phoneNumber;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -27,7 +27,7 @@ public class Customer extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 하이픈(-)을 포함한 10~11자리입니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 하이픈(-)을 포함한 10~11자리이어야 합니다.")
     @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 

--- a/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
@@ -10,14 +10,10 @@ public enum CustomerErrorCode {
     CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보가 존재하지 않습니다.");
 
     private final HttpStatus errorHttpStatus;
-    private String errorMessage;
+    private final String errorMessage;
 
     CustomerErrorCode(HttpStatus errorHttpStatus, String errorMessage) {
         this.errorHttpStatus = errorHttpStatus;
         this.errorMessage = errorMessage;
-    }
-
-    public void updateErrorMessage(String wrongInput) {
-        this.errorMessage = this.errorMessage + " : " + wrongInput;
     }
 }

--- a/src/main/java/com/example/sharemind/customer/exception/CustomerException.java
+++ b/src/main/java/com/example/sharemind/customer/exception/CustomerException.java
@@ -1,14 +1,15 @@
 package com.example.sharemind.customer.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class CustomerException extends RuntimeException {
 
-    private final CustomerErrorCode errorCode;
+    private final HttpStatus errorCode;
 
     public CustomerException(CustomerErrorCode errorCode, String message) {
-        this.errorCode = errorCode;
-        errorCode.updateErrorMessage(message);
+        super(errorCode.getErrorMessage() + " : " + message);
+        this.errorCode = errorCode.getErrorHttpStatus();
     }
 }

--- a/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Boolean existsByEmailAndIsActivatedIsTrue(String email);
-    Optional<Customer> findByEmail(String email);
+    Optional<Customer> findByEmailAndIsActivatedIsTrue(String email);
 }

--- a/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/example/sharemind/customer/repository/CustomerRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
-    Boolean existsByEmail(String email);
+    Boolean existsByEmailAndIsActivatedIsTrue(String email);
     Optional<Customer> findByEmail(String email);
 }

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
@@ -16,16 +16,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<GlobalExceptionResponse> catchAuthException(AuthException e) {
-        log.error(e.getErrorCode().getErrorMessage(), e);
-        return ResponseEntity.status(e.getErrorCode().getErrorHttpStatus())
-                .body(GlobalExceptionResponse.of(e.getErrorCode().getErrorHttpStatus(), e.getErrorCode().getErrorMessage()));
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode())
+                .body(GlobalExceptionResponse.of(e.getErrorCode(), e.getMessage()));
     }
 
     @ExceptionHandler(CustomerException.class)
     public ResponseEntity<GlobalExceptionResponse> catchCustomerException(CustomerException e) {
-        log.error(e.getErrorCode().getErrorMessage(), e);
-        return ResponseEntity.status(e.getErrorCode().getErrorHttpStatus())
-                .body(GlobalExceptionResponse.of(e.getErrorCode().getErrorHttpStatus(), e.getErrorCode().getErrorMessage()));
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode())
+                .body(GlobalExceptionResponse.of(e.getErrorCode(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.sharemind.customer.exception.CustomerException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -24,6 +25,13 @@ public class GlobalExceptionHandler {
         log.error(e.getErrorCode().getErrorMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getErrorHttpStatus())
                 .body(GlobalExceptionResponse.of(e.getErrorCode().getErrorHttpStatus(), e.getErrorCode().getErrorMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<GlobalExceptionResponse> catchMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST, e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.sharemind.global.exception;
 
 import com.example.sharemind.auth.exception.AuthException;
 import com.example.sharemind.customer.exception.CustomerException;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,13 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST, e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<GlobalExceptionResponse> catchConstraintViolationException(ConstraintViolationException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST, e.getConstraintViolations().stream().findFirst().get().getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/sharemind/global/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/example/sharemind/global/jwt/CustomUserDetailsService.java
@@ -4,7 +4,6 @@ import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.customer.exception.CustomerErrorCode;
 import com.example.sharemind.customer.exception.CustomerException;
 import com.example.sharemind.customer.repository.CustomerRepository;
-import com.example.sharemind.global.common.BaseEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -20,8 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-        Customer customer = customerRepository.findByEmail(username)
-                .filter(BaseEntity::isActivated)
+        Customer customer = customerRepository.findByEmailAndIsActivatedIsTrue(username)
                 .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, username));
 
         return new CustomUserDetails(customer);

--- a/src/main/java/com/example/sharemind/global/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/sharemind/global/jwt/JwtAccessDeniedHandler.java
@@ -16,6 +16,6 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
         log.error("Forbidden Request : {}", request.getRequestURI());
-        response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }
 }

--- a/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationEntryPoint.java
@@ -16,6 +16,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         log.error("Unauthorized Request : {}", request.getRequestURI());
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "사용자 인증이 필요합니다.");
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/sharemind/global/jwt/JwtAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-        if (token != null && tokenProvider.validateToken(token)) {
+        if (token != null && tokenProvider.validateAccessToken(token)) {
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
+++ b/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
@@ -125,6 +125,10 @@ public class TokenProvider implements InitializingBean {
         }
     }
 
+    public String getEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
+
     private Claims parseClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)

--- a/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
+++ b/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
@@ -101,10 +101,24 @@ public class TokenProvider implements InitializingBean {
         return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
     }
 
-    public boolean validateToken(String token) {
+    public boolean validateAccessToken(String accessToken) {
         try {
-            Claims claims = parseClaims(token);
+            Claims claims = parseClaims(accessToken);
             return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            log.warn(e.getMessage(), e);
+            return false;
+        }
+    }
+
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            Claims claims = parseClaims(refreshToken);
+
+            String email = claims.getSubject();
+            String savedRefreshToken = refreshTokenRepository.findByKey(email);
+
+            return refreshToken.equals(savedRefreshToken);
         } catch (Exception e) {
             log.warn(e.getMessage(), e);
             return false;

--- a/src/main/java/com/example/sharemind/nonRealtimeConsult/content/NonRealtimeConsultStatus.java
+++ b/src/main/java/com/example/sharemind/nonRealtimeConsult/content/NonRealtimeConsultStatus.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.nonRealtimeConsult.content;
+
+public enum NonRealtimeConsultStatus {
+    WAITING,
+    FIRST_ASKING,
+    FIRST_ANSWER,
+    SECOND_ASKING,
+    FINISH
+}

--- a/src/main/java/com/example/sharemind/nonRealtimeConsult/domain/NonRealtimeConsult.java
+++ b/src/main/java/com/example/sharemind/nonRealtimeConsult/domain/NonRealtimeConsult.java
@@ -2,6 +2,7 @@ package com.example.sharemind.nonRealtimeConsult.domain;
 
 import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.content.ConsultCategory;
+import com.example.sharemind.nonRealtimeConsult.content.NonRealtimeConsultStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,4 +21,7 @@ public class NonRealtimeConsult extends BaseEntity {
 
     @Column(name = "read_id")
     private Long readId;
+
+    @Column(name = "consult_status")
+    private NonRealtimeConsultStatus consultStatus;
 }

--- a/src/main/java/com/example/sharemind/realtimeConsult/content/RealtimeConsultStatus.java
+++ b/src/main/java/com/example/sharemind/realtimeConsult/content/RealtimeConsultStatus.java
@@ -1,0 +1,7 @@
+package com.example.sharemind.realtimeConsult.content;
+
+public enum RealtimeConsultStatus {
+    WAITING,
+    ONGOING,
+    FINISH
+}

--- a/src/main/java/com/example/sharemind/realtimeConsult/domain/RealtimeConsult.java
+++ b/src/main/java/com/example/sharemind/realtimeConsult/domain/RealtimeConsult.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.realtimeConsult.domain;
 
 import com.example.sharemind.global.common.BaseEntity;
+import com.example.sharemind.realtimeConsult.content.RealtimeConsultStatus;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
@@ -18,8 +19,8 @@ public class RealtimeConsult extends BaseEntity {
     @Column(name = "started_at")
     private LocalDateTime startedAt;
 
-    @Column(name = "is_finished")
-    private Boolean isFinished;
+    @Column(name = "consult_status")
+    private RealtimeConsultStatus consultStatus;
 
     @Column(name = "read_id")
     private Long readId;


### PR DESCRIPTION
## 📄구현 내용
- validateAccessToken과 validateRefreshToken 분리
  - 액세스 토큰은 만료 여부만 확인(나머지는 시큐리티가 알아서 함), 리프레쉬 토큰은 레디스에 저장된 값과 일치 여부 확인(만료 기간 후에는 알아서 삭제되므로 만료 기간도 자동으로 같이 확인 가능)

- reIssueToken에서 사용되던 @AuthenticationPrincipal 삭제
  - 액세스 토큰이 이미 만료된 상황이므로 @AuthenticationPrinicipal 사용해도 값이 null로 들어오게 됨, 토큰 생성 시 필요한 사용자 정보는 리프레쉬 토큰에서 email 꺼내서 사용자 정보 조회 및 사용하는 방식으로 수정

- email unique 제약조건 삭제
  - unique 제약조건 설정할 경우 탈퇴 후 동일한 이메일로 재가입 시 가입 불가, 그 대신 회원가입 시 IsActivated 포함한 Customer 조회로 활성화 계정들 중 중복 이메일 여부 확인

- 필드 값 형식 검증
  - requestDto는 기본적으로 notBlank(null, "", " ")만 확인
  - 필드 형식 검증은 도메인에서 확인
  - 비밀번호는 저장 시 암호화된 값이므로 예외적으로 requestDto에서 형식 검증
  - 관련 예외 처리 GlobalExceptionHandler에 추가

- 커스텀 예외 에러 메시지 수정 주체 변경
  - ErrorCode enum에서 updateErrorMessage로 에러 메시지 수정하려고 하였으나, 그렇게 할 경우 에러 메시지가 영구적으로 수정되는 문제 발생, v0과 같이 Exception에서 수정해주는 것으로 변경

## 📝기타 알림사항
- 비실시간/실시간 상담 엔티티 수정 전 이미 push 해두었던 커밋들이 있어 커밋 내역이 약간 꼬이게 되었는데, 같은 내용으로 덮어씌워진 것이라 코드 상으로는 문제없을 것으로 보입니다...ㅎㅎㅎ