### PR TITLE
fix: 이메일 인증 api 리턴 타입 변경

### DIFF
--- a/src/main/java/com/example/sharemind/email/application/EmailService.java
+++ b/src/main/java/com/example/sharemind/email/application/EmailService.java
@@ -1,7 +1,9 @@
 package com.example.sharemind.email.application;
 
+import com.example.sharemind.email.dto.response.EmailGetSendCountResponse;
+
 public interface EmailService {
-    void sendVerificationCode(String email);
+    EmailGetSendCountResponse sendVerificationCode(String email);
 
     void verifyCode(String email, String code);
 }

--- a/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
+++ b/src/main/java/com/example/sharemind/email/application/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.email.application;
 
+import com.example.sharemind.email.dto.response.EmailGetSendCountResponse;
 import com.example.sharemind.email.exception.EmailErrorCode;
 import com.example.sharemind.email.exception.EmailException;
 import java.security.SecureRandom;
@@ -25,7 +26,7 @@ public class EmailServiceImpl implements EmailService {
     private final JavaMailSender mailSender;
 
     @Override
-    public void sendVerificationCode(String email) {
+    public EmailGetSendCountResponse sendVerificationCode(String email) {
         String code = checkExistingCode(email);
         int count = 0;
         if (code == null) {
@@ -35,6 +36,8 @@ public class EmailServiceImpl implements EmailService {
         }
         sendEmail(email, code);
         storeCodeInRedis(email, code, count);
+
+        return EmailGetSendCountResponse.of(count + 1);
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/email/dto/response/EmailGetSendCountResponse.java
+++ b/src/main/java/com/example/sharemind/email/dto/response/EmailGetSendCountResponse.java
@@ -1,0 +1,15 @@
+package com.example.sharemind.email.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class EmailGetSendCountResponse {
+    @Schema(description = "이메일 보낸 횟수", example = "1")
+    private final int count;
+
+    public static EmailGetSendCountResponse of(int count) {
+        return new EmailGetSendCountResponse(count);
+    }
+}

--- a/src/main/java/com/example/sharemind/email/presentation/EmailController.java
+++ b/src/main/java/com/example/sharemind/email/presentation/EmailController.java
@@ -4,7 +4,11 @@ import com.example.sharemind.auth.application.AuthService;
 import com.example.sharemind.email.application.EmailService;
 import com.example.sharemind.email.dto.request.EmailPostCodeRequest;
 import com.example.sharemind.email.dto.request.EmailPostRequest;
+import com.example.sharemind.email.dto.response.EmailGetSendCountResponse;
+import com.example.sharemind.global.exception.CustomExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,20 +32,27 @@ public class EmailController {
     @Operation(summary = "이메일 인증코드 발송", description = "회원가입 시 이메일 인증코드를 발송")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "해당 이메일로 인증 코드 발송 성공"),
-            @ApiResponse(responseCode = "400", description = "1. 이미 회원으로 등록된 이메일\n 2. 5분 내에 코드 전송 5회 횟수를 초과 했을 경우\n3. 올바르지 않은 이메일 형식")
+            @ApiResponse(responseCode = "400", description = "1. 이미 회원으로 등록된 이메일\n"
+                    + "2. 5분 내에 코드 전송 5회 횟수를 초과 했을 경우\n"
+                    + "3. 올바르지 않은 이메일 형식", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
     })
     @PostMapping
-    public ResponseEntity<Void> sendVerificationCode(@Valid @RequestBody EmailPostRequest emailPostRequest) {
+    public ResponseEntity<EmailGetSendCountResponse> sendVerificationCode(
+            @Valid @RequestBody EmailPostRequest emailPostRequest) {
         authService.checkDuplicateEmail(emailPostRequest.getEmail());
 
-        emailService.sendVerificationCode(emailPostRequest.getEmail());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(emailService.sendVerificationCode(emailPostRequest.getEmail()));
     }
 
     @Operation(summary = "회원가입 이메일 인증코드 검증", description = "회원가입 이메일 인증코드가 일치하는지 검증")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검증 성공"),
-            @ApiResponse(responseCode = "400", description = "1. 잘못된 인증코드\n2. 올바르지 않은 이메일 형식")
+            @ApiResponse(responseCode = "400", description = "1. 잘못된 인증코드\n"
+                    + "2. 올바르지 않은 이메일 형식", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
     })
     @PostMapping("/code")
     public ResponseEntity<Void> verifyCode(@Valid @RequestBody EmailPostCodeRequest emailPostCodeRequest) {


### PR DESCRIPTION
## 📄구현 내용
- 이메일 인증 api 리턴 시 발송 횟수 같이 리턴해주는 형식으로 바꾸었습니다

## 📝기타 알림사항
- count 하나이긴 하지만 다른 response와 형식 통일해주었습니다.