### PR TITLE
feat: 상담 신청 구현

### DIFF
--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -44,7 +44,7 @@ public class AuthServiceImpl implements AuthService {
                 .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, authSignInRequest.getEmail()));
 
         if (!passwordEncoder.matches(authSignInRequest.getPassword(), customer.getPassword())) {
-            throw new AuthException(AuthErrorCode.ILLEGAL_PASSWORD);
+            throw new AuthException(AuthErrorCode.INVALID_PASSWORD);
         }
 
         String accessToken = tokenProvider.createAccessToken(customer.getEmail(), customer.getRoles());
@@ -57,7 +57,7 @@ public class AuthServiceImpl implements AuthService {
     public TokenDto reissueToken(AuthReissueRequest authReissueRequest) {
 
         if(!tokenProvider.validateRefreshToken(authReissueRequest.getRefreshToken())) {
-            throw new AuthException(AuthErrorCode.ILLEGAL_REFRESH_TOKEN);
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         String email = tokenProvider.getEmail(authReissueRequest.getRefreshToken());

--- a/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
@@ -6,8 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum AuthErrorCode {
 
-    ILLEGAL_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    ILLEGAL_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 이미 만료되었거나 올바르지 않습니다.");
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 이미 만료되었거나 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
@@ -9,11 +9,11 @@ public enum AuthErrorCode {
     ILLEGAL_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     ILLEGAL_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 이미 만료되었거나 올바르지 않습니다.");
 
-    private final HttpStatus errorHttpStatus;
-    private final String errorMessage;
+    private final HttpStatus httpStatus;
+    private final String message;
 
-    AuthErrorCode(HttpStatus errorHttpStatus, String errorMessage) {
-        this.errorHttpStatus = errorHttpStatus;
-        this.errorMessage = errorMessage;
+    AuthErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
     }
 }

--- a/src/main/java/com/example/sharemind/auth/exception/AuthException.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthException.java
@@ -1,15 +1,14 @@
 package com.example.sharemind.auth.exception;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public class AuthException extends RuntimeException {
 
-    private final HttpStatus errorCode;
+    private final AuthErrorCode errorCode;
 
     public AuthException(AuthErrorCode errorCode) {
-        super(errorCode.getErrorMessage());
-        this.errorCode = errorCode.getErrorHttpStatus();
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.consult.application;
+
+import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
+import com.example.sharemind.consult.dto.response.ConsultCreateResponse;
+import com.example.sharemind.customer.domain.Customer;
+
+public interface ConsultService {
+    ConsultCreateResponse createConsult(ConsultCreateRequest consultCreateRequest, Customer customer);
+}

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -1,0 +1,46 @@
+package com.example.sharemind.consult.application;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
+import com.example.sharemind.consult.dto.response.ConsultCreateResponse;
+import com.example.sharemind.consult.repository.ConsultRepository;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.exception.CounselorErrorCode;
+import com.example.sharemind.counselor.exception.CounselorException;
+import com.example.sharemind.counselor.repository.CounselorRepository;
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.global.content.ConsultType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ConsultServiceImpl implements ConsultService {
+
+    private final ConsultRepository consultRepository;
+    private final CounselorRepository counselorRepository;
+
+    @Transactional
+    @Override
+    public ConsultCreateResponse createConsult(ConsultCreateRequest consultCreateRequest, Customer customer) {
+
+        // TODO 프로필 수정 심사 중인지도 확인해야할 것 같음
+        Counselor counselor = counselorRepository.findByCounselorIdAndIsActivatedIsTrue(consultCreateRequest.getCounselorId())
+                .orElseThrow(() -> new CounselorException(CounselorErrorCode.COUNSELOR_NOT_FOUND, consultCreateRequest.getCounselorId().toString()));
+
+        ConsultType consultType = ConsultType.getConsultTypeByName(consultCreateRequest.getConsultTypeName());
+        Long cost = counselor.getConsultCost(consultType);
+
+        Consult consult = Consult.builder()
+                .customer(customer)
+                .counselor(counselor)
+                .consultType(consultType)
+                .cost(cost)
+                .build();
+        consultRepository.save(consult);
+
+        return ConsultCreateResponse.of(consult, counselor);
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -29,15 +29,18 @@ public class Consult extends BaseEntity {
     @JoinColumn(name = "counselor_id")
     private Counselor counselor;
 
+    @Column(nullable = false)
     private Long cost;
 
-    @Column(name = "is_paid")
+    @Column(name = "is_paid", nullable = false)
     private Boolean isPaid;
 
-    @Column(name = "refund_status")
+    @Column(name = "refund_status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private RefundStatus refundStatus;
 
-    @Column(name = "type")
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
     private ConsultType consultType;
 
     @OneToOne
@@ -51,4 +54,15 @@ public class Consult extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "realtime_id", unique = true)
     private RealtimeConsult realtimeConsult;
+
+    @Builder
+    public Consult(Customer customer, Counselor counselor, Long cost, ConsultType consultType) {
+        this.customer = customer;
+        this.counselor = counselor;
+        this.cost = cost;
+        this.consultType = consultType;
+
+        this.isPaid = false;
+        this.refundStatus = RefundStatus.NO_REFUND;
+    }
 }

--- a/src/main/java/com/example/sharemind/consult/dto/request/ConsultCreateRequest.java
+++ b/src/main/java/com/example/sharemind/consult/dto/request/ConsultCreateRequest.java
@@ -1,0 +1,15 @@
+package com.example.sharemind.consult.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ConsultCreateRequest {
+
+    @NotNull(message = "상담사 id는 공백일 수 없습니다.")
+    private Long counselorId;
+
+    @NotBlank(message = "상담 유형은 공백일 수 없습니다.")
+    private String consultTypeName;
+}

--- a/src/main/java/com/example/sharemind/consult/dto/response/ConsultCreateResponse.java
+++ b/src/main/java/com/example/sharemind/consult/dto/response/ConsultCreateResponse.java
@@ -1,0 +1,37 @@
+package com.example.sharemind.consult.dto.response;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.global.content.ConsultCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ConsultCreateResponse {
+
+    private final Long consultId;
+    private final String nickname; // TODO 이런 식의 상담사 정보를 요청하는 api가 많아진다면 나중에 dto로 묶어버려도 될 듯
+    private final Integer level;
+    private final Double ratingAverage;
+    private final Long totalReview;
+    private final Set<String> consultCategories;
+    private final String consultStyle;
+    private final String consultType;
+    private final Long cost;
+
+    public static ConsultCreateResponse of(Consult consult, Counselor counselor) {
+        Set<String> consultCategories = counselor.getConsultCategories().stream()
+                .map(ConsultCategory::getDisplayName)
+                .collect(Collectors.toSet());
+
+        return new ConsultCreateResponse(consult.getConsultId(),
+                counselor.getNickname(), counselor.getLevel(), counselor.getRatingAverage(),
+                counselor.getTotalReview(), consultCategories, counselor.getConsultStyle().getDisplayName(),
+                consult.getConsultType().getDisplayName(), consult.getCost());
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -1,0 +1,27 @@
+package com.example.sharemind.consult.presentation;
+
+import com.example.sharemind.consult.application.ConsultService;
+import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
+import com.example.sharemind.consult.dto.response.ConsultCreateResponse;
+import com.example.sharemind.global.jwt.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/consults")
+@RequiredArgsConstructor
+public class ConsultController {
+
+    private final ConsultService consultService;
+
+    @PostMapping
+    public ResponseEntity<ConsultCreateResponse> createConsult(@Valid @RequestBody ConsultCreateRequest consultCreateRequest,
+                                                               @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(consultService.createConsult(consultCreateRequest, customUserDetails.getCustomer()));
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
+++ b/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.consult.repository;
+
+import com.example.sharemind.consult.domain.Consult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConsultRepository extends JpaRepository<Consult, Long> {
+}

--- a/src/main/java/com/example/sharemind/counselor/domain/ConsultCost.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/ConsultCost.java
@@ -1,0 +1,28 @@
+package com.example.sharemind.counselor.domain;
+
+import com.example.sharemind.global.content.ConsultType;
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ConsultCost {
+
+    private ConsultType consultType;
+
+    @Min(value = 5000, message = "상담료는 최소 5000원이어야 합니다.")
+    @Max(value = 100000, message = "상담료는 최대 100000원이어야 합니다.")
+    private Long cost;
+
+    @Builder
+    public ConsultCost(ConsultType consultType, Long cost) {
+        this.consultType = consultType;
+        this.cost = cost;
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -4,6 +4,7 @@ import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.content.Bank;
 import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.global.content.ConsultStyle;
+import com.example.sharemind.global.content.ConsultType;
 import jakarta.persistence.*;
 import java.util.Set;
 import lombok.*;
@@ -22,6 +23,18 @@ public class Counselor extends BaseEntity {
 
     @Column(name = "is_educated")
     private Boolean isEducated;
+
+    @ElementCollection(targetClass = ConsultCost.class, fetch = FetchType.LAZY)
+    @JoinTable(name = "costs", joinColumns = @JoinColumn(name = "counselor_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "consult_costs")
+    private Set<ConsultCost> consultCosts;
+
+    @ElementCollection(targetClass = ConsultType.class, fetch = FetchType.LAZY)
+    @JoinTable(name = "types", joinColumns = @JoinColumn(name = "counselor_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "consult_types")
+    private Set<ConsultType> consultTypes;
 
     @ElementCollection(targetClass = ConsultCategory.class, fetch = FetchType.LAZY)
     @JoinTable(name = "categories", joinColumns = @JoinColumn(name = "counselor_id"))
@@ -46,4 +59,10 @@ public class Counselor extends BaseEntity {
 
     @Column(name = "account_holder")
     private String accountHolder;
+
+    @Column(name = "total_review")
+    private Long totalReview;
+
+    @Column(name = "rating_average")
+    private Float ratingAverage;
 }

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -1,5 +1,7 @@
 package com.example.sharemind.counselor.domain;
 
+import com.example.sharemind.counselor.exception.CounselorErrorCode;
+import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.content.Bank;
 import com.example.sharemind.global.content.ConsultCategory;
@@ -43,6 +45,7 @@ public class Counselor extends BaseEntity {
     private Set<ConsultCategory> consultCategories;
 
     @Column(name = "consult_style")
+    @Enumerated(EnumType.STRING)
     private ConsultStyle consultStyle;
 
     @Column(columnDefinition = "TEXT")
@@ -55,6 +58,7 @@ public class Counselor extends BaseEntity {
 
     private String account;
 
+    @Enumerated(EnumType.STRING)
     private Bank bank;
 
     @Column(name = "account_holder")
@@ -64,5 +68,12 @@ public class Counselor extends BaseEntity {
     private Long totalReview;
 
     @Column(name = "rating_average")
-    private Float ratingAverage;
+    private Double ratingAverage;
+
+    public Long getConsultCost(ConsultType consultType) {
+        return this.consultCosts.stream()
+                .filter(consultCost -> consultCost.getConsultType().equals(consultType))
+                .findAny().orElseThrow(() -> new CounselorException(CounselorErrorCode.COST_NOT_FOUND))
+                .getCost();
+    }
 }

--- a/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
+++ b/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.sharemind.counselor.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CounselorErrorCode {
+
+    COUNSELOR_NOT_FOUND(HttpStatus.NOT_FOUND, "상담사 정보가 존재하지 않습니다."),
+    COST_NOT_FOUND(HttpStatus.NOT_FOUND, "상담료 정보가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    CounselorErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/exception/CounselorException.java
+++ b/src/main/java/com/example/sharemind/counselor/exception/CounselorException.java
@@ -1,0 +1,19 @@
+package com.example.sharemind.counselor.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CounselorException extends RuntimeException {
+
+    private final CounselorErrorCode errorCode;
+
+    public CounselorException(CounselorErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CounselorException(CounselorErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
+++ b/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
@@ -1,0 +1,12 @@
+package com.example.sharemind.counselor.repository;
+
+import com.example.sharemind.counselor.domain.Counselor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CounselorRepository extends JpaRepository<Counselor, Long> {
+    Optional<Counselor> findByCounselorIdAndIsActivatedIsTrue(Long id);
+}

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -65,7 +65,7 @@ public class Customer extends BaseEntity {
         this.recoveryEmail = recoveryEmail;
 
         this.roles = new ArrayList<>() {{
-            add(Role.CUSTOMER);
+            add(Role.ROLE_CUSTOMER);
         }};
     }
 }

--- a/src/main/java/com/example/sharemind/customer/domain/Role.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Role.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum Role {
 
-    CUSTOMER,
-    COUNSELOR
+    ROLE_CUSTOMER,
+    ROLE_COUNSELOR
 }

--- a/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
+++ b/src/main/java/com/example/sharemind/customer/exception/CustomerErrorCode.java
@@ -9,11 +9,11 @@ public enum CustomerErrorCode {
     EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 회원으로 등록된 이메일입니다."),
     CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보가 존재하지 않습니다.");
 
-    private final HttpStatus errorHttpStatus;
-    private final String errorMessage;
+    private final HttpStatus httpStatus;
+    private final String message;
 
-    CustomerErrorCode(HttpStatus errorHttpStatus, String errorMessage) {
-        this.errorHttpStatus = errorHttpStatus;
-        this.errorMessage = errorMessage;
+    CustomerErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
     }
 }

--- a/src/main/java/com/example/sharemind/customer/exception/CustomerException.java
+++ b/src/main/java/com/example/sharemind/customer/exception/CustomerException.java
@@ -1,15 +1,14 @@
 package com.example.sharemind.customer.exception;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public class CustomerException extends RuntimeException {
 
-    private final HttpStatus errorCode;
+    private final CustomerErrorCode errorCode;
 
     public CustomerException(CustomerErrorCode errorCode, String message) {
-        super(errorCode.getErrorMessage() + " : " + message);
-        this.errorCode = errorCode.getErrorHttpStatus();
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.example.sharemind.global.config;
 
-import com.example.sharemind.customer.domain.Role;
 import com.example.sharemind.global.jwt.JwtAccessDeniedHandler;
 import com.example.sharemind.global.jwt.JwtAuthenticationEntryPoint;
 import com.example.sharemind.global.jwt.JwtAuthenticationFilter;
@@ -26,6 +25,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private static final String ROLE_CUSTOMER = "CUSTOMER";
+
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -46,7 +47,7 @@ public class SecurityConfig {
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(
                         requests -> requests.requestMatchers("/error", "/api/v1/auth/**").permitAll()
-                                .requestMatchers("/api/v1/customers/**").hasRole(Role.CUSTOMER.name())
+                                .requestMatchers("/api/v1/consults/**").hasRole(ROLE_CUSTOMER)
                                 .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer

--- a/src/main/java/com/example/sharemind/global/content/ConsultCategory.java
+++ b/src/main/java/com/example/sharemind/global/content/ConsultCategory.java
@@ -1,12 +1,21 @@
 package com.example.sharemind.global.content;
 
+import lombok.Getter;
+
+@Getter
 public enum ConsultCategory {
-    DATING,
-    BREAKUP,
-    FEMALE_PSYCHOLOGY,
-    MALE_PSYCHOLOGY,
-    BEGINNING,
-    ONE_SIDED,
-    BOREDOM,
-    ETC
+    DATING("연애갈등"),
+    BREAKUP("이별/재회"),
+    FEMALE_PSYCHOLOGY("여자심리"),
+    MALE_PSYCHOLOGY("남자심리"),
+    BEGINNING("썸/연애시작"),
+    ONE_SIDED("짝사랑"),
+    BOREDOM("권태기"),
+    ETC("기타");
+
+    private final String displayName;
+
+    ConsultCategory(String displayName) {
+        this.displayName = displayName;
+    }
 }

--- a/src/main/java/com/example/sharemind/global/content/ConsultStyle.java
+++ b/src/main/java/com/example/sharemind/global/content/ConsultStyle.java
@@ -1,7 +1,16 @@
 package com.example.sharemind.global.content;
 
+import lombok.Getter;
+
+@Getter
 public enum ConsultStyle {
-    SYMPATHY,
-    ADVICE,
-    FACT
+    SYMPATHY("공감"),
+    ADVICE("조언"),
+    FACT("팩폭");
+
+    private final String displayName;
+
+    ConsultStyle(String displayName) {
+        this.displayName = displayName;
+    }
 }

--- a/src/main/java/com/example/sharemind/global/content/ConsultType.java
+++ b/src/main/java/com/example/sharemind/global/content/ConsultType.java
@@ -1,6 +1,25 @@
 package com.example.sharemind.global.content;
 
+import com.example.sharemind.global.exception.GlobalErrorCode;
+import com.example.sharemind.global.exception.GlobalException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
 public enum ConsultType {
-    REALTIME,
-    NON_REALTIME,
+    REALTIME("채팅"),
+    NON_REALTIME("편지");
+
+    private final String displayName;
+
+    ConsultType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public static ConsultType getConsultTypeByName(String name) {
+        return Arrays.stream(ConsultType.values())
+                .filter(consultType -> consultType.name().equalsIgnoreCase(name))
+                .findAny().orElseThrow(() -> new GlobalException(GlobalErrorCode.CONSULT_TYPE_NOT_FOUND, name));
+    }
 }

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -12,40 +12,40 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class CustomExceptionHandler {
 
     @ExceptionHandler(AuthException.class)
-    public ResponseEntity<GlobalExceptionResponse> catchAuthException(AuthException e) {
+    public ResponseEntity<CustomExceptionResponse> catchAuthException(AuthException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(GlobalExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
     }
 
     @ExceptionHandler(CustomerException.class)
-    public ResponseEntity<GlobalExceptionResponse> catchCustomerException(CustomerException e) {
+    public ResponseEntity<CustomExceptionResponse> catchCustomerException(CustomerException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(GlobalExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<GlobalExceptionResponse> catchMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<CustomExceptionResponse> catchMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST.name(), e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+                .body(CustomExceptionResponse.of(HttpStatus.BAD_REQUEST.name(), e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<GlobalExceptionResponse> catchConstraintViolationException(ConstraintViolationException e) {
+    public ResponseEntity<CustomExceptionResponse> catchConstraintViolationException(ConstraintViolationException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST.name(), e.getConstraintViolations().stream().findFirst().get().getMessage()));
+                .body(CustomExceptionResponse.of(HttpStatus.BAD_REQUEST.name(), e.getConstraintViolations().stream().findFirst().get().getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<GlobalExceptionResponse> catchException(Exception e) {
+    public ResponseEntity<CustomExceptionResponse> catchException(Exception e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(GlobalExceptionResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage()));
+                .body(CustomExceptionResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage()));
     }
 }

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.global.exception;
 
 import com.example.sharemind.auth.exception.AuthException;
+import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.exception.CustomerException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(CustomerException.class)
     public ResponseEntity<CustomExceptionResponse> catchCustomerException(CustomerException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(CounselorException.class)
+    public ResponseEntity<CustomExceptionResponse> catchCounselorException(CounselorException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -28,6 +28,13 @@ public class CustomExceptionHandler {
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
     }
 
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<CustomExceptionResponse> catchGlobalException(GlobalException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CustomExceptionResponse> catchMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error(e.getMessage(), e);

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionResponse.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionResponse.java
@@ -8,13 +8,13 @@ import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class GlobalExceptionResponse {
+public class CustomExceptionResponse {
 
     private final String errorName;
     private final String message;
     private final LocalDateTime timeStamp;
 
-    public static GlobalExceptionResponse of(String errorName, String message) {
-        return new GlobalExceptionResponse(errorName, message, LocalDateTime.now());
+    public static CustomExceptionResponse of(String errorName, String message) {
+        return new CustomExceptionResponse(errorName, message, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/example/sharemind/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.sharemind.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum GlobalErrorCode {
+
+    CONSULT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "상담 유형이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    GlobalErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/sharemind/global/exception/GlobalException.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+    private final GlobalErrorCode errorCode;
+
+    public GlobalException(GlobalErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionHandler.java
@@ -17,35 +17,35 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<GlobalExceptionResponse> catchAuthException(AuthException e) {
         log.error(e.getMessage(), e);
-        return ResponseEntity.status(e.getErrorCode())
-                .body(GlobalExceptionResponse.of(e.getErrorCode(), e.getMessage()));
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(GlobalExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
     }
 
     @ExceptionHandler(CustomerException.class)
     public ResponseEntity<GlobalExceptionResponse> catchCustomerException(CustomerException e) {
         log.error(e.getMessage(), e);
-        return ResponseEntity.status(e.getErrorCode())
-                .body(GlobalExceptionResponse.of(e.getErrorCode(), e.getMessage()));
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(GlobalExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<GlobalExceptionResponse> catchMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST, e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST.name(), e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<GlobalExceptionResponse> catchConstraintViolationException(ConstraintViolationException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST, e.getConstraintViolations().stream().findFirst().get().getMessage()));
+                .body(GlobalExceptionResponse.of(HttpStatus.BAD_REQUEST.name(), e.getConstraintViolations().stream().findFirst().get().getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<GlobalExceptionResponse> catchException(Exception e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(GlobalExceptionResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
+                .body(GlobalExceptionResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage()));
     }
 }

--- a/src/main/java/com/example/sharemind/global/exception/GlobalExceptionResponse.java
+++ b/src/main/java/com/example/sharemind/global/exception/GlobalExceptionResponse.java
@@ -3,7 +3,6 @@ package com.example.sharemind.global.exception;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
@@ -11,11 +10,11 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class GlobalExceptionResponse {
 
-    private final HttpStatus httpStatus;
+    private final String errorName;
     private final String message;
     private final LocalDateTime timeStamp;
 
-    public static GlobalExceptionResponse of(HttpStatus httpStatus, String message) {
-        return new GlobalExceptionResponse(httpStatus, message, LocalDateTime.now());
+    public static GlobalExceptionResponse of(String errorName, String message) {
+        return new GlobalExceptionResponse(errorName, message, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/example/sharemind/global/jwt/CustomUserDetails.java
+++ b/src/main/java/com/example/sharemind/global/jwt/CustomUserDetails.java
@@ -21,7 +21,7 @@ public class CustomUserDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return customer.getRoles()
                 .stream()
-                .map(role -> new SimpleGrantedAuthority(role.toString()))
+                .map(role -> new SimpleGrantedAuthority(role.name()))
                 .toList();
     }
 

--- a/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
+++ b/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
@@ -2,9 +2,7 @@ package com.example.sharemind.global.jwt;
 
 import com.example.sharemind.auth.repository.RefreshTokenRepository;
 import com.example.sharemind.customer.domain.Role;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -105,10 +103,17 @@ public class TokenProvider implements InitializingBean {
         try {
             Claims claims = parseClaims(accessToken);
             return !claims.getExpiration().before(new Date());
-        } catch (Exception e) {
-            log.warn(e.getMessage(), e);
-            return false;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 JWT입니다.", e);
         }
+
+        return false;
     }
 
     public boolean validateRefreshToken(String refreshToken) {
@@ -119,10 +124,17 @@ public class TokenProvider implements InitializingBean {
             String savedRefreshToken = refreshTokenRepository.findByKey(email);
 
             return refreshToken.equals(savedRefreshToken);
-        } catch (Exception e) {
-            log.warn(e.getMessage(), e);
-            return false;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 JWT입니다.", e);
         }
+
+        return false;
     }
 
     public String getEmail(String token) {


### PR DESCRIPTION
## 📄구현 내용
- 상담 생성
  - 피그마 기준 구매자-상담 신청 부분입니다. response Dto 값으로 상담 신청-결제 페이지에 필요한 정보들을 담았습니다.

## 📝기타 알림사항
- 커스텀 예외 수정
  - errorCode enum의 변수명 수정 (error prefix 제거)
  - GlobalExceptionResponse에서 HttpStatus 대신 errorCode명 반환 (ex. CUSTOMER_NOT_FOUND)
  - 위의 이유로 커스텀 예외에서 errorCode의 httpStatus 대신 errorCode 자체 담아서 생성하도록 수정
  - AuthErrorCode 네이밍 수정
  - 토큰 검증 로직에서 발생할 수 있는 예외 세부화
  - GlobalExceptionResponse, GlobalExceptionHandler 클래스명 수정

- ConsultType, ConsultCategory, ConsultStyle에 displayName 추가
  - 프론트에서 바로 값을 사용할 수 있도록 화면에 노출되는 이름으로 반환

- Counselor 테이블에 상담 유형, 상담 가격, 리뷰 수, 평점 추가
  - 상담 가격을 ConsultCost라는 임베디드 타입을 만들어 넣어봤는데 괜찮은지 의견 부탁드립니다!

- 추후에 계좌번호, 계좌은행, 예금주 묶어서 임베디드 타입으로 만들어도 좋을 것 같음