### PR TITLE
feat: 리뷰 조회 구현

### DIFF
--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -8,7 +8,10 @@ import com.example.sharemind.consult.exception.ConsultErrorCode;
 import com.example.sharemind.consult.exception.ConsultException;
 import com.example.sharemind.consult.repository.ConsultRepository;
 import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.counselor.content.ProfileStatus;
 import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.exception.CounselorErrorCode;
+import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
 import lombok.RequiredArgsConstructor;
@@ -28,9 +31,10 @@ public class ConsultServiceImpl implements ConsultService {
     @Transactional
     @Override
     public ConsultCreateResponse createConsult(ConsultCreateRequest consultCreateRequest, Customer customer) {
-
-        // TODO 프로필 수정 심사 중인지도 확인해야할 것 같음
         Counselor counselor = counselorService.getCounselorByCounselorId(consultCreateRequest.getCounselorId());
+        if (!counselor.getProfileStatus().equals(ProfileStatus.EVALUATION_COMPLETE)) {
+            throw new CounselorException(CounselorErrorCode.COUNSELOR_NOT_COMPLETE_EVALUATION);
+        }
 
         ConsultType consultType = ConsultType.getConsultTypeByName(consultCreateRequest.getConsultTypeName());
         Long cost = counselor.getConsultCost(consultType);

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -29,6 +29,11 @@ public class ConsultController {
     @Operation(summary = "상담 신청", description = "consult 생성")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "신청 성공"),
+            @ApiResponse(responseCode = "400",
+                    description = "프로필 심사가 완료되지 않은 상담사 아이디로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
             @ApiResponse(responseCode = "404",
                     description = "1. 존재하지 않는 상담사 아이디로 요청됨\n 2. 존재하지 않는 상담 종류로 요청됨\n 3. 상담 종류에 대한 상담료 존재하지 않음",
                     content = @Content(mediaType = "application/json",

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -90,7 +90,7 @@ public class CounselorServiceImpl implements CounselorService {
             throw new CounselorException(CounselorErrorCode.COUNSELOR_ALREADY_IN_EVALUATION);
         }
 
-        checkDuplicateNickname(counselorUpdateProfileRequest.getNickname());
+        checkDuplicateNickname(counselorUpdateProfileRequest.getNickname(), counselor.getCounselorId());
 
         Set<ConsultCategory> consultCategories = new HashSet<>();
         for (String consultCategory : counselorUpdateProfileRequest.getConsultCategories()) {
@@ -173,8 +173,8 @@ public class CounselorServiceImpl implements CounselorService {
         return CounselorGetInfoResponse.of(counselor);
     }
 
-    private void checkDuplicateNickname(String nickname) {
-        if (counselorRepository.existsByNickname(nickname)) {
+    private void checkDuplicateNickname(String nickname, Long counselorId) {
+        if (counselorRepository.existsByNicknameAndCounselorIdNot(nickname, counselorId)) {
             throw new CounselorException(CounselorErrorCode.DUPLICATE_NICKNAME);
         }
     }

--- a/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
+++ b/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
@@ -11,6 +11,7 @@ public enum CounselorErrorCode {
     COUNSELOR_NOT_FOUND(HttpStatus.NOT_FOUND, "상담사 정보가 존재하지 않습니다."),
     COUNSELOR_ALREADY_IN_EVALUATION(HttpStatus.BAD_REQUEST, "이미 프로필 심사 중입니다."),
     COUNSELOR_NOT_IN_EVALUATION(HttpStatus.BAD_REQUEST, "심사 중인 프로필이 아닙니다."),
+    COUNSELOR_NOT_COMPLETE_EVALUATION(HttpStatus.BAD_REQUEST, "프로필 심사 완료된 상담사가 아닙니다."),
     CONSULT_STYLE_NOT_FOUND(HttpStatus.NOT_FOUND, "상담 스타일이 존재하지 않습니다."),
     DAY_OF_WEEK_NOT_FOUND(HttpStatus.NOT_FOUND, "요일이 존재하지 않습니다."),
     CONSULT_TIME_OVERFLOW(HttpStatus.BAD_REQUEST, "한 요일에 설정 가능한 상담 가능 시간은 최대 2개입니다."),

--- a/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
+++ b/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 @Repository
 public interface CounselorRepository extends JpaRepository<Counselor, Long> {
-    Boolean existsByNickname(String nickname);
+    Boolean existsByNicknameAndCounselorIdNot(String nickname, Long counselorId);
 
     Optional<Counselor> findByCounselorIdAndIsActivatedIsTrue(Long id);
 

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -26,6 +26,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private static final String ROLE_CUSTOMER = "CUSTOMER";
+    private static final String ROLE_COUNSELOR = "COUNSELOR";
     private static final String ROLE_ADMIN = "ADMIN";
 
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
@@ -49,7 +50,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         requests -> requests.requestMatchers("/error", "/swagger-ui/**", "/api-docs/**",
                                         "/api/v1/auth/**", "/api/v1/emails/**").permitAll()
-                                .requestMatchers("/api/v1/consults/**").hasRole(ROLE_CUSTOMER)
+                                .requestMatchers("/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -4,7 +4,7 @@ import com.example.sharemind.chat.content.ChatStatus;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.chatMessage.domain.ChatMessage;
 import com.example.sharemind.counselor.domain.Counselor;
-import com.example.sharemind.global.utils.TimeUtil;
+import com.example.sharemind.global.utils.*;
 import com.example.sharemind.letter.dto.response.LetterGetResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/sharemind/global/utils/TimeUtil.java
+++ b/src/main/java/com/example/sharemind/global/utils/TimeUtil.java
@@ -25,4 +25,14 @@ public class TimeUtil {
             return "방금";
         }
     }
+
+    public static String getUpdatedAtForReview(LocalDateTime updatedAt) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (ChronoUnit.YEARS.between(updatedAt, now) > 0) {
+            return updatedAt.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+        } else {
+            return updatedAt.format(DateTimeFormatter.ofPattern("MM월 dd일"));
+        }
+    }
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewService.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewService.java
@@ -9,4 +9,6 @@ public interface ReviewService {
     void saveReview(ReviewSaveRequest reviewSaveRequest, Long customerId);
 
     List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, int pageNumber, Long customerId);
+
+    List<ReviewGetResponse> getReviewsByCounselor(int pageNumber, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewService.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewService.java
@@ -2,6 +2,7 @@ package com.example.sharemind.review.application;
 
 import com.example.sharemind.review.dto.request.ReviewSaveRequest;
 import com.example.sharemind.review.dto.response.ReviewGetResponse;
+import com.example.sharemind.review.dto.response.ReviewGetShortResponse;
 
 import java.util.List;
 
@@ -11,4 +12,6 @@ public interface ReviewService {
     List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, int pageNumber, Long customerId);
 
     List<ReviewGetResponse> getReviewsByCounselor(int pageNumber, Long customerId);
+
+    List<ReviewGetShortResponse> getShortReviews(int pageNumber, int pageSize, Long counselorId);
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewService.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewService.java
@@ -9,9 +9,11 @@ import java.util.List;
 public interface ReviewService {
     void saveReview(ReviewSaveRequest reviewSaveRequest, Long customerId);
 
-    List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, int pageNumber, Long customerId);
+    List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, Long cursorId, Long customerId);
 
-    List<ReviewGetResponse> getReviewsByCounselor(int pageNumber, Long customerId);
+    List<ReviewGetResponse> getReviewsByCounselor(Long cursorId, Long customerId);
 
-    List<ReviewGetShortResponse> getShortReviews(int pageNumber, int pageSize, Long counselorId);
+    List<ReviewGetShortResponse> getShortReviewsForCounselorHome(Long customerId);
+
+    List<ReviewGetShortResponse> getShortReviewsForCounselorProfile(Long cursorId, Long counselorId);
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewService.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewService.java
@@ -1,7 +1,12 @@
 package com.example.sharemind.review.application;
 
 import com.example.sharemind.review.dto.request.ReviewSaveRequest;
+import com.example.sharemind.review.dto.response.ReviewGetResponse;
+
+import java.util.List;
 
 public interface ReviewService {
     void saveReview(ReviewSaveRequest reviewSaveRequest, Long customerId);
+
+    List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, int pageNumber, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.review.domain.Review;
 import com.example.sharemind.review.dto.request.ReviewSaveRequest;
 import com.example.sharemind.review.dto.response.ReviewGetResponse;
+import com.example.sharemind.review.dto.response.ReviewGetShortResponse;
 import com.example.sharemind.review.exception.ReviewErrorCode;
 import com.example.sharemind.review.exception.ReviewException;
 import com.example.sharemind.review.repository.ReviewRepository;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,6 +64,17 @@ public class ReviewServiceImpl implements ReviewService {
         Pageable pageable = PageRequest.of(pageNumber, REVIEW_PAGE_SIZE);
         Page<ReviewGetResponse> page = reviewRepository.findAllByCounselorAndIsCompletedIsTrue(counselor, pageable)
                 .map(review -> ReviewGetResponse.of(review, IS_COUNSELOR));
+
+        return page.getContent();
+    }
+
+    @Override
+    public List<ReviewGetShortResponse> getShortReviews(int pageNumber, int pageSize, Long counselorId) {
+        Counselor counselor = counselorService.getCounselorByCounselorId(counselorId);
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("updatedAt").descending());
+        Page<ReviewGetShortResponse> page = reviewRepository.findAllByCounselorAndIsCompletedIsTrue(counselor, pageable)
+                .map(ReviewGetShortResponse::of);
 
         return page.getContent();
     }

--- a/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
@@ -25,7 +25,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
     private static final int DEFAULT_PAGE_NUMBER = 0;
-    private static final int COUNSELOR_HOME_PAGE_SIZE = 2;
     private static final int REVIEW_PAGE_SIZE = 3;
     private static final Boolean IS_CUSTOMER = true;
     private static final Boolean IS_COUNSELOR = false;
@@ -81,12 +80,9 @@ public class ReviewServiceImpl implements ReviewService {
     public List<ReviewGetShortResponse> getShortReviewsForCounselorHome(Long customerId) {
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
 
-        Pageable pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, COUNSELOR_HOME_PAGE_SIZE);
-        Page<ReviewGetShortResponse> page = reviewRepository.findAllByCounselorAndIsCompletedIsTrueOrderByUpdatedAtDesc(
-                counselor, pageable)
-                .map(ReviewGetShortResponse::of);
-
-        return page.getContent();
+        return reviewRepository.findTop2ByCounselorAndIsCompletedIsTrueOrderByUpdatedAtDesc(counselor).stream()
+                .map(ReviewGetShortResponse::of)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.sharemind.review.application;
 
+import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.review.domain.Review;
@@ -22,8 +24,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
     private static final int REVIEW_PAGE_SIZE = 3;
+    private static final Boolean IS_CUSTOMER = true;
+    private static final Boolean IS_COUNSELOR = false;
 
     private final CustomerService customerService;
+    private final CounselorService counselorService;
     private final ReviewRepository reviewRepository;
 
     @Transactional
@@ -45,7 +50,18 @@ public class ReviewServiceImpl implements ReviewService {
 
         Pageable pageable = PageRequest.of(pageNumber, REVIEW_PAGE_SIZE);
         Page<ReviewGetResponse> page = reviewRepository.findAllByCustomerAndIsCompleted(customer, isCompleted, pageable)
-                .map(review -> ReviewGetResponse.of(review, true));
+                .map(review -> ReviewGetResponse.of(review, IS_CUSTOMER));
+
+        return page.getContent();
+    }
+
+    @Override
+    public List<ReviewGetResponse> getReviewsByCounselor(int pageNumber, Long customerId) {
+        Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
+
+        Pageable pageable = PageRequest.of(pageNumber, REVIEW_PAGE_SIZE);
+        Page<ReviewGetResponse> page = reviewRepository.findAllByCounselorAndIsCompletedIsTrue(counselor, pageable)
+                .map(review -> ReviewGetResponse.of(review, IS_COUNSELOR));
 
         return page.getContent();
     }

--- a/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
@@ -1,19 +1,29 @@
 package com.example.sharemind.review.application;
 
+import com.example.sharemind.customer.application.CustomerService;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.review.domain.Review;
 import com.example.sharemind.review.dto.request.ReviewSaveRequest;
+import com.example.sharemind.review.dto.response.ReviewGetResponse;
 import com.example.sharemind.review.exception.ReviewErrorCode;
 import com.example.sharemind.review.exception.ReviewException;
 import com.example.sharemind.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
+    private static final int REVIEW_PAGE_SIZE = 3;
 
+    private final CustomerService customerService;
     private final ReviewRepository reviewRepository;
 
     @Transactional
@@ -27,5 +37,16 @@ public class ReviewServiceImpl implements ReviewService {
         }
 
         review.updateReview(reviewSaveRequest.getRating(), reviewSaveRequest.getComment());
+    }
+
+    @Override
+    public List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, int pageNumber, Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+
+        Pageable pageable = PageRequest.of(pageNumber, REVIEW_PAGE_SIZE);
+        Page<ReviewGetResponse> page = reviewRepository.findAllByCustomerAndIsCompleted(customer, isCompleted, pageable)
+                .map(review -> ReviewGetResponse.of(review, true));
+
+        return page.getContent();
     }
 }

--- a/src/main/java/com/example/sharemind/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/example/sharemind/review/dto/response/ReviewGetResponse.java
@@ -1,0 +1,74 @@
+package com.example.sharemind.review.dto.response;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.review.domain.Review;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewGetResponse {
+
+    @Schema(description = "리뷰 아이디")
+    private final Long reviewId;
+
+    @Schema(description = "닉네임")
+    private final String nickname;
+
+    @Schema(description = "상담 스타일", example = "팩폭")
+    private final String consultStyle;
+
+    @Schema(description = "레벨", example = "1")
+    private final Integer level;
+
+    @Schema(description = "리뷰 평점")
+    private final Double ratingAverage;
+
+    @Schema(description = "총 리뷰 수")
+    private final Long totalReview;
+
+    @Schema(description = "상담 방식", example = "편지")
+    private final String consultType;
+
+    @Schema(description = "상담 날짜", example = "2024년 1월 12일", type = "string")
+    @JsonFormat(pattern = "yyyy년 MM월 dd일")
+    private final LocalDateTime consultedAt;
+
+    @Schema(description = "상담료", example = "20000")
+    private final Long consultCost;
+
+    @Schema(description = "평점", example = "3")
+    private final Integer rating;
+
+    @Schema(description = "리뷰 내용")
+    private final String comment;
+
+    public static ReviewGetResponse of(Review review, Boolean isCustomer) {
+        Consult consult = review.getConsult();
+
+        LocalDateTime consultedAt = null;
+        switch (consult.getConsultType()) {
+            case LETTER -> consultedAt = consult.getLetter().getCreatedAt();
+            case CHAT -> consultedAt = consult.getChat().getCreatedAt();
+        }
+
+        if (isCustomer) {
+            Counselor counselor = consult.getCounselor();
+            return new ReviewGetResponse(review.getReviewId(), counselor.getNickname(),
+                    counselor.getConsultStyle().getDisplayName(), counselor.getLevel(), counselor.getRatingAverage(),
+                    counselor.getTotalReview(), consult.getConsultType().getDisplayName(), consultedAt,
+                    consult.getCost(), review.getRating(), review.getComment());
+        } else {
+            String nickname = consult.getCustomer().getNickname().charAt(0) + "**";
+            return new ReviewGetResponse(review.getReviewId(), nickname, null, null, null,
+                    null, consult.getConsultType().getDisplayName(), consultedAt, consult.getCost(),
+                    review.getRating(), review.getComment());
+        }
+    }
+}

--- a/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
+++ b/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
@@ -1,0 +1,38 @@
+package com.example.sharemind.review.dto.response;
+
+import com.example.sharemind.review.domain.Review;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewGetShortResponse {
+
+    @Schema(description = "리뷰 아이디")
+    private final Long reviewId;
+
+    @Schema(description = "구매자 닉네임")
+    private final String nickname;
+
+    @Schema(description = "평점", example = "3")
+    private final Integer rating;
+
+    @Schema(description = "리뷰 내용")
+    private final String comment;
+
+    @Schema(description = "작성 일시", example = "2024년 1월 23일", type = "string")
+    @JsonFormat(pattern = "yyyy년 MM월 dd일")
+    private final LocalDateTime updatedAt;
+
+    public static ReviewGetShortResponse of(Review review) {
+        String nickname = review.getConsult().getCustomer().getNickname().charAt(0) + "**";
+
+        return new ReviewGetShortResponse(review.getReviewId(), nickname, review.getRating(), review.getComment(),
+                review.getUpdatedAt());
+    }
+}

--- a/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
+++ b/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
@@ -1,13 +1,11 @@
 package com.example.sharemind.review.dto.response;
 
+import com.example.sharemind.global.utils.*;
 import com.example.sharemind.review.domain.Review;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -25,14 +23,13 @@ public class ReviewGetShortResponse {
     @Schema(description = "리뷰 내용")
     private final String comment;
 
-    @Schema(description = "작성 일시", example = "2024년 1월 23일", type = "string")
-    @JsonFormat(pattern = "yyyy년 MM월 dd일")
-    private final LocalDateTime updatedAt;
+    @Schema(description = "작성 일시", example = "2024년 1월 23일")
+    private final String updatedAt;
 
     public static ReviewGetShortResponse of(Review review) {
         String nickname = review.getConsult().getCustomer().getNickname().charAt(0) + "**";
 
         return new ReviewGetShortResponse(review.getReviewId(), nickname, review.getRating(), review.getComment(),
-                review.getUpdatedAt());
+                TimeUtil.getUpdatedAtForReview(review.getUpdatedAt()));
     }
 }

--- a/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
+++ b/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
@@ -55,7 +55,7 @@ public class ReviewController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "구매자 리뷰 조회", description = "- 구매자 페이지에서 리뷰 조회\n " +
+    @Operation(summary = "구매자 리뷰 조회", description = "- 구매자 리뷰 관리 탭에서 리뷰 작성/남긴 리뷰에 해당하는 리뷰 리스트 조회\n " +
             "- 주소 형식: /api/v1/reviews/customers?isCompleted=true&pageNumber=0")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공(필요하지 않은 값은 null로 반환)"),
@@ -74,6 +74,30 @@ public class ReviewController {
                                                                         @RequestParam int pageNumber,
                                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(reviewService.getReviewsByCustomer(isCompleted, pageNumber,
+                customUserDetails.getCustomer().getCustomerId()));
+    }
+
+    @Operation(summary = "상담사 리뷰 조회", description = "- 상담사 받은 리뷰 탭에 해당하는 리뷰 리스트 조회\n " +
+            "- 주소 형식: /api/v1/reviews/counselors?pageNumber=0")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공(필요하지 않은 값은 null로 반환)"),
+            @ApiResponse(responseCode = "403", description = "아직 프로필 심사가 완료되지 않은 상담사",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 상담사",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "pageNumber", description = "조회 결과는 3개씩 반환하며, 페이지 번호로 구분" +
+                    "(ex. pageNumber 0: 가장 앞 3개 반환, pageNumber 1: 그다음 3개 반환)")
+    })
+    @GetMapping("/counselors")
+    public ResponseEntity<List<ReviewGetResponse>> getReviewsByCounselor(@RequestParam int pageNumber,
+                                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(reviewService.getReviewsByCounselor(pageNumber,
                 customUserDetails.getCustomer().getCustomerId()));
     }
 }

--- a/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
+++ b/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
@@ -5,6 +5,7 @@ import com.example.sharemind.global.jwt.CustomUserDetails;
 import com.example.sharemind.review.application.ReviewService;
 import com.example.sharemind.review.dto.request.ReviewSaveRequest;
 import com.example.sharemind.review.dto.response.ReviewGetResponse;
+import com.example.sharemind.review.dto.response.ReviewGetShortResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -26,6 +27,9 @@ import java.util.List;
 @RequestMapping("/api/v1/reviews")
 @RequiredArgsConstructor
 public class ReviewController {
+    private static final int COUNSELOR_HOME_PAGE_NUMBER = 0;
+    private static final int COUNSELOR_HOME_PAGE_SIZE = 2;
+    private static final int COUNSELOR_PROFILE_PAGE_SIZE = 3;
 
     private final ReviewService reviewService;
 
@@ -55,7 +59,7 @@ public class ReviewController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "구매자 리뷰 조회", description = "- 구매자 리뷰 관리 탭에서 리뷰 작성/남긴 리뷰에 해당하는 리뷰 리스트 조회\n " +
+    @Operation(summary = "구매자 리뷰 조회", description = "- 구매자 페이지 리뷰 관리 탭에서 리뷰 작성/남긴 리뷰에 해당하는 리뷰 리스트 조회\n " +
             "- 주소 형식: /api/v1/reviews/customers?isCompleted=true&pageNumber=0")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공(필요하지 않은 값은 null로 반환)"),
@@ -77,7 +81,7 @@ public class ReviewController {
                 customUserDetails.getCustomer().getCustomerId()));
     }
 
-    @Operation(summary = "상담사 리뷰 조회", description = "- 상담사 받은 리뷰 탭에 해당하는 리뷰 리스트 조회\n " +
+    @Operation(summary = "상담사 리뷰 조회", description = "- 상담사 페이지 받은 리뷰 탭에 해당하는 리뷰 리스트 조회\n " +
             "- 주소 형식: /api/v1/reviews/counselors?pageNumber=0")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공(필요하지 않은 값은 null로 반환)"),
@@ -99,5 +103,44 @@ public class ReviewController {
                                                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(reviewService.getReviewsByCounselor(pageNumber,
                 customUserDetails.getCustomer().getCustomerId()));
+    }
+
+    @Operation(summary = "상담사 홈화면 받은 리뷰 조회", description = "상담사 페이지 홈화면에 필요한 최신 리뷰 2개 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "아직 프로필 심사가 완료되지 않은 상담사",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 상담사",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @GetMapping("/counselors/home")
+    public ResponseEntity<List<ReviewGetShortResponse>> getReviewsForCounselorHome(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(reviewService.getShortReviews(COUNSELOR_HOME_PAGE_NUMBER, COUNSELOR_HOME_PAGE_SIZE,
+                customUserDetails.getCustomer().getCounselor().getCounselorId()));
+    }
+
+    @Operation(summary = "상담사 프로필 후기 탭 리뷰 조회", description = "- 구매자 페이지 상담사 프로필 후기 탭에 해당하는 리뷰 리스트 조회\n " +
+            "- 주소 형식: /api/v1/reviews/{counselorId}?pageNumber=0")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 상담사",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "counselorId", description = "상담사 아이디"),
+            @Parameter(name = "pageNumber", description = "조회 결과는 3개씩 반환하며, 페이지 번호로 구분" +
+                    "(ex. pageNumber 0: 가장 앞 3개 반환, pageNumber 1: 그다음 3개 반환)")
+    })
+    @GetMapping("/{counselorId}")
+    public ResponseEntity<List<ReviewGetShortResponse>> getReviewsForCounselorProfile(@PathVariable Long counselorId,
+                                                                                      @RequestParam int pageNumber) {
+        return ResponseEntity.ok(reviewService.getShortReviews(pageNumber, COUNSELOR_PROFILE_PAGE_SIZE, counselorId));
     }
 }

--- a/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -39,6 +40,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT r FROM Review r JOIN FETCH r.consult c " +
             "WHERE c.counselor = :counselor AND r.isCompleted = true AND r.isActivated = true " +
-            "ORDER BY r.updatedAt DESC")
-    Page<Review> findAllByCounselorAndIsCompletedIsTrueOrderByUpdatedAtDesc(Counselor counselor, Pageable pageable);
+            "ORDER BY r.updatedAt DESC LIMIT 2")
+    List<Review> findTop2ByCounselorAndIsCompletedIsTrueOrderByUpdatedAtDesc(Counselor counselor);
 }

