### PR TITLE
feat: 회원가입시 이메일 인증 api 구현

### DIFF
--- a/src/main/java/com/example/sharemind/customer/application/CustomerService.java
+++ b/src/main/java/com/example/sharemind/customer/application/CustomerService.java
@@ -4,4 +4,6 @@ import com.example.sharemind.customer.domain.Customer;
 
 public interface CustomerService {
     Customer getCustomerByCustomerId(Long customerId);
+
+    void checkDuplicateEmail(String email);
 }

--- a/src/main/java/com/example/sharemind/customer/application/CustomerServiceImpl.java
+++ b/src/main/java/com/example/sharemind/customer/application/CustomerServiceImpl.java
@@ -21,4 +21,11 @@ public class CustomerServiceImpl implements CustomerService {
                 .orElseThrow(() -> new CustomerException(
                         CustomerErrorCode.CUSTOMER_NOT_FOUND, customerId.toString()));
     }
+
+    @Override
+    public void checkDuplicateEmail(String email) {
+        if (customerRepository.existsByEmailAndIsActivatedIsTrue(email)) {
+            throw new CustomerException(CustomerErrorCode.EMAIL_ALREADY_EXIST, email);
+        }
+    }
 }

--- a/src/main/java/com/example/sharemind/email/application/EmailService.java
+++ b/src/main/java/com/example/sharemind/email/application/EmailService.java
@@ -1,0 +1,7 @@
+package com.example.sharemind.email.application;
+
+public interface EmailService {
+    void sendVerificationCode(String email);
+
+    void verifyCode(String email, String code);
+}

