### PR TITLE
feat: 리뷰 생성/작성 구현

### DIFF
--- a/src/main/java/com/example/sharemind/chat/domain/Chat.java
+++ b/src/main/java/com/example/sharemind/chat/domain/Chat.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.chat.domain;
 
+import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.chat.content.ChatStatus;
 import jakarta.persistence.*;
@@ -29,6 +30,9 @@ public class Chat extends BaseEntity {
     @Column(name = "counseolor_read_id", nullable = false)
     private Long counselorReadId = 0L;
 
+    @OneToOne(mappedBy = "chat")
+    private Consult consult;
+
     public void updateChatStatus(ChatStatus chatStatus) {
         this.chatStatus = chatStatus;
     }
@@ -43,6 +47,10 @@ public class Chat extends BaseEntity {
 
     public void updateCounselorReadId(Long id) {
         this.counselorReadId = id;
+    }
+
+    public void setConsult(Consult consult) {
+        this.consult = consult;
     }
 
     public static Chat newInstance() {

--- a/src/main/java/com/example/sharemind/chat/domain/Chat.java
+++ b/src/main/java/com/example/sharemind/chat/domain/Chat.java
@@ -35,6 +35,10 @@ public class Chat extends BaseEntity {
 
     public void updateChatStatus(ChatStatus chatStatus) {
         this.chatStatus = chatStatus;
+
+        if (this.chatStatus.equals(ChatStatus.FINISH)) {
+            this.consult.setReview();
+        }
     }
 
     public void updateStartedAt() {

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -45,7 +45,7 @@ public class Consult extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ConsultType consultType;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "review_id", unique = true)
     private Review review;
 
@@ -80,6 +80,10 @@ public class Consult extends BaseEntity {
 
         this.isPaid = true;
         setChat(chat);
+    }
+
+    public void setReview() {
+        this.review = Review.builder().consult(this).build();
     }
 
     private void validateConsultType(ConsultType consultType) {

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -95,5 +95,6 @@ public class Consult extends BaseEntity {
 
     private void setChat(Chat chat) {
         this.chat = chat;
+        chat.setConsult(this);
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -83,6 +83,8 @@ public class CounselorServiceImpl implements CounselorService {
             throw new CounselorException(CounselorErrorCode.COUNSELOR_ALREADY_IN_EVALUATION);
         }
 
+        checkDuplicateNickname(counselorUpdateProfileRequest.getNickname());
+
         Set<ConsultCategory> consultCategories = new HashSet<>();
         for (String consultCategory : counselorUpdateProfileRequest.getConsultCategories()) {
             consultCategories.add(ConsultCategory.getConsultCategoryByName(consultCategory));
@@ -152,5 +154,11 @@ public class CounselorServiceImpl implements CounselorService {
         }
 
         return CounselorGetInfoResponse.of(counselor);
+    }
+
+    private void checkDuplicateNickname(String nickname) {
+        if (counselorRepository.existsByNickname(nickname)) {
+            throw new CounselorException(CounselorErrorCode.DUPLICATE_NICKNAME);
+        }
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -30,7 +30,7 @@ public class Counselor extends BaseEntity {
     private Long counselorId;
 
     @Size(min = 1, max = 8, message = "닉네임은 최대 8자입니다.")
-    @Column(nullable = false) // TODO unique 조건 추가할지 기획 파트와 상의 필요
+    @Column(unique = true, nullable = false)
     private String nickname;
 
     @Column(name = "is_educated")

--- a/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetInfoResponse.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetInfoResponse.java
@@ -16,6 +16,9 @@ public class CounselorGetInfoResponse {
 
     @Schema(description = "레벨")
     private final Integer level;
+    
+    @Schema(description = "상담 스타일")
+    private final String consultStyle;
 
     @Schema(description = "교육 수료 여부")
     private final Boolean isEducated;
@@ -24,12 +27,17 @@ public class CounselorGetInfoResponse {
     private final String profileStatus;
 
     public static CounselorGetInfoResponse of() {
-        return new CounselorGetInfoResponse("연애상담마스터", 0, false,
+        return new CounselorGetInfoResponse("연애상담마스터", 0, null, false,
                 ProfileStatus.NO_PROFILE.name());
     }
 
     public static CounselorGetInfoResponse of(Counselor counselor) {
-        return new CounselorGetInfoResponse(counselor.getNickname(), counselor.getLevel(), counselor.getIsEducated(),
+        String consultStyle = null;
+        if (counselor.getConsultStyle() != null) {
+            consultStyle = counselor.getConsultStyle().getDisplayName();
+        }
+        
+        return new CounselorGetInfoResponse(counselor.getNickname(), counselor.getLevel(), consultStyle, counselor.getIsEducated(),
                 counselor.getProfileStatus().name());
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
+++ b/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
@@ -15,6 +15,7 @@ public enum CounselorErrorCode {
     DAY_OF_WEEK_NOT_FOUND(HttpStatus.NOT_FOUND, "요일이 존재하지 않습니다."),
     CONSULT_TIME_OVERFLOW(HttpStatus.BAD_REQUEST, "한 요일에 설정 가능한 상담 가능 시간은 최대 2개입니다."),
     CONSULT_TIME_DUPLICATE(HttpStatus.CONFLICT, "설정한 상담 가능 시간이 서로 겹칩니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     COST_NOT_FOUND(HttpStatus.NOT_FOUND, "상담료 정보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -82,7 +82,8 @@ public class CounselorController {
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             ),
-            @ApiResponse(responseCode = "409", description = "한 요일에 대한 상담 가능 시간이 서로 겹침(ex. 13~15, 14~20)",
+            @ApiResponse(responseCode = "409", description = "1. 한 요일에 대한 상담 가능 시간이 서로 겹침(ex. 13~15, 14~20)\n " +
+                    "2. 이미 존재하는 닉네임",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             )

--- a/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
+++ b/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 @Repository
 public interface CounselorRepository extends JpaRepository<Counselor, Long> {
+    Boolean existsByNickname(String nickname);
+
     Optional<Counselor> findByCounselorIdAndIsActivatedIsTrue(Long id);
 
     @Query("SELECT c FROM Counselor c WHERE  c.profileStatus = 'EVALUATION_PENDING' AND c.isActivated = true")

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.global.dto.response;
 
+import com.example.sharemind.chat.content.ChatStatus;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.chatMessage.domain.ChatMessage;
 import com.example.sharemind.counselor.domain.Counselor;
@@ -38,20 +39,30 @@ public class ChatLetterGetResponse {
     @Schema(description = "읽지 않은 메시지 수")
     private final Integer unreadMessageCount;
 
+    @Schema(description = "리뷰 작성 여부")
+    private final Boolean reviewCompleted;
+
     public static ChatLetterGetResponse of(LetterGetResponse letterGetResponse) {
         return new ChatLetterGetResponse(letterGetResponse.getLetterId(), letterGetResponse.getConsultStyle(),
                 letterGetResponse.getLetterStatus(), letterGetResponse.getOpponentName(),
-                letterGetResponse.getUpdatedAt(), letterGetResponse.getRecentContent(), null, null);
+                letterGetResponse.getUpdatedAt(), letterGetResponse.getRecentContent(), null,
+                null, letterGetResponse.getReviewCompleted());
     }
 
     public static ChatLetterGetResponse of(String nickname, int unreadMessageCount, Chat chat, Counselor counselor,
                                            ChatMessage chatMessage) {
+        Boolean reviewCompleted = null;
+        if (chat.getChatStatus().equals(ChatStatus.FINISH)) {
+            reviewCompleted = chat.getConsult().getReview().getIsCompleted();
+        }
+
         if (chatMessage == null) {
             return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
-                    chat.getChatStatus().getDisplayName(), nickname, null, null, null, null);
+                    chat.getChatStatus().getDisplayName(), nickname, null, null,
+                    null, null, reviewCompleted);
         }
         return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
                 chat.getChatStatus().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chatMessage.getUpdatedAt()),
-                chatMessage.getContent(), chatMessage.getIsCustomer(), unreadMessageCount);
+                chatMessage.getContent(), chatMessage.getIsCustomer(), unreadMessageCount, reviewCompleted);
     }
 }

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -8,6 +8,7 @@ import com.example.sharemind.customer.exception.CustomerException;
 import com.example.sharemind.email.exception.EmailException;
 import com.example.sharemind.letter.exception.LetterException;
 import com.example.sharemind.letterMessage.exception.LetterMessageException;
+import com.example.sharemind.review.exception.ReviewException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -71,6 +72,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(ChatException.class)
     public ResponseEntity<CustomExceptionResponse> catchChatException(ChatException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ReviewException.class)
+    public ResponseEntity<CustomExceptionResponse> catchReviewException(ReviewException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/letter/domain/Letter.java
+++ b/src/main/java/com/example/sharemind/letter/domain/Letter.java
@@ -66,7 +66,10 @@ public class Letter extends BaseEntity {
                 updateCounselorReadId(messageId);
                 updateDeadline();
             }
-            case FINISH -> updateCounselorReadId(messageId);
+            case FINISH -> {
+                updateCounselorReadId(messageId);
+                this.consult.setReview();
+            }
         }
     }
 

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
@@ -2,6 +2,7 @@ package com.example.sharemind.letter.dto.response;
 
 import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
 import com.example.sharemind.global.utils.TimeUtil;
+import com.example.sharemind.letter.content.LetterStatus;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.letterMessage.domain.LetterMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,6 +32,9 @@ public class LetterGetResponse {
     @Schema(description = "마지막 업데이트 내용", example = "안녕하세요, 어쩌구저쩌구~")
     private final String recentContent;
 
+    @Schema(description = "리뷰 작성 여부")
+    private final Boolean reviewCompleted;
+
     public static ChatLetterGetResponse of(Letter letter, LetterMessage recentMessage, Boolean isCustomer) {
         String letterStatus;
         String opponentName;
@@ -42,14 +46,19 @@ public class LetterGetResponse {
             opponentName = letter.getConsult().getCustomer().getNickname();
         }
 
+        Boolean reviewCompleted = null;
+        if (letter.getLetterStatus().equals(LetterStatus.FINISH)) {
+            reviewCompleted = letter.getConsult().getReview().getIsCompleted();
+        }
+
         if (recentMessage == null) {
             return ChatLetterGetResponse.of(new LetterGetResponse(letter.getLetterId(), letterStatus,
                     letter.getConsult().getCounselor().getConsultStyle().getDisplayName(), opponentName,
-                    null, null));
+                    null, null, reviewCompleted));
         }
 
         return ChatLetterGetResponse.of(new LetterGetResponse(letter.getLetterId(), letterStatus,
                 letter.getConsult().getCounselor().getConsultStyle().getDisplayName(), opponentName,
-                TimeUtil.getUpdatedAt((recentMessage.getUpdatedAt())), recentMessage.getContent()));
+                TimeUtil.getUpdatedAt((recentMessage.getUpdatedAt())), recentMessage.getContent(), reviewCompleted));
     }
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewService.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewService.java
@@ -1,0 +1,7 @@
+package com.example.sharemind.review.application;
+
+import com.example.sharemind.review.dto.request.ReviewSaveRequest;
+
+public interface ReviewService {
+    void saveReview(ReviewSaveRequest reviewSaveRequest, Long customerId);
+}

--- a/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
@@ -1,0 +1,31 @@
+package com.example.sharemind.review.application;
+
+import com.example.sharemind.review.domain.Review;
+import com.example.sharemind.review.dto.request.ReviewSaveRequest;
+import com.example.sharemind.review.exception.ReviewErrorCode;
+import com.example.sharemind.review.exception.ReviewException;
+import com.example.sharemind.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    @Override
+    public void saveReview(ReviewSaveRequest reviewSaveRequest, Long customerId) {
+        Review review = reviewRepository.findByReviewIdAndIsActivatedIsTrue(reviewSaveRequest.getReviewId())
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND,
+                        reviewSaveRequest.getReviewId().toString()));
+        if (!review.getConsult().getCustomer().getCustomerId().equals(customerId)) {
+            throw new ReviewException(ReviewErrorCode.REVIEW_MODIFY_DENIED);
+        }
+
+        review.updateReview(reviewSaveRequest.getRating(), reviewSaveRequest.getComment());
+    }
+}

--- a/src/main/java/com/example/sharemind/review/domain/Review.java
+++ b/src/main/java/com/example/sharemind/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.review.domain;
 
+import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -18,4 +19,16 @@ public class Review extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String comment;
+
+    @Column(name = "is_completed", nullable = false)
+    private Boolean isCompleted;
+
+    @OneToOne(mappedBy = "review", optional = false)
+    private Consult consult;
+
+    @Builder
+    public Review(Consult consult) {
+        this.consult = consult;
+        this.isCompleted = false;
+    }
 }

--- a/src/main/java/com/example/sharemind/review/domain/Review.java
+++ b/src/main/java/com/example/sharemind/review/domain/Review.java
@@ -2,7 +2,12 @@ package com.example.sharemind.review.domain;
 
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.global.common.BaseEntity;
+import com.example.sharemind.review.exception.ReviewErrorCode;
+import com.example.sharemind.review.exception.ReviewException;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,8 +20,11 @@ public class Review extends BaseEntity {
     @Column(name = "review_id")
     private Long reviewId;
 
+    @Min(value = 1, message = "평점은 최소 1입니다.")
+    @Max(value = 5, message = "평점은 최대 5입니다.")
     private Integer rating;
 
+    @Size(max = 500, message = "리뷰 내용은 최대 500자입니다.")
     @Column(columnDefinition = "TEXT")
     private String comment;
 
@@ -30,5 +38,19 @@ public class Review extends BaseEntity {
     public Review(Consult consult) {
         this.consult = consult;
         this.isCompleted = false;
+    }
+
+    public void updateReview(Integer rating, String comment) {
+        validateReview();
+
+        this.rating = rating;
+        this.comment = comment;
+        this.isCompleted = true;
+    }
+
+    private void validateReview() {
+        if (this.isCompleted) {
+            throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_COMPLETED);
+        }
     }
 }

--- a/src/main/java/com/example/sharemind/review/dto/request/ReviewSaveRequest.java
+++ b/src/main/java/com/example/sharemind/review/dto/request/ReviewSaveRequest.java
@@ -1,0 +1,24 @@
+package com.example.sharemind.review.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+@Getter
+public class ReviewSaveRequest {
+
+    @Schema(description = "리뷰 아이디")
+    @NotNull(message = "리뷰 id는 공백일 수 없습니다.")
+    private Long reviewId;
+
+    @Schema(description = "평점", example = "3")
+    @Min(value = 1, message = "평점은 최소 1입니다.")
+    @Max(value = 5, message = "평점은 최대 5입니다.")
+    @NotNull(message = "평점은 공백일 수 없습니다.")
+    private Integer rating;
+
+    @Schema(description = "리뷰 내용", example = "이 상담사는 좀... 별로인 듯?")
+    @Size(max = 500, message = "리뷰 내용은 최대 500자입니다.")
+    @NotBlank(message = "리뷰 내용은 공백일 수 없습니다.")
+    private String comment;
+}

--- a/src/main/java/com/example/sharemind/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/example/sharemind/review/exception/ReviewErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.sharemind.review.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ReviewErrorCode {
+
+    REVIEW_MODIFY_DENIED(HttpStatus.FORBIDDEN, "리뷰 작성 권한이 없습니다."),
+    REVIEW_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 작성된 리뷰입니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ReviewErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/sharemind/review/exception/ReviewException.java
+++ b/src/main/java/com/example/sharemind/review/exception/ReviewException.java
@@ -1,0 +1,19 @@
+package com.example.sharemind.review.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewException extends RuntimeException {
+
+    private final ReviewErrorCode errorCode;
+
+    public ReviewException(ReviewErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ReviewException(ReviewErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
+++ b/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
@@ -1,0 +1,55 @@
+package com.example.sharemind.review.presentation;
+
+import com.example.sharemind.global.exception.CustomExceptionResponse;
+import com.example.sharemind.global.jwt.CustomUserDetails;
+import com.example.sharemind.review.application.ReviewService;
+import com.example.sharemind.review.dto.request.ReviewSaveRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Review Controller", description = "리뷰 컨트롤러")
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "리뷰 저장", description = "리뷰 저장")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "400",
+                    description = "1. 올바르지 않은 형식의 요청 값(ex. 리뷰 아이디가 공백, 리뷰 내용이 500자 초과)\n " +
+                            "2. 이미 작성된 리뷰에 대한 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "403",
+                    description = "작성 권한이 없는 리뷰에 대한 요청(리뷰에 해당하는 상담의 구매자가 아님)",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 리뷰 아이디로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @PatchMapping
+    public ResponseEntity<Void> saveReview(@Valid @RequestBody ReviewSaveRequest reviewSaveRequest,
+                                           @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        reviewService.saveReview(reviewSaveRequest, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
@@ -1,0 +1,12 @@
+package com.example.sharemind.review.repository;
+
+import com.example.sharemind.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Optional<Review> findByReviewIdAndIsActivatedIsTrue(Long reviewId);
+}


### PR DESCRIPTION
## 📄구현 내용
- 리뷰 생성
  - 편지/채팅 상태가 상담 종료로 바뀜과 동시에 리뷰 생성
    - 이거 하느라 Chat도 Consult와 양방향 매핑하는 방식으로 수정하였습니다.
- 리뷰 작성
- 상담사 닉네임 중복 확인
- ChatLetterGetResponse에 리뷰 작성 여부 나타내는 reviewCompleted 필드 추가
  - 피그마 기준 상담 리스트 조회에서 상담 종료 시 나타나는 '리뷰 작성하기'를 위해 추가하였습니다.
  - 상담 종료 상태가 아닌 상담에는 null 값이 들어가고, 상담 종료-리뷰 작성 전은 false, 상담 종료-리뷰 작성 완료는 true가 들어갑니다.
- 상담사 내 정보 조회 시 상담 스타일 반환값 추가

## 📝기타 알림사항
- 순수하게 리뷰 생성 및 작성 기능만 구현하였습니다. 추가로 필요한 기능 및 조회는 다음 이슈로 구현 예정입니다.
- 피그마 기준 리뷰 조회 시 상담사 및 상담 정보를 같이 보여줘야해서 Review와 Consult를 양방향 매핑으로 설정하였습니다.
- 추후 작성 전 리뷰와 이미 작성된 리뷰를 구분하기 위해 isCompleted 필드를 추가하였습니다.