--- a/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
@@ -15,9 +15,30 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByReviewIdAndIsActivatedIsTrue(Long reviewId);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.consult c WHERE c.customer = :customer AND r.isCompleted = :isCompleted AND r.isActivated = true")
+    @Query("SELECT r FROM Review r JOIN FETCH r.consult c " +
+            "WHERE c.customer = :customer AND r.isCompleted = :isCompleted AND r.isActivated = true " +
+            "ORDER BY r.reviewId DESC")
     Page<Review> findAllByCustomerAndIsCompleted(Customer customer, Boolean isCompleted, Pageable pageable);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.consult c WHERE c.counselor = :counselor AND r.isCompleted = true AND r.isActivated = true")
+    @Query("SELECT r FROM Review r JOIN FETCH r.consult c " +
+            "WHERE r.reviewId < :reviewId AND c.customer = :customer AND r.isCompleted = :isCompleted AND r.isActivated = true " +
+            "ORDER BY r.reviewId DESC")
+    Page<Review> findAllByReviewIdLessThanAndCustomerAndIsCompleted(Long reviewId, Customer customer,
+                                                                    Boolean isCompleted, Pageable pageable);
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.consult c " +
+            "WHERE c.counselor = :counselor AND r.isCompleted = true AND r.isActivated = true " +
+            "ORDER BY r.reviewId DESC")
     Page<Review> findAllByCounselorAndIsCompletedIsTrue(Counselor counselor, Pageable pageable);
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.consult c " +
+            "WHERE r.reviewId < :reviewId AND c.counselor = :counselor AND r.isCompleted = true AND r.isActivated = true " +
+            "ORDER BY r.reviewId DESC")
+    Page<Review> findAllByReviewIdLessThanAndCounselorAndIsCompletedIsTrue(Long reviewId, Counselor counselor,
+                                                                           Pageable pageable);
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.consult c " +
+            "WHERE c.counselor = :counselor AND r.isCompleted = true AND r.isActivated = true " +
+            "ORDER BY r.updatedAt DESC")
+    Page<Review> findAllByCounselorAndIsCompletedIsTrueOrderByUpdatedAtDesc(Counselor counselor, Pageable pageable);
 }

