### PR TITLE
feat: 상담사 인증 구현

### DIFF
--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -8,4 +8,6 @@ public interface CounselorService {
     Counselor getCounselorByCustomerId(Long customerId);
 
     void updateIsEducated(Boolean isEducated, Long customerId);
+
+    Boolean getRetryPermission(Long customerId);
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -6,4 +6,6 @@ public interface CounselorService {
     Counselor getCounselorByCounselorId(Long counselorId);
 
     Counselor getCounselorByCustomerId(Long customerId);
+
+    void updateIsEducated(Boolean isEducated, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -46,5 +48,19 @@ public class CounselorServiceImpl implements CounselorService {
 
         Counselor counselor = customer.getCounselor();
         counselor.updateIsEducated(isEducated);
+    }
+
+    @Override
+    public Boolean getRetryPermission(Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+        Counselor counselor = customer.getCounselor();
+        if (counselor == null) {
+            throw new CounselorException(CounselorErrorCode.COUNSELOR_NOT_FOUND, null);
+        }
+
+        if (counselor.getRetryEducation() == null) {
+            return true;
+        }
+        return counselor.getRetryEducation().isBefore(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -60,6 +60,8 @@ public class CounselorServiceImpl implements CounselorService {
 
         if (counselor.getRetryEducation() == null) {
             return true;
+        } else if (counselor.getIsEducated()) {
+            return false;
         }
         return counselor.getRetryEducation().isBefore(LocalDateTime.now());
     }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -34,4 +34,17 @@ public class CounselorServiceImpl implements CounselorService {
         }
         return counselor;
     }
+
+    @Transactional
+    @Override
+    public void updateIsEducated(Boolean isEducated, Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+        if (customer.getCounselor() == null) {
+            Counselor counselor = counselorRepository.save(Counselor.builder().isEducated(isEducated).build());
+            customer.setCounselor(counselor);
+        }
+
+        Counselor counselor = customer.getCounselor();
+        counselor.updateIsEducated(isEducated);
+    }
 }

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -20,6 +20,7 @@ import lombok.*;
 @Entity
 public class Counselor extends BaseEntity {
     private static final Integer RETRY_EDUCATION_OFFSET = 1;
+    private static final Integer COUNSELOR_BASIC_LEVEL = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -85,7 +86,7 @@ public class Counselor extends BaseEntity {
         this.isEducated = isEducated;
 
         this.nickname = "판매자" + new Random().nextInt(999999);
-        this.level = 1;
+        this.level = 0;
         this.totalReview = 0L;
         this.ratingAverage = 0.0;
     }
@@ -102,6 +103,8 @@ public class Counselor extends BaseEntity {
 
         if (isEducated.equals(false)) {
             this.retryEducation = LocalDateTime.now().plusDays(RETRY_EDUCATION_OFFSET);
+        } else {
+            this.level = COUNSELOR_BASIC_LEVEL;
         }
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -99,12 +99,19 @@ public class Counselor extends BaseEntity {
     }
 
     public void updateIsEducated(Boolean isEducated) {
+        validateIsEducated();
         this.isEducated = isEducated;
 
         if (isEducated.equals(false)) {
             this.retryEducation = LocalDateTime.now().plusDays(RETRY_EDUCATION_OFFSET);
         } else {
             this.level = COUNSELOR_BASIC_LEVEL;
+        }
+    }
+
+    private void validateIsEducated() {
+        if (this.isEducated.equals(true)) {
+            throw new CounselorException(CounselorErrorCode.COUNSELOR_ALREADY_EDUCATED);
         }
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -9,6 +9,9 @@ import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.counselor.content.ConsultStyle;
 import com.example.sharemind.global.content.ConsultType;
 import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.Random;
 import java.util.Set;
 import lombok.*;
 
@@ -16,16 +19,21 @@ import lombok.*;
 @Getter
 @Entity
 public class Counselor extends BaseEntity {
+    private static final Integer RETRY_EDUCATION_OFFSET = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "counselor_id")
     private Long counselorId;
 
+    @Column(nullable = false)
     private String nickname;
 
-    @Column(name = "is_educated")
+    @Column(name = "is_educated", nullable = false)
     private Boolean isEducated;
+
+    @Column(name = "retry_education")
+    private LocalDateTime retryEducation;
 
     @ElementCollection(targetClass = ConsultCost.class, fetch = FetchType.LAZY)
     @JoinTable(name = "costs", joinColumns = @JoinColumn(name = "counselor_id"))
@@ -55,6 +63,7 @@ public class Counselor extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String introduction;
 
+    @Column(nullable = false)
     private Integer level;
 
     private String account;
@@ -65,16 +74,34 @@ public class Counselor extends BaseEntity {
     @Column(name = "account_holder")
     private String accountHolder;
 
-    @Column(name = "total_review")
+    @Column(name = "total_review", nullable = false)
     private Long totalReview;
 
-    @Column(name = "rating_average")
+    @Column(name = "rating_average", nullable = false)
     private Double ratingAverage;
+
+    @Builder
+    public Counselor(Boolean isEducated) {
+        this.isEducated = isEducated;
+
+        this.nickname = "판매자" + new Random().nextInt(999999);
+        this.level = 1;
+        this.totalReview = 0L;
+        this.ratingAverage = 0.0;
+    }
 
     public Long getConsultCost(ConsultType consultType) {
         return this.consultCosts.stream()
                 .filter(consultCost -> consultCost.getConsultType().equals(consultType))
                 .findAny().orElseThrow(() -> new CounselorException(CounselorErrorCode.COST_NOT_FOUND))
                 .getCost();
+    }
+
+    public void updateIsEducated(Boolean isEducated) {
+        this.isEducated = isEducated;
+
+        if (isEducated.equals(false)) {
+            this.retryEducation = LocalDateTime.now().plusDays(RETRY_EDUCATION_OFFSET);
+        }
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
+++ b/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CounselorErrorCode {
 
+    COUNSELOR_ALREADY_EDUCATED(HttpStatus.BAD_REQUEST, "이미 교육을 수료한 상담사입니다."),
     COUNSELOR_NOT_FOUND(HttpStatus.NOT_FOUND, "상담사 정보가 존재하지 않습니다."),
     COST_NOT_FOUND(HttpStatus.NOT_FOUND, "상담료 정보가 존재하지 않습니다.");
 

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Counselor Controller", description = "상담사 컨트롤러")
 @RestController
@@ -37,5 +34,14 @@ public class CounselorController {
                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         counselorService.updateIsEducated(isEducated, customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "퀴즈 재응시 가능 여부 조회", description = "퀴즈 통과 실패 후 24시간 경과 여부 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공")
+    })
+    @GetMapping("/quiz")
+    public ResponseEntity<Boolean> getRetryPermission(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(counselorService.getRetryPermission(customUserDetails.getCustomer().getCustomerId()));
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -1,0 +1,41 @@
+package com.example.sharemind.counselor.presentation;
+
+import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.global.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Counselor Controller", description = "상담사 컨트롤러")
+@RestController
+@RequestMapping("/api/v1/counselors")
+@RequiredArgsConstructor
+public class CounselorController {
+
+    private final CounselorService counselorService;
+
+    @Operation(summary = "퀴즈 통과 여부 수정",
+            description = "상담사 인증 퀴즈 통과 여부 수정, 첫 퀴즈 응시일 경우 상담사 데이터 생성, 주소 형식: /api/v1/counselors/quiz?isEducated=true")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공")
+    })
+    @Parameters({
+            @Parameter(name = "isEducated", description = "퀴즈 통과 여부")
+    })
+    @PostMapping("/quiz")
+    public ResponseEntity<Void> updateIsEducated(@RequestParam Boolean isEducated,
+                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        counselorService.updateIsEducated(isEducated, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -1,10 +1,13 @@
 package com.example.sharemind.counselor.presentation;
 
 import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,7 +27,11 @@ public class CounselorController {
     @Operation(summary = "퀴즈 통과 여부 수정",
             description = "상담사 인증 퀴즈 통과 여부 수정, 첫 퀴즈 응시일 경우 상담사 데이터 생성, 주소 형식: /api/v1/counselors/quiz?isEducated=true")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수정 성공")
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 퀴즈 통과한 상담사에 대해 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
     })
     @Parameters({
             @Parameter(name = "isEducated", description = "퀴즈 통과 여부")
@@ -38,7 +45,7 @@ public class CounselorController {
 
     @Operation(summary = "퀴즈 재응시 가능 여부 조회", description = "퀴즈 통과 실패 후 24시간 경과 여부 조회")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수정 성공")
+            @ApiResponse(responseCode = "200", description = "조회 성공(이미 퀴즈 통과한 경우도 false 반환)")
     })
     @GetMapping("/quiz")
     public ResponseEntity<Boolean> getRetryPermission(@AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -74,6 +74,10 @@ public class Customer extends BaseEntity {
         }};
     }
 
+    public void setCounselor(Counselor counselor) {
+        this.counselor = counselor;
+    }
+
     private void validateEmails(String email, String recoveryEmail) {
         if (email.equals(recoveryEmail)) {
             throw new AuthException(AuthErrorCode.INVALID_RECOVERY_EMAIL);


### PR DESCRIPTION
## 📄구현 내용
- 상담사 교육 수료 여부 수정 구현
  - 상담사 생성되지 않은 경우, 생성 후 교육 수료 여부 수정
- 상담사 교육 재수료 가능 여부 조회 구현
  - 인증 실패 후 24시간 지났는지 여부 계산
## 📝기타 알림사항
- 인증 실패 후 24시간 경과 확인을 위해 counselor에 retryEducation 필드를 추가하였습니다.
