### PR TITLE
feat: 상담사 총 리뷰 수, 평점 업데이트 로직 구현

### DIFF
--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignUpRequest.java
@@ -6,8 +6,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
-import java.util.Random;
-
 @Getter
 public class AuthSignUpRequest {
 
@@ -31,7 +29,6 @@ public class AuthSignUpRequest {
 
     public Customer toEntity(String password) {
         return Customer.builder()
-                .nickname("사용자" + new Random().nextInt(999999))
                 .email(email)
                 .password(password)
                 .phoneNumber(phoneNumber)

--- a/src/main/java/com/example/sharemind/consult/dto/response/ConsultCreateResponse.java
+++ b/src/main/java/com/example/sharemind/consult/dto/response/ConsultCreateResponse.java
@@ -30,7 +30,7 @@ public class ConsultCreateResponse {
     @Schema(description = "총 리뷰 수", example = "123")
     private final Long totalReview;
 
-    @Schema(description = "상담 카테고리", example = "권태기, 짝사랑, 이별/재회")
+    @Schema(description = "상담 카테고리", example = "[\"연애갈등\", \"짝사랑\", \"남자심리\"]")
     private final Set<String> consultCategories;
 
     @Schema(description = "상담 스타일", example = "팩폭")

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -60,6 +60,11 @@ public class CounselorServiceImpl implements CounselorService {
     public void updateIsEducated(Boolean isEducated, Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
         if (customer.getCounselor() == null) {
+            String nickname = "마인더" + new Random().nextInt(99999);
+            while (counselorRepository.existsByNickname(nickname)) {
+                nickname = "마인더" + new Random().nextInt(99999);
+            }
+
             Counselor counselor = counselorRepository.save(Counselor.builder().build());
             customer.setCounselor(counselor);
         }

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -157,6 +157,14 @@ public class Counselor extends BaseEntity {
         }
     }
 
+    public void updateTotalReviewAndRatingAverage(Integer rating) {
+        double preTotalRating = this.ratingAverage * this.totalReview;
+        this.totalReview += 1;
+
+        double newTotalRating = (preTotalRating + rating) / this.totalReview;
+        this.ratingAverage = Math.round(newTotalRating * 10) / 10.0;
+    }
+
     private void validateIsEducated() {
         if ((this.isEducated != null) && (this.isEducated.equals(true))) {
             throw new CounselorException(CounselorErrorCode.COUNSELOR_ALREADY_EDUCATED);

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -11,13 +11,13 @@ import com.example.sharemind.global.content.ConsultType;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
-import java.util.Random;
 import java.util.Set;
 
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Counselor extends BaseEntity {
@@ -104,8 +104,8 @@ public class Counselor extends BaseEntity {
     private Long totalConsult;
 
     @Builder
-    public Counselor() {
-        this.nickname = "판매자" + new Random().nextInt(99999);
+    public Counselor(String nickname) {
+        this.nickname = nickname;
         this.level = 0;
         this.totalReview = 0L;
         this.ratingAverage = 0.0;

--- a/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetInfoResponse.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetInfoResponse.java
@@ -17,7 +17,7 @@ public class CounselorGetInfoResponse {
     @Schema(description = "레벨")
     private final Integer level;
     
-    @Schema(description = "상담 스타일")
+    @Schema(description = "상담 스타일", example = "공감")
     private final String consultStyle;
 
     @Schema(description = "교육 수료 여부")

--- a/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
+++ b/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 
 @Repository
 public interface CounselorRepository extends JpaRepository<Counselor, Long> {
+    Boolean existsByNickname(String nickname);
+
     Boolean existsByNicknameAndCounselorIdNot(String nickname, Long counselorId);
 
     Optional<Counselor> findByCounselorIdAndIsActivatedIsTrue(Long id);

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -13,6 +13,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -60,10 +61,10 @@ public class Customer extends BaseEntity {
     private Counselor counselor;
 
     @Builder
-    public Customer(String nickname, String email, String password, String phoneNumber, String recoveryEmail) {
+    public Customer(String email, String password, String phoneNumber, String recoveryEmail) {
         validateEmails(email, recoveryEmail);
 
-        this.nickname = nickname;
+        this.nickname = "셰어" + new Random().nextInt(999999);
         this.email = email;
         this.password = password;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetCounselorCategoriesResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetCounselorCategoriesResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class LetterGetCounselorCategoriesResponse {
 
-    @Schema(description = "상담 카테고리", example = "이별/재회, 권태기, 기타")
+    @Schema(description = "상담 카테고리", example = "[\"연애갈등\", \"짝사랑\", \"남자심리\"]")
     private final List<String> categories;
 
     public static LetterGetCounselorCategoriesResponse of(Letter letter) {

--- a/src/main/java/com/example/sharemind/review/domain/Review.java
+++ b/src/main/java/com/example/sharemind/review/domain/Review.java
@@ -46,6 +46,8 @@ public class Review extends BaseEntity {
         this.rating = rating;
         this.comment = comment;
         this.isCompleted = true;
+
+        this.consult.getCounselor().updateTotalReviewAndRatingAverage(this.rating);
     }
 
     private void validateReview() {

--- a/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
+++ b/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
@@ -23,7 +23,7 @@ public class ReviewGetShortResponse {
     @Schema(description = "리뷰 내용")
     private final String comment;
 
-    @Schema(description = "작성 일시", example = "2024년 1월 23일")
+    @Schema(description = "작성 일시", example = "2023년 1월 23일")
     private final String updatedAt;
 
     public static ReviewGetShortResponse of(Review review) {

--- a/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
+++ b/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
@@ -7,6 +7,8 @@ import com.example.sharemind.searchWord.application.SearchWordService;
 import com.example.sharemind.searchWord.dto.request.SearchWordDeleteRequest;
 import com.example.sharemind.searchWord.dto.request.SearchWordFindRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -43,14 +45,18 @@ public class SearchWordController {
     }
 
     @Operation(summary = "검색 결과 반환", description = """
-            sortType(LATEST: 최근순, POPULARITY: 인기순, STAR_RATING: 별점 평균 순
-            주소 형식 예시 : /api/v1/searchWords/results?sortType=STAR_RATING검색어 결과를 상담사 닉네임, 소개 제목, 소개 내용에서 찾아서 반환. 정확하게 일치하는 정보만 반환
-            만약 이전에 검색했던 검색어의 경우(ex) 연애, 갈등)에서 갈등이 다시 검색된다면 (갈등, 연애)순서로 다시 서버에 저장합니다.
-            (중복 저장x)검색 결관느 4개씩 반환하며, index는 페이지 번호 입니다(ex index 0 : id 0~3에 해당하는 값 반환 index 1: 4~7에 해당하는 값 반환해당하는 검색 결과가 없을 때(범위를 벗어난 인덱스 혹은 음수 인덱스는 빈배열을 리턴합니다.""")
+            - 주소 형식 예시 : /api/v1/searchWords/results?sortType=STAR_RATING
+            - 검색어 결과를 상담사 닉네임, 소개 제목, 소개 내용에서 찾아서 반환. 정확하게 일치하는 정보만 반환
+            - 만약 이전에 검색했던 검색어의 경우(ex) 연애, 갈등)에서 갈등이 다시 검색된다면 (갈등, 연애)순서로 다시 서버에 저장합니다. (중복 저장x)
+            - 검색 결과는 4개씩 반환하며, index는 페이지 번호 입니다(ex index 0 : id 0~3에 해당하는 값 반환 index 1: 4~7에 해당하는 값 반환)
+            - 해당하는 검색 결과가 없을 때(범위를 벗어난 인덱스 혹은 음수 인덱스)는 빈배열을 리턴합니다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "1. 검색어가 2~20자 사이가 아님", content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = CustomExceptionResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "sortType", description = "LATEST: 최근순, POPULARITY: 인기순, STAR_RATING: 별점 평균 순")
     })
     @PatchMapping("/results")
     public ResponseEntity<List<CounselorGetListResponse>> getSearchWordResults(


### PR DESCRIPTION
## 📄구현 내용
- 상담사 totalReview, ratingAverage 업데이트 로직 구현 및 적용
  - 리뷰 작성 시 같이 업데이트 되도록 했습니다.
  - ratingAverage는 피그마 참고하여 소수점 한 자리 수까지만 저장되도록 구현했습니다.

- 스웨거 설명 추가
  - 어젯밤에 인영님께서 관련 이슈 언급해주시고나서 전체적으로 다시 살펴보니 example 값이 애매하게 적혀있는 부분들이 좀 있는 것 같아 수정하였습니다.

- 상담사/구매자 랜덤 닉네임 워딩 수정
  - 판매자/구매자 대신 마인더/셰어 워딩으로 수정하였습니다.

- 상담사 랜덤 닉네임 중복 확인 로직 추가
  - 현재 unique 조건 걸려있는데 생각해보니 0~99999 중 랜덤 숫자로 넣게 되면 중복 발생이 꽤 나올 것 같아 확인해주는 로직을 추가하였습니다.

## 📝기타 알림사항
- SearchWordController쪽 스웨거는 커밋하려던 건 아니고 제가 보기 편하려고 정리해둔 것인데 섞여들어간 것 같습니다ㅠㅠ 이쪽 작업 중이신 것으로 아는데 원상복구 필요하시면 말씀해주세요!