--- a/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.review.repository;
 
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.review.domain.Review;
 import org.springframework.data.domain.Page;
@@ -16,4 +17,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT r FROM Review r JOIN FETCH r.consult c WHERE c.customer = :customer AND r.isCompleted = :isCompleted AND r.isActivated = true")
     Page<Review> findAllByCustomerAndIsCompleted(Customer customer, Boolean isCompleted, Pageable pageable);
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.consult c WHERE c.counselor = :counselor AND r.isCompleted = true AND r.isActivated = true")
+    Page<Review> findAllByCounselorAndIsCompletedIsTrue(Counselor counselor, Pageable pageable);
 }

--- a/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/sharemind/review/repository/ReviewRepository.java
@@ -1,7 +1,11 @@
 package com.example.sharemind.review.repository;
 
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.review.domain.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,4 +13,7 @@ import java.util.Optional;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByReviewIdAndIsActivatedIsTrue(Long reviewId);
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.consult c WHERE c.customer = :customer AND r.isCompleted = :isCompleted AND r.isActivated = true")
+    Page<Review> findAllByCustomerAndIsCompleted(Customer customer, Boolean isCompleted, Pageable pageable);
 }


### PR DESCRIPTION
## 📄구현 내용
- 구매자 작성 전/작성 완료 리뷰 리스트 조회
  - 피그마 기준 구매자 리뷰 관리 탭에서 필요한 리뷰 리스트 조회 api입니다.
  - isCompleted로 리뷰 작성/남긴 리뷰 탭을 구분합니다.
