### PR TITLE
feat: 편지 목록/상태 조회 구현

### DIFF
--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -41,7 +41,7 @@ public class AdminController {
                             content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             ),
-            @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 상담 아이디로 요청됨\n 2. 존재하지 않는 후원 아이디로 요청됨",
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 상담 아이디로 요청됨",
                             content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             )

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -32,11 +32,7 @@ public class AuthController {
     @Operation(summary = "회원가입", description = "customer 생성")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "400", description = "이미 가입된 이메일 주소",
-                            content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = CustomExceptionResponse.class))
-            ),
-            @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 상담 아이디로 요청됨\n 2. 존재하지 않는 후원 아이디로 요청됨",
+            @ApiResponse(responseCode = "400", description = "1. 이미 가입된 이메일 주소\n 2. 올바르지 않은 이메일/비밀번호/전화번호 형식",
                             content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             )
@@ -64,7 +60,8 @@ public class AuthController {
         return ResponseEntity.ok(authService.signIn(authSignInRequest));
     }
 
-    @Operation(summary = "accessToken 재발급", description = "accessToken 유효기간 1시간, refreshToken 유효기간 1주")
+    @Operation(summary = "accessToken, refreshToken 재발급",
+            description = "accessToken 유효기간 1시간, refreshToken 유효기간 1주 (refreshToken도 같이 재발급되므로 1주가 지나지 않아도 재발급 후엔 이전 refreshToken은 사용 불가)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "재발급 성공"),
             @ApiResponse(responseCode = "400", description = "유효하지 않은 refreshToken",

--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -4,6 +4,7 @@ import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
 import com.example.sharemind.consult.dto.response.ConsultCreateResponse;
 import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.global.content.ConsultType;
 
 import java.util.List;
 
@@ -13,4 +14,8 @@ public interface ConsultService {
     Consult getConsultByConsultId(Long consultId);
 
     List<Consult> getUnpaidConsults();
+
+    List<Consult> getConsultsByCustomerIdAndConsultTypeAndIsPaid(Long customerId, ConsultType consultType);
+
+    List<Consult> getConsultsByCounselorIdAndConsultTypeAndIsPaid(Long counselorId, ConsultType consultType);
 }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -56,4 +56,14 @@ public class ConsultServiceImpl implements ConsultService {
     public List<Consult> getUnpaidConsults() {
         return consultRepository.findAllByIsPaidIsFalseAndIsActivatedIsTrue();
     }
+
+    @Override
+    public List<Consult> getConsultsByCustomerIdAndConsultTypeAndIsPaid(Long customerId, ConsultType consultType) {
+        return consultRepository.findByCustomerIdAndConsultTypeAndIsPaid(customerId, consultType);
+    }
+
+    @Override
+    public List<Consult> getConsultsByCounselorIdAndConsultTypeAndIsPaid(Long counselorId, ConsultType consultType) {
+        return consultRepository.findByCounselorIdAndConsultTypeAndIsPaid(counselorId, consultType);
+    }
 }

--- a/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
+++ b/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
@@ -2,8 +2,6 @@ package com.example.sharemind.consult.repository;
 
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.global.content.ConsultType;
-import com.example.sharemind.counselor.domain.Counselor;
-import com.example.sharemind.customer.domain.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -28,10 +26,4 @@ public interface ConsultRepository extends JpaRepository<Consult, Long> {
 
     @Query("SELECT c FROM Consult c WHERE c.counselor.counselorId = :counselorId AND c.consultType = :consultType AND c.isPaid = true AND c.isActivated = true")
     List<Consult> findByCounselorIdAndConsultTypeAndIsPaid(Long counselorId, ConsultType consultType);
-
-    // TODO 임시
-    List<Consult> findAllByCustomerAndConsultType(Customer customer, ConsultType consultType);
-
-    // TODO 임시
-    List<Consult> findAllByCounselorAndConsultType(Counselor counselor, ConsultType consultType);
 }

--- a/src/main/java/com/example/sharemind/letter/application/LetterService.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterService.java
@@ -17,6 +17,5 @@ public interface LetterService {
 
     LetterGetNicknameCategoryResponse getCustomerNicknameAndCategory(Long letterId);
 
-    // TODO 임시, 나중에 보완 필요
-    List<LetterGetResponse> getLetters(Customer customer, Boolean isCustomer);
+    List<LetterGetResponse> getLetters(Boolean filter, Boolean isCustomer, String sortType, Customer customer);
 }

--- a/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
@@ -2,6 +2,9 @@ package com.example.sharemind.letter.application;
 
 import com.example.sharemind.consult.application.ConsultService;
 import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.exception.CounselorErrorCode;
+import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
 import com.example.sharemind.letter.content.LetterSortType;
@@ -75,8 +78,13 @@ public class LetterServiceImpl implements LetterService {
             consults = consultService.getConsultsByCustomerIdAndConsultTypeAndIsPaid(
                     customer.getCustomerId(), ConsultType.LETTER);
         } else {
+            Counselor counselor = customer.getCounselor();
+            if (counselor == null) {
+                throw new CounselorException(CounselorErrorCode.COUNSELOR_NOT_FOUND, null);
+            }
+
             consults = consultService.getConsultsByCounselorIdAndConsultTypeAndIsPaid(
-                    customer.getCounselor().getCounselorId(), ConsultType.LETTER);
+                    counselor.getCounselorId(), ConsultType.LETTER);
         }
 
         List<Letter> letters;

--- a/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
@@ -1,9 +1,11 @@
 package com.example.sharemind.letter.application;
 
+import com.example.sharemind.consult.application.ConsultService;
 import com.example.sharemind.consult.domain.Consult;
-import com.example.sharemind.consult.repository.ConsultRepository;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
+import com.example.sharemind.letter.content.LetterSortType;
+import com.example.sharemind.letter.content.LetterStatus;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.letter.dto.response.LetterGetCounselorCategoriesResponse;
 import com.example.sharemind.letter.dto.response.LetterGetNicknameCategoryResponse;
@@ -11,20 +13,28 @@ import com.example.sharemind.letter.dto.response.LetterGetResponse;
 import com.example.sharemind.letter.exception.LetterErrorCode;
 import com.example.sharemind.letter.exception.LetterException;
 import com.example.sharemind.letter.repository.LetterRepository;
+import com.example.sharemind.letterMessage.content.LetterMessageType;
+import com.example.sharemind.letterMessage.domain.LetterMessage;
+import com.example.sharemind.letterMessage.exception.LetterMessageErrorCode;
+import com.example.sharemind.letterMessage.exception.LetterMessageException;
+import com.example.sharemind.letterMessage.repository.LetterMessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class LetterServiceImpl implements LetterService {
+    private static final Boolean IS_COMPLETED = true;
+    private static final Integer FINISH_AT_FIRST_MESSAGES = 2;
 
-    private final ConsultRepository consultRepository;
+    private final ConsultService consultService;
     private final LetterRepository letterRepository;
+    private final LetterMessageRepository letterMessageRepository;
 
     @Transactional
     @Override
@@ -57,22 +67,114 @@ public class LetterServiceImpl implements LetterService {
     }
 
     @Override
-    public List<LetterGetResponse> getLetters(Customer customer, Boolean isCustomer) {
-        List<Letter> letters = new ArrayList<>();
+    public List<LetterGetResponse> getLetters(Boolean filter, Boolean isCustomer, String letterSortType, Customer customer) {
+        LetterSortType sortType = LetterSortType.getSortTypeByName(letterSortType);
+
+        List<Consult> consults;
         if (isCustomer) {
-            List<Consult> consults = consultRepository.findAllByCustomerAndConsultType(customer, ConsultType.LETTER);
-            for (Consult consult : consults) {
-                letters.add(consult.getLetter());
-            }
+            consults = consultService.getConsultsByCustomerIdAndConsultTypeAndIsPaid(
+                    customer.getCustomerId(), ConsultType.LETTER);
         } else {
-            List<Consult> consults = consultRepository.findAllByCounselorAndConsultType(customer.getCounselor(), ConsultType.LETTER);
-            for (Consult consult : consults) {
-                letters.add(consult.getLetter());
-            }
+            consults = consultService.getConsultsByCounselorIdAndConsultTypeAndIsPaid(
+                    customer.getCounselor().getCounselorId(), ConsultType.LETTER);
+        }
+
+        List<Letter> letters;
+        if (filter) {
+            letters = consults.stream()
+                    .map(Consult::getLetter)
+                    .filter(letter -> (letter.getLetterStatus() != LetterStatus.FINISH) && (letter.getLetterStatus() != LetterStatus.CANCEL))
+                    .collect(Collectors.toList());
+        } else {
+            letters = consults.stream()
+                    .map(Consult::getLetter)
+                    .collect(Collectors.toList());
+        }
+
+        switch (sortType) {
+            case LATEST -> letters.sort((letter1, letter2) -> letter2.getUpdatedAt().compareTo(letter1.getUpdatedAt()));
+            case UNREAD -> letters.sort((letter1, letter2) -> {
+                Boolean checkLetter1 = checkLetterReadAll(letter1, isCustomer);
+                Boolean checkLetter2 = checkLetterReadAll(letter2, isCustomer);
+
+                if (checkLetter1.equals(checkLetter2)) {
+                    return letter2.getUpdatedAt().compareTo(letter1.getUpdatedAt());
+                } else {
+                    if (checkLetter1) {
+                        return 1;
+                    } else {
+                        return -1;
+                    }
+                }
+            });
         }
 
         return letters.stream()
-                .map(letter -> LetterGetResponse.of(letter, isCustomer))
+                .map(letter -> LetterGetResponse.of(letter, getRecentMessage(letter), isCustomer))
                 .toList();
+    }
+
+    private Boolean checkLetterReadAll(Letter letter, Boolean isCustomer) {
+        Boolean readAllLetter = null;
+
+        switch (letter.getLetterStatus()) {
+            case WAITING, CANCEL -> readAllLetter = true;
+            case FIRST_ASKING, SECOND_ASKING -> {
+                if (isCustomer) {
+                    readAllLetter = true;
+                } else {
+                    LetterMessageType messageType = LetterMessageType.getLetterMessageTypeByStatus(letter.getLetterStatus());
+                    LetterMessage recentMessage = letterMessageRepository.findByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(letter, messageType, IS_COMPLETED)
+                            .orElseThrow(() -> new LetterMessageException(LetterMessageErrorCode.LETTER_MESSAGE_NOT_FOUND));
+
+                    readAllLetter = letter.getCounselorReadId().equals(recentMessage.getMessageId());
+                }
+            }
+            case FIRST_ANSWER -> {
+                if (isCustomer) {
+                    LetterMessageType messageType = LetterMessageType.getLetterMessageTypeByStatus(letter.getLetterStatus());
+                    LetterMessage recentMessage = letterMessageRepository.findByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(letter, messageType, IS_COMPLETED)
+                            .orElseThrow(() -> new LetterMessageException(LetterMessageErrorCode.LETTER_MESSAGE_NOT_FOUND));
+
+                    readAllLetter = letter.getCustomerReadId().equals(recentMessage.getMessageId());
+                } else {
+                    readAllLetter = true;
+                }
+            }
+            case FINISH -> {
+                if (isCustomer) {
+                    LetterMessage recentMessage;
+                    if (letterMessageRepository.countByLetterAndIsCompletedIsTrueAndIsActivatedIsTrue(letter).equals(FINISH_AT_FIRST_MESSAGES)) {
+                        recentMessage = letterMessageRepository.findByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(letter, LetterMessageType.FIRST_REPLY, IS_COMPLETED)
+                                .orElseThrow(() -> new LetterMessageException(LetterMessageErrorCode.LETTER_MESSAGE_NOT_FOUND));
+                    } else {
+                        recentMessage = letterMessageRepository.findByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(letter, LetterMessageType.SECOND_REPLY, IS_COMPLETED)
+                                .orElseThrow(() -> new LetterMessageException(LetterMessageErrorCode.LETTER_MESSAGE_NOT_FOUND));
+                    }
+
+                    readAllLetter = letter.getCustomerReadId().equals(recentMessage.getMessageId());
+                } else {
+                    readAllLetter = true;
+                }
+            }
+        }
+
+        return readAllLetter;
+    }
+
+    private LetterMessage getRecentMessage(Letter letter) {
+        LetterMessageType recentType = null;
+        switch (letterMessageRepository.countByLetterAndIsCompletedIsTrueAndIsActivatedIsTrue(letter)) {
+            case 0 -> {
+                return null;
+            }
+            case 1 -> recentType = LetterMessageType.FIRST_QUESTION;
+            case 2 -> recentType = LetterMessageType.FIRST_REPLY;
+            case 3 -> recentType = LetterMessageType.SECOND_QUESTION;
+            case 4 -> recentType = LetterMessageType.SECOND_REPLY;
+        }
+
+        return letterMessageRepository.findByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(letter, recentType, IS_COMPLETED)
+                .orElseThrow(() -> new LetterMessageException(LetterMessageErrorCode.LETTER_MESSAGE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/sharemind/letter/content/LetterSortType.java
+++ b/src/main/java/com/example/sharemind/letter/content/LetterSortType.java
@@ -1,0 +1,20 @@
+package com.example.sharemind.letter.content;
+
+import com.example.sharemind.letter.exception.LetterErrorCode;
+import com.example.sharemind.letter.exception.LetterException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum LetterSortType {
+
+    LATEST,
+    UNREAD;
+
+    public static LetterSortType getSortTypeByName(String name) {
+        return Arrays.stream(LetterSortType.values())
+                .filter(sortType -> sortType.name().equalsIgnoreCase(name))
+                .findAny().orElseThrow(() -> new LetterException(LetterErrorCode.LETTER_SORT_TYPE_NOT_FOUND, name));
+    }
+}

--- a/src/main/java/com/example/sharemind/letter/domain/Letter.java
+++ b/src/main/java/com/example/sharemind/letter/domain/Letter.java
@@ -67,6 +67,16 @@ public class Letter extends BaseEntity {
         }
     }
 
+    public Boolean checkReadAuthority(Customer customer) {
+        if (this.consult.getCustomer().getCustomerId().equals(customer.getCustomerId())) {
+            return true;
+        } else if ((customer.getCounselor() != null) && (this.consult.getCounselor().getCounselorId().equals(customer.getCounselor().getCounselorId()))) {
+            return false;
+        } else {
+            throw new LetterMessageException(LetterMessageErrorCode.MESSAGE_ACCESS_DENIED);
+        }
+    }
+
     private void validateConsultCategory(ConsultCategory category) {
         if (!this.getConsult().getCounselor().getConsultCategories().contains(category)) {
             throw new LetterException(LetterErrorCode.CONSULT_CATEGORY_MISMATCH, category.name());

--- a/src/main/java/com/example/sharemind/letter/domain/Letter.java
+++ b/src/main/java/com/example/sharemind/letter/domain/Letter.java
@@ -30,6 +30,12 @@ public class Letter extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LetterStatus letterStatus;
 
+    @Column(name = "counselor_read_id")
+    private Long counselorReadId;
+
+    @Column(name = "customer_read_id")
+    private Long customerReadId;
+
     @OneToOne(mappedBy = "letter")
     private Consult consult;
 
@@ -42,8 +48,13 @@ public class Letter extends BaseEntity {
         this.consult = consult;
     }
 
-    public void updateLetterStatus(LetterStatus letterStatus) {
+    public void updateLetterStatusAndReadId(LetterStatus letterStatus, Long messageId) {
         this.letterStatus = letterStatus;
+
+        switch (this.letterStatus) {
+            case FIRST_ASKING, SECOND_ASKING -> updateCustomerReadId(messageId);
+            case FIRST_ANSWER, FINISH -> updateCounselorReadId(messageId);
+        }
     }
 
     public void updateConsultCategory(ConsultCategory category) {
@@ -52,7 +63,19 @@ public class Letter extends BaseEntity {
         this.consultCategory = category;
     }
 
-    public void checkAuthority(LetterMessageType messageType, Customer customer) {
+    public void updateCounselorReadId(Long counselorReadId) {
+        if ((this.counselorReadId == null) || (this.counselorReadId < counselorReadId)) {
+            this.counselorReadId = counselorReadId;
+        }
+    }
+
+    public void updateCustomerReadId(Long customerReadId) {
+        if ((this.customerReadId == null) || (this.customerReadId < customerReadId)) {
+            this.customerReadId = customerReadId;
+        }
+    }
+
+    public void checkWriteAuthority(LetterMessageType messageType, Customer customer) {
         switch (messageType) {
             case FIRST_QUESTION, SECOND_QUESTION -> {
                 if (!this.consult.getCustomer().getCustomerId().equals(customer.getCustomerId())) {

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
@@ -2,6 +2,7 @@ package com.example.sharemind.letter.dto.response;
 
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.letterMessage.domain.LetterMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,14 +16,19 @@ import java.time.temporal.ChronoUnit;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class LetterGetResponse {
 
+    @Schema(description = "편지 아이디")
     private final Long letterId;
 
+    @Schema(description = "편지 진행 상태", example = "답변 대기")
     private final String letterStatus;
 
+    @Schema(description = "대화 상대방 닉네임", example = "사용자37482")
     private final String opponentName;
 
+    @Schema(description = "마지막 업데이트 일시", example = "8분 전")
     private final String updatedAt;
 
+    @Schema(description = "마지막 업데이트 내용", example = "안녕하세요, 어쩌구저쩌구~")
     private final String recentContent;
 
     public static LetterGetResponse of(Letter letter, LetterMessage recentMessage, Boolean isCustomer) {

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
@@ -46,12 +46,12 @@ public class LetterGetResponse {
     private static String getUpdatedAt(LocalDateTime updatedAt) {
         LocalDateTime now = LocalDateTime.now();
 
-        if (ChronoUnit.DAYS.between(now, updatedAt) > 0) {
+        if (ChronoUnit.DAYS.between(updatedAt, now) > 0) {
             return updatedAt.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM));
-        } else if (ChronoUnit.HOURS.between(now, updatedAt) > 0) {
-            return ChronoUnit.HOURS.between(now, updatedAt) + "시간 전";
+        } else if (ChronoUnit.HOURS.between(updatedAt, now) > 0) {
+            return ChronoUnit.HOURS.between(updatedAt, now) + "시간 전";
         } else {
-            return ChronoUnit.MINUTES.between(now, updatedAt) + "분 전";
+            return ChronoUnit.MINUTES.between(updatedAt, now) + "분 전";
         }
     }
 }

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
@@ -1,9 +1,15 @@
 package com.example.sharemind.letter.dto.response;
 
 import com.example.sharemind.letter.domain.Letter;
+import com.example.sharemind.letterMessage.domain.LetterMessage;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.time.temporal.ChronoUnit;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,7 +21,11 @@ public class LetterGetResponse {
 
     private final String opponentName;
 
-    public static LetterGetResponse of(Letter letter, Boolean isCustomer) {
+    private final String updatedAt;
+
+    private final String recentContent;
+
+    public static LetterGetResponse of(Letter letter, LetterMessage recentMessage, Boolean isCustomer) {
         String letterStatus;
         String opponentName;
         if (isCustomer) {
@@ -26,6 +36,22 @@ public class LetterGetResponse {
             opponentName = letter.getConsult().getCustomer().getNickname();
         }
 
-        return new LetterGetResponse(letter.getLetterId(), letterStatus, opponentName);
+        if (recentMessage == null) {
+            return new LetterGetResponse(letter.getLetterId(), letterStatus, opponentName, null, null);
+        }
+
+        return new LetterGetResponse(letter.getLetterId(), letterStatus, opponentName, getUpdatedAt(recentMessage.getUpdatedAt()), recentMessage.getContent());
+    }
+
+    private static String getUpdatedAt(LocalDateTime updatedAt) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (ChronoUnit.DAYS.between(now, updatedAt) > 0) {
+            return updatedAt.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM));
+        } else if (ChronoUnit.HOURS.between(now, updatedAt) > 0) {
+            return ChronoUnit.HOURS.between(now, updatedAt) + "시간 전";
+        } else {
+            return ChronoUnit.MINUTES.between(now, updatedAt) + "분 전";
+        }
     }
 }

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
@@ -52,12 +52,20 @@ public class LetterGetResponse {
     private static String getUpdatedAt(LocalDateTime updatedAt) {
         LocalDateTime now = LocalDateTime.now();
 
-        if (ChronoUnit.DAYS.between(updatedAt, now) > 0) {
+        if (ChronoUnit.YEARS.between(updatedAt, now) > 0) {
             return updatedAt.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM));
+        } else if (ChronoUnit.DAYS.between(updatedAt, now) > 0) {
+            if (ChronoUnit.DAYS.between(updatedAt, now) == 1) {
+                return "어제";
+            } else {
+                return updatedAt.format(DateTimeFormatter.ofPattern("MM.dd"));
+            }
         } else if (ChronoUnit.HOURS.between(updatedAt, now) > 0) {
-            return ChronoUnit.HOURS.between(updatedAt, now) + "시간 전";
-        } else {
+            return updatedAt.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT));
+        } else if (ChronoUnit.MINUTES.between(updatedAt, now) > 0) {
             return ChronoUnit.MINUTES.between(updatedAt, now) + "분 전";
+        } else {
+            return "방금";
         }
     }
 }

--- a/src/main/java/com/example/sharemind/letter/exception/LetterErrorCode.java
+++ b/src/main/java/com/example/sharemind/letter/exception/LetterErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum LetterErrorCode {
 
     LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "편지(비실시간 상담) 정보가 존재하지 않습니다."),
+    LETTER_SORT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "편지 정렬 방식이 존재하지 않습니다."),
     CONSULT_CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "상담사가 제공하지 않은 상담 카테고리입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
+++ b/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
@@ -61,6 +61,19 @@ public class LetterController {
         return ResponseEntity.ok(letterService.getCustomerNicknameAndCategory(letterId));
     }
 
+    @Operation(summary = "편지 리스트 조회", description = "편지 리스트 조회, 주소 형식: /api/v1/letters?filter=true&isCustomer=false&sortType=latest")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공(아직 메시지가 존재하지 않는 경우 updatedAt과 recentContent는 null)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 정렬 방식으로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "filter", description = "완료/취소된 상담 제외 여부"),
+            @Parameter(name = "isCustomer", description = "요청 주체가 구매자인지 판매자인지 여부"),
+            @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
+    })
     @GetMapping
     public ResponseEntity<List<LetterGetResponse>> getLetters(@RequestParam Boolean filter, @RequestParam Boolean isCustomer, @RequestParam String sortType,
                                            @AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
+++ b/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
@@ -61,10 +61,9 @@ public class LetterController {
         return ResponseEntity.ok(letterService.getCustomerNicknameAndCategory(letterId));
     }
 
-    // TODO 임시, 나중에 보완 필요
     @GetMapping
-    public ResponseEntity<List<LetterGetResponse>> getLetters(@RequestParam Boolean isCustomer,
+    public ResponseEntity<List<LetterGetResponse>> getLetters(@RequestParam Boolean filter, @RequestParam Boolean isCustomer, @RequestParam String sortType,
                                            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.ok(letterService.getLetters(customUserDetails.getCustomer(), isCustomer));
+        return ResponseEntity.ok(letterService.getLetters(filter, isCustomer, sortType, customUserDetails.getCustomer()));
     }
 }

--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageService.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageService.java
@@ -5,6 +5,7 @@ import com.example.sharemind.letterMessage.domain.LetterMessage;
 import com.example.sharemind.letterMessage.dto.request.*;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetDeadlineResponse;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetIsSavedResponse;
+import com.example.sharemind.letterMessage.dto.response.LetterMessageGetRecentTypeResponse;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetResponse;
 
 public interface LetterMessageService {
@@ -21,4 +22,6 @@ public interface LetterMessageService {
     LetterMessageGetResponse getLetterMessage(Long letterId, String messageType, Boolean isCompleted);
 
     LetterMessageGetDeadlineResponse getDeadline(Long letterId, String messageType);
+
+    LetterMessageGetRecentTypeResponse getRecentMessageType(Long letterId);
 }

--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageService.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageService.java
@@ -19,7 +19,7 @@ public interface LetterMessageService {
 
     LetterMessageGetIsSavedResponse getIsSaved(Long letterId, String messageType);
 
-    LetterMessageGetResponse getLetterMessage(Long letterId, String messageType, Boolean isCompleted);
+    LetterMessageGetResponse getLetterMessage(Long letterId, String messageType, Boolean isCompleted, Customer customer);
 
     LetterMessageGetDeadlineResponse getDeadline(Long letterId, String messageType);
 

--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
@@ -155,12 +155,13 @@ public class LetterMessageServiceImpl implements LetterMessageService {
     public LetterMessageGetRecentTypeResponse getRecentMessageType(Long letterId) {
         Letter letter = letterService.getLetterByLetterId(letterId);
 
-        String recentType;
-        try {
-            LetterMessageType messageType = LetterMessageType.getLetterMessageTypeByStatus(letter.getLetterStatus());
-            recentType = messageType.getDisplayName();
-        } catch (LetterMessageException e) {
-            recentType = "해당 편지에 대해 작성된 메시지가 없습니다.";
+        String recentType = null;
+        switch (letterMessageRepository.countByLetterAndIsCompletedIsTrueAndIsActivatedIsTrue(letter)) {
+            case 0 -> recentType = "해당 편지에 대해 작성된 메시지가 없습니다.";
+            case 1 -> recentType = LetterMessageType.FIRST_QUESTION.getDisplayName();
+            case 2 -> recentType = LetterMessageType.FIRST_REPLY.getDisplayName();
+            case 3 -> recentType = LetterMessageType.SECOND_QUESTION.getDisplayName();
+            case 4 -> recentType = LetterMessageType.SECOND_REPLY.getDisplayName();
         }
 
         return LetterMessageGetRecentTypeResponse.of(recentType);

--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.sharemind.letterMessage.domain.LetterMessage;
 import com.example.sharemind.letterMessage.dto.request.*;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetDeadlineResponse;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetIsSavedResponse;
+import com.example.sharemind.letterMessage.dto.response.LetterMessageGetRecentTypeResponse;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetResponse;
 import com.example.sharemind.letterMessage.exception.LetterMessageErrorCode;
 import com.example.sharemind.letterMessage.exception.LetterMessageException;
@@ -137,5 +138,20 @@ public class LetterMessageServiceImpl implements LetterMessageService {
         }
 
         return LetterMessageGetDeadlineResponse.of(letter.getUpdatedAt().plusDays(DEADLINE_OFFSET));
+    }
+
+    @Override
+    public LetterMessageGetRecentTypeResponse getRecentMessageType(Long letterId) {
+        Letter letter = letterService.getLetterByLetterId(letterId);
+
+        String recentType;
+        try {
+            LetterMessageType messageType = LetterMessageType.getLetterMessageTypeByStatus(letter.getLetterStatus());
+            recentType = messageType.getDisplayName();
+        } catch (LetterMessageException e) {
+            recentType = "해당 편지에 대해 작성된 메시지가 없습니다.";
+        }
+
+        return LetterMessageGetRecentTypeResponse.of(recentType);
     }
 }

--- a/src/main/java/com/example/sharemind/letterMessage/content/LetterMessageType.java
+++ b/src/main/java/com/example/sharemind/letterMessage/content/LetterMessageType.java
@@ -32,4 +32,14 @@ public enum LetterMessageType {
                         )
                 );
     }
+
+    public static LetterMessageType getLetterMessageTypeByStatus(LetterStatus letterStatus) {
+        return Arrays.stream(LetterMessageType.values())
+                .filter(messageType -> messageType.getLetterStatus().equals(letterStatus))
+                .findAny().orElseThrow(
+                        () -> new LetterMessageException(
+                                LetterMessageErrorCode.Letter_MESSAGE_TYPE_NOT_FOUND
+                        )
+                );
+    }
 }

--- a/src/main/java/com/example/sharemind/letterMessage/domain/LetterMessage.java
+++ b/src/main/java/com/example/sharemind/letterMessage/domain/LetterMessage.java
@@ -52,7 +52,7 @@ public class LetterMessage extends BaseEntity {
 
     public void updateLetterStatus() {
         if (this.isCompleted) {
-            this.letter.updateLetterStatus(this.messageType.getLetterStatus());
+            this.letter.updateLetterStatusAndReadId(this.messageType.getLetterStatus(), this.messageId);
         }
     }
 

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetDeadlineResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetDeadlineResponse.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class LetterMessageGetDeadlineResponse {
 
-    @Schema(description = "마감일시", example = "2024년 1월 25일 9시")
+    @Schema(description = "마감일시", example = "2024년 1월 25일 9시", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH시")
     private final LocalDateTime deadline;
 

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetIsSavedResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetIsSavedResponse.java
@@ -16,7 +16,7 @@ public class LetterMessageGetIsSavedResponse {
     @Schema(description = "임시저장 메시지 존재하면 true, 아니면 false", example = "true")
     private final Boolean isSaved;
 
-    @Schema(description = "마지막 수정일시, isSaved false면 null", example = "2023년 12월 25일 오후 12시 34분")
+    @Schema(description = "마지막 수정일시, isSaved false면 null", example = "2023년 12월 25일 오후 12시 34분", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 a HH시 mm분")
     private final LocalDateTime updatedAt;
 

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetRecentTypeResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetRecentTypeResponse.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.letterMessage.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class LetterMessageGetRecentTypeResponse {
 
+    @Schema(description = "마지막으로 작성된 메시지 종류", example = "추가 질문")
     private final String recentType;
 
     public static LetterMessageGetRecentTypeResponse of(String recentType) {

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetRecentTypeResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetRecentTypeResponse.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.letterMessage.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class LetterMessageGetRecentTypeResponse {
+
+    private final String recentType;
+
+    public static LetterMessageGetRecentTypeResponse of(String recentType) {
+        return new LetterMessageGetRecentTypeResponse(recentType);
+    }
+}

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetResponse.java
@@ -22,7 +22,7 @@ public class LetterMessageGetResponse {
     @Schema(description = "메시지 내용, 메시지 존재하지 않으면 null", example = "니냐니뇨")
     private final String content;
 
-    @Schema(description = "작성 일시, 메시지 존재하지 않으면 null", example = "2024년 1월 4일 오전 9시 45분")
+    @Schema(description = "작성 일시, 메시지 존재하지 않으면 null", example = "2024년 1월 4일 오전 9시 45분", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 a HH시 mm분")
     private final LocalDateTime updatedAt;
 

--- a/src/main/java/com/example/sharemind/letterMessage/exception/LetterMessageErrorCode.java
+++ b/src/main/java/com/example/sharemind/letterMessage/exception/LetterMessageErrorCode.java
@@ -11,6 +11,7 @@ public enum LetterMessageErrorCode {
     LETTER_MESSAGE_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 메시지가 최종 제출되었습니다."),
     Letter_MESSAGE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "메시지 유형이 존재하지 않습니다."),
     MESSAGE_MODIFY_DENIED(HttpStatus.FORBIDDEN, "메시지 작성 권한이 없습니다."),
+    MESSAGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "메시지 접근 권한이 없습니다."),
     INVALID_LETTER_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "현재 작성 가능한 메시지 유형이 아닙니다."),
     NO_DEADLINE(HttpStatus.BAD_REQUEST, "마감시간이 존재하지 않습니다.");
 

--- a/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
+++ b/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
@@ -6,6 +6,7 @@ import com.example.sharemind.letterMessage.application.LetterMessageService;
 import com.example.sharemind.letterMessage.dto.request.*;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetDeadlineResponse;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetIsSavedResponse;
+import com.example.sharemind.letterMessage.dto.response.LetterMessageGetRecentTypeResponse;
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -189,5 +190,10 @@ public class LetterMessageController {
     @GetMapping("/deadline/{letterId}")
     public ResponseEntity<LetterMessageGetDeadlineResponse> getDeadline(@PathVariable Long letterId, @RequestParam String messageType) {
         return ResponseEntity.ok(letterMessageService.getDeadline(letterId, messageType));
+    }
+
+    @GetMapping("/recent-type/{letterId}")
+    public ResponseEntity<LetterMessageGetRecentTypeResponse> getRecentMessageType(@PathVariable Long letterId) {
+        return ResponseEntity.ok(letterMessageService.getRecentMessageType(letterId));
     }
 }

--- a/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
+++ b/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
@@ -165,8 +165,9 @@ public class LetterMessageController {
     })
     @GetMapping("/{letterId}")
     public ResponseEntity<LetterMessageGetResponse> getLetterMessage(@PathVariable Long letterId,
-                                                                     @RequestParam String messageType, @RequestParam Boolean isCompleted) {
-        return ResponseEntity.ok(letterMessageService.getLetterMessage(letterId, messageType, isCompleted));
+                                                                     @RequestParam String messageType, @RequestParam Boolean isCompleted,
+                                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(letterMessageService.getLetterMessage(letterId, messageType, isCompleted, customUserDetails.getCustomer()));
     }
 
     @Operation(summary = "메시지 마감일시 조회",

--- a/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
+++ b/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
@@ -84,7 +84,7 @@ public class LetterMessageController {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "생성 성공"),
             @ApiResponse(responseCode = "400",
-                    description = "1. 이미 최초 생성된 메시지 유형에 대한 요청\n 2. 올바른 순서의 메시지 유형이 아님(ex. 첫번째 답장 순서에 추가 질문 생성 요청",
+                    description = "1. 이미 최초 생성된 메시지 유형에 대한 요청\n 2. 올바른 순서의 메시지 유형이 아님(ex. 첫번째 답장 순서에 추가 질문 생성 요청)",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             ),
@@ -184,8 +184,7 @@ public class LetterMessageController {
     })
     @Parameters({
             @Parameter(name = "letterId", description = "편지 아이디"),
-            @Parameter(name = "messageType", description = "메시지 유형"),
-            @Parameter(name = "isCompleted", description = "조회하려는 메시지가 임시저장된건지 최종 제출된건지")
+            @Parameter(name = "messageType", description = "메시지 유형")
     })
     @GetMapping("/deadline/{letterId}")
     public ResponseEntity<LetterMessageGetDeadlineResponse> getDeadline(@PathVariable Long letterId, @RequestParam String messageType) {

--- a/src/main/java/com/example/sharemind/letterMessage/repository/LetterMessageRepository.java
+++ b/src/main/java/com/example/sharemind/letterMessage/repository/LetterMessageRepository.java
@@ -19,4 +19,6 @@ public interface LetterMessageRepository extends JpaRepository<LetterMessage, Lo
 
     Optional<LetterMessage> findByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(
             Letter letter, LetterMessageType messageType, Boolean isCompleted);
+
+    Integer countByLetterAndIsCompletedIsTrueAndIsActivatedIsTrue(Letter letter);
 }


### PR DESCRIPTION
## 📄구현 내용
- 편지 상태 조회 구현
  - 편지가 어느 메시지까지 작성되었는지 알려주는 api

- 편지 목록 조회 구현
  - 완료/취소된 상담 제외 필터링 조건
  - 최근순, 읽지 않은 순 정렬
    - 정렬 방식을 enum으로 관리하는 것이 깔끔할 것 같아 LetterSortType enum을 생성하였습니다.
    - 읽지 않음 확인을 위해 letter에 counselorReadId, customerReadId 필드 추가

## 📝기타 알림사항
- 이때까지 작성했던 스웨거 설명 리팩토링 진행
- letterService에서 letterMessageService를 사용하면 순환참조가 발생하게 되어 불가피하게 letterMessageRepository를 바로 가져와 사용하게 되었습니다.
- counselorReadId와 customerReadId는 크게 2가지 경우에 업데이트됩니다.
  - 편지의 letterStatus를 수정하는 경우(새로운 질문 또는 답변이 작성됨)
  - getLetter에서 이전까지 읽지 않은 메시지를 읽음
- 읽지 않은 순 정렬이 너무 복잡해서 잘 구현되었는지 모르겠습니다... 일단 제가 테스트해봤을 때는 괜찮았습니다...ㅠㅠㅠ