--- a/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
+++ b/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
@@ -32,7 +32,7 @@ public class EmailServiceImpl implements EmailService {
 
     @Override
     public void verifyCode(String email, String code) {
-        String storedCode = redisTemplate.opsForValue().get(email);
+        String storedCode = redisTemplate.opsForValue().get(EMAIL_PREFIX + email);
         if (!code.equals(storedCode)) {
             throw new EmailException(EmailErrorCode.CODE_MISMATCH, code);
         }
@@ -46,7 +46,7 @@ public class EmailServiceImpl implements EmailService {
     }
 
     private void storeCodeInRedis(String email, String code) {
-        redisTemplate.opsForValue().set(email, code, EXPIRATION_TIME, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(EMAIL_PREFIX + email, code, EXPIRATION_TIME, TimeUnit.SECONDS);
     }
 
     private String createVerificationCode() {
@@ -58,8 +58,8 @@ public class EmailServiceImpl implements EmailService {
     private void sendEmail(String to, String text) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(to);
-        message.setSubject("ceos vote 인증 메일입니다.");
-        message.setText(text);
+        message.setSubject("sharemind 회원 가입 인증 코드입니다.");
+        message.setText("sharemind 회원 가입 인증 코드입니다.\n5분 내에 입력해주세요\n코드 : " + text);
         mailSender.send(message);
     }
 

--- a/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
+++ b/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
@@ -62,5 +62,4 @@ public class EmailServiceImpl implements EmailService {
         message.setText("sharemind 회원 가입 인증 코드입니다.\n5분 내에 입력해주세요\n코드 : " + text);
         mailSender.send(message);
     }
-
 }

--- a/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
+++ b/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
@@ -1,0 +1,66 @@
+package com.example.sharemind.email.application;
+
+import com.example.sharemind.email.exception.EmailErrorCode;
+import com.example.sharemind.email.exception.EmailException;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private static final int EXPIRATION_TIME = 5 * 60; //5분
+    private static final String EMAIL_PREFIX = "email: ";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void sendVerificationCode(String email) {
+        checkExistingCode(email);
+        String code = createVerificationCode();
+        sendEmail(email, code);
+        storeCodeInRedis(email, code);
+    }
+
+    @Override
+    public void verifyCode(String email, String code) {
+        String storedCode = redisTemplate.opsForValue().get(email);
+        if (!code.equals(storedCode)) {
+            throw new EmailException(EmailErrorCode.CODE_MISMATCH, code);
+        }
+    }
+
+    private void checkExistingCode(String email) {
+        String existingCode = redisTemplate.opsForValue().get(EMAIL_PREFIX + email);
+        if (existingCode != null) {
+            throw new EmailException(EmailErrorCode.CODE_ALREADY_EXISTS, email);
+        }
+    }
+
+    private void storeCodeInRedis(String email, String code) {
+        redisTemplate.opsForValue().set(email, code, EXPIRATION_TIME, TimeUnit.SECONDS);
+    }
+
+    private String createVerificationCode() {
+        SecureRandom random = new SecureRandom();
+        int code = random.nextInt(900000) + 100000; // 100000~999999 범위로 숫자 생성
+        return String.valueOf(code);
+    }
+
+    private void sendEmail(String to, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("ceos vote 인증 메일입니다.");
+        message.setText(text);
+        mailSender.send(message);
+    }
+
+}

--- a/src/main/java/com/example/sharemind/email/dto/request/EmailPostCodeRequest.java
+++ b/src/main/java/com/example/sharemind/email/dto/request/EmailPostCodeRequest.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.email.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class EmailPostCodeRequest {
+
+    @NotNull(message = "이메일은 공백일 수 없습니다.")
+    @Email
+    private String email;
+
+    @NotNull(message = "인증 코드는 공백일 수 없습니다.")
+    private String code;
+}

--- a/src/main/java/com/example/sharemind/email/dto/request/EmailPostRequest.java
+++ b/src/main/java/com/example/sharemind/email/dto/request/EmailPostRequest.java
@@ -1,0 +1,13 @@
+package com.example.sharemind.email.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class EmailPostRequest {
+
+    @NotNull(message = "이메일은 공백일 수 없습니다.")
+    @Email
+    private String email;
+}

--- a/src/main/java/com/example/sharemind/email/exception/EmailErrorCode.java
+++ b/src/main/java/com/example/sharemind/email/exception/EmailErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.sharemind.email.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum EmailErrorCode {
+
+    CODE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "아직 만료되지 않은 코드가 남아있습니다."),
+    CODE_MISMATCH(HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다."),
+    INVALID_EMAIL(HttpStatus.FORBIDDEN, "잘못된 이메일 형식입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    EmailErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/sharemind/email/exception/EmailErrorCode.java
+++ b/src/main/java/com/example/sharemind/email/exception/EmailErrorCode.java
@@ -7,8 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum EmailErrorCode {
 
     CODE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "아직 만료되지 않은 코드가 남아있습니다."),
-    CODE_MISMATCH(HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다."),
-    INVALID_EMAIL(HttpStatus.FORBIDDEN, "잘못된 이메일 형식입니다.");
+    CODE_MISMATCH(HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/sharemind/email/exception/EmailException.java
+++ b/src/main/java/com/example/sharemind/email/exception/EmailException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.email.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EmailException extends RuntimeException {
+
+    private final EmailErrorCode errorCode;
+
+    public EmailException(EmailErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/email/presentation/EmailController.java
+++ b/src/main/java/com/example/sharemind/email/presentation/EmailController.java
@@ -4,6 +4,10 @@ import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.email.application.EmailService;
 import com.example.sharemind.email.dto.request.EmailPostCodeRequest;
 import com.example.sharemind.email.dto.request.EmailPostRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Email Controller", description = "이메일 컨트롤러")
 @RestController
 @RequestMapping("/api/v1/emails")
 @RequiredArgsConstructor
@@ -20,6 +25,11 @@ public class EmailController {
     private final EmailService emailService;
     private final CustomerService customerService;
 
+    @Operation(summary = "이메일 인증코드 발송", description = "회원가입 시 이메일 인증코드를 발송")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "해당 이메일로 인증 코드 발송 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 이미 회원으로 등록된 이메일\n 2. 유효기간이 만료되지 않은 코드가 남아있을 경우\n3. 올바르지 않은 이메일 형식")
+    })
     @PostMapping
     public ResponseEntity<Void> sendVerificationCode(@Valid @RequestBody EmailPostRequest emailPostRequest) {
         customerService.checkDuplicateEmail(emailPostRequest.getEmail());
@@ -28,6 +38,11 @@ public class EmailController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "회원가입 이메일 인증코드 검증", description = "회원가입 이메일 인증코드가 일치하는지 검증")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검증 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 잘못된 인증코드\n2. 올바르지 않은 이메일 형식")
+    })
     @PostMapping("/code")
     public ResponseEntity<Void> verifyCode(@Valid @RequestBody EmailPostCodeRequest emailPostCodeRequest) {
         emailService.verifyCode(emailPostCodeRequest.getEmail(), emailPostCodeRequest.getCode());

--- a/src/main/java/com/example/sharemind/email/presentation/EmailController.java
+++ b/src/main/java/com/example/sharemind/email/presentation/EmailController.java
@@ -1,0 +1,36 @@
+package com.example.sharemind.email.presentation;
+
+import com.example.sharemind.customer.application.CustomerService;
+import com.example.sharemind.email.application.EmailService;
+import com.example.sharemind.email.dto.request.EmailPostCodeRequest;
+import com.example.sharemind.email.dto.request.EmailPostRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/emails")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailService emailService;
+    private final CustomerService customerService;
+
+    @PostMapping
+    public ResponseEntity<Void> sendVerificationCode(@Valid @RequestBody EmailPostRequest emailPostRequest) {
+        customerService.checkDuplicateEmail(emailPostRequest.getEmail());
+
+        emailService.sendVerificationCode(emailPostRequest.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/code")
+    public ResponseEntity<Void> verifyCode(@Valid @RequestBody EmailPostCodeRequest emailPostCodeRequest) {
+        emailService.verifyCode(emailPostCodeRequest.getEmail(), emailPostCodeRequest.getCode());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 .httpBasic(HttpBasicConfigurer::disable)
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(
-                        requests -> requests.requestMatchers("/error", "/swagger-ui/**", "/api-docs/**", "/api/v1/auth/**").permitAll()
+                        requests -> requests.requestMatchers("/error", "/swagger-ui/**", "/api-docs/**", "/api/v1/auth/**", "/api/v1/emails/**").permitAll()
                                 .requestMatchers("/api/v1/consults/**").hasRole(ROLE_CUSTOMER)
                                 .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/index.html","/app.js", "/customerChat/**").permitAll()

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.sharemind.chat.exception.ChatException;
 import com.example.sharemind.consult.exception.ConsultException;
 import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.exception.CustomerException;
+import com.example.sharemind.email.exception.EmailException;
 import com.example.sharemind.letter.exception.LetterException;
 import com.example.sharemind.letterMessage.exception.LetterMessageException;
 import jakarta.validation.ConstraintViolationException;
@@ -42,6 +43,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(ConsultException.class)
     public ResponseEntity<CustomExceptionResponse> catchConsultException(ConsultException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(EmailException.class)
+    public ResponseEntity<CustomExceptionResponse> catchEmailException(EmailException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));


### PR DESCRIPTION
## 📄구현 내용
- 회원 가입 시 이메일 인증 api 구현
- 이미 있는 이메일인지 validate 검사
- 스웨거 설정

## 📝기타 알림사항
- 레디스에 저장하는 내용이 많아 email prefix를 설정하였습니다
- 이메일 인증 관련은 전부 이메일 컨트롤러에 두었는데 이메일컨트롤러에 둘까 auth컨트롤러에 둘까 고민이네요 이메일 전송 로직이라 이메일 컨트롤러에 두긴 했습니다!