- 판매자 받은 리뷰 리스트 조회
  - 피그마 기준 판매자 받은 리뷰 탭에서 필요한 리뷰 리스트 조회 api입니다.

-> 여기까지는 ReviewGetResponse라는 dto로 통일하였습니다. 페이지네이션으로 3개씩 반환합니다.

- 상담사 프로필 후기 탭 리뷰 리스트 조회
  - 피그마 기준 구매자 페이지에서 상담사 프로필 조회 시 후기 탭에 필요한 api입니다.
  - 페이지네이션으로 3개씩 반환합니다.
- 상담사 홈화면 받은 리뷰 조회
  - 피그마 기준 상담사 홈화면에서 받은 리뷰에 필요한 api입니다.
  - 세부 기능 명세서에 따라 최신 업데이트 순으로 2개 반환합니다.

-> 여기까지는 ReviewGetShortResponse라는 dto로 통일하였습니다. 서비스 로직도 getShortReviews로 통일하였습니다.

- 상담 신청 시 프로필 심사 중인 상담사는 신청 불가하도록 로직 추가하였습니다.
- 상담사 닉네임 중복 확인 로직 본인 닉네임 제외하도록 수정하였습니다.

## 📝기타 알림사항
- 상담사 페이지쪽에서 필요한 리뷰 api는 주소 prefix counselors로 두고 권한 설정하였습니다.