### PR TITLE
feat: 결제 엔티티 생성

### DIFF
--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -46,7 +46,7 @@ public class AdminServiceImpl implements AdminService {
     public void updateIsPaid(Long consultId) {
 
         Consult consult = consultService.getConsultByConsultId(consultId);
-        if (consult.getIsPaid()) {
+        if (consult.getPayment().getIsPaid()) {
             throw new ConsultException(ConsultErrorCode.CONSULT_ALREADY_PAID, consultId.toString());
         }
 

--- a/src/main/java/com/example/sharemind/chat/domain/Chat.java
+++ b/src/main/java/com/example/sharemind/chat/domain/Chat.java
@@ -37,8 +37,7 @@ public class Chat extends BaseEntity {
         this.chatStatus = chatStatus;
 
         if (this.chatStatus.equals(ChatStatus.FINISH)) {
-            this.consult.setReview();
-            this.consult.getCounselor().increaseTotalConsult();
+            this.consult.updateConsultStatusFinish();
         }
     }
 

--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -3,14 +3,12 @@ package com.example.sharemind.consult.application;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
-import com.example.sharemind.consult.dto.response.ConsultCreateResponse;
-import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
 
 import java.util.List;
 
 public interface ConsultService {
-    ConsultCreateResponse createConsult(ConsultCreateRequest consultCreateRequest, Customer customer);
+    void createConsult(ConsultCreateRequest consultCreateRequest, Long customerId);
 
     Consult getConsultByConsultId(Long consultId);
 

--- a/src/main/java/com/example/sharemind/consult/content/ConsultStatus.java
+++ b/src/main/java/com/example/sharemind/consult/content/ConsultStatus.java
@@ -1,0 +1,18 @@
+package com.example.sharemind.consult.content;
+
+import lombok.Getter;
+
+@Getter
+public enum ConsultStatus {
+
+    WAITING("상담 대기"),
+    ONGOING("상담 중"),
+    FINISH("상담 종료"),
+    CANCEL("상담 취소");
+
+    private final String displayName;
+
+    ConsultStatus(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -1,17 +1,21 @@
 package com.example.sharemind.consult.domain;
 
+import com.example.sharemind.consult.content.ConsultStatus;
 import com.example.sharemind.consult.exception.ConsultErrorCode;
 import com.example.sharemind.consult.exception.ConsultException;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.content.ConsultType;
-import com.example.sharemind.consult.content.RefundStatus;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.chat.domain.Chat;
+import com.example.sharemind.payment.content.PaymentCustomerStatus;
+import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.review.domain.Review;
 import com.example.sharemind.customer.domain.Customer;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -34,16 +38,16 @@ public class Consult extends BaseEntity {
     @Column(nullable = false)
     private Long cost;
 
-    @Column(name = "is_paid", nullable = false)
-    private Boolean isPaid;
-
-    @Column(name = "refund_status", nullable = false)
-    @Enumerated(EnumType.STRING)
-    private RefundStatus refundStatus;
-
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
     private ConsultType consultType;
+
+    @Column(name = "consult_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ConsultStatus consultStatus;
+
+    @Column(name = "consulted_at")
+    private LocalDateTime consultedAt;
 
     @OneToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "review_id", unique = true)
@@ -57,29 +61,52 @@ public class Consult extends BaseEntity {
     @JoinColumn(name = "chat_id", unique = true)
     private Chat chat;
 
+    @OneToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "payment_id", unique = true)
+    private Payment payment;
+
     @Builder
     public Consult(Customer customer, Counselor counselor, Long cost, ConsultType consultType) {
         this.customer = customer;
         this.counselor = counselor;
         this.cost = cost;
         this.consultType = consultType;
+        this.consultStatus = ConsultStatus.WAITING;
+        this.payment = Payment.builder().consult(this).build();
+    }
 
-        this.isPaid = false;
-        this.refundStatus = RefundStatus.NO_REFUND;
+    public void updateConsultStatusOnGoing() {
+        this.consultStatus = ConsultStatus.ONGOING;
+        updateConsultedAt();
+    }
+
+    public void updateConsultStatusFinish() {
+        this.consultStatus = ConsultStatus.FINISH;
+        setReview();
+
+        this.counselor.increaseTotalConsult();
+    }
+
+    public void updateConsultStatusCancel() {
+        this.consultStatus = ConsultStatus.CANCEL;
+
+        this.payment.updatePaymentCustomerStatus(PaymentCustomerStatus.REFUND_WAITING);
     }
 
     public void updateIsPaidAndLetter(Letter letter) {
         validateConsultType(ConsultType.LETTER);
-
-        this.isPaid = true;
         setLetter(letter);
+        updateConsultedAt();
+
+        this.payment.updateIsPaidTrue();
     }
 
     public void updateIsPaidAndChat(Chat chat) {
         validateConsultType(ConsultType.CHAT);
-
-        this.isPaid = true;
         setChat(chat);
+        updateConsultedAt();
+
+        this.payment.updateIsPaidTrue();
     }
 
     public void setReview() {
@@ -90,6 +117,10 @@ public class Consult extends BaseEntity {
         if (!this.consultType.equals(consultType)) {
             throw new ConsultException(ConsultErrorCode.CONSULT_TYPE_MISMATCH);
         }
+    }
+
+    private void updateConsultedAt() {
+        this.consultedAt = LocalDateTime.now();
     }
 
     private void setLetter(Letter letter) {

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -2,7 +2,6 @@ package com.example.sharemind.consult.presentation;
 
 import com.example.sharemind.consult.application.ConsultService;
 import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
-import com.example.sharemind.consult.dto.response.ConsultCreateResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,7 +29,7 @@ public class ConsultController {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "신청 성공"),
             @ApiResponse(responseCode = "400",
-                    description = "프로필 심사가 완료되지 않은 상담사 아이디로 요청됨",
+                    description = "1. 프로필 심사가 완료되지 않은 상담사 아이디로 요청됨\n 2. 상담사가 제공하지 않는 상담 유형",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             ),
@@ -41,9 +40,9 @@ public class ConsultController {
             )
     })
     @PostMapping
-    public ResponseEntity<ConsultCreateResponse> createConsult(@Valid @RequestBody ConsultCreateRequest consultCreateRequest,
+    public ResponseEntity<Void> createConsult(@Valid @RequestBody ConsultCreateRequest consultCreateRequest,
                                                                @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(consultService.createConsult(consultCreateRequest, customUserDetails.getCustomer()));
+        consultService.createConsult(consultCreateRequest, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
+++ b/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
@@ -14,18 +14,25 @@ import java.util.Optional;
 public interface ConsultRepository extends JpaRepository<Consult, Long> {
     Optional<Consult> findByConsultIdAndIsActivatedIsTrue(Long consultId);
 
+    @Query("SELECT c FROM Consult c JOIN FETCH Payment p WHERE p.isPaid = false AND c.isActivated = true")
     List<Consult> findAllByIsPaidIsFalseAndIsActivatedIsTrue();
 
-    @Query("SELECT chat.chatId FROM Consult c JOIN c.chat chat WHERE c.customer.customerId = :customerId AND c.isActivated = true")
+    @Query("SELECT chat.chatId FROM Consult c JOIN c.chat chat " +
+            "WHERE c.customer.customerId = :customerId AND c.isActivated = true")
     List<Long> findChatIdsByCustomerId(Long customerId); //todo: 쿼리 최적화 필요
 
-    @Query("SELECT chat.chatId FROM Consult c JOIN c.chat chat WHERE c.counselor.counselorId = :counselorId AND c.isActivated = true")
+    @Query("SELECT chat.chatId FROM Consult c JOIN c.chat chat " +
+            "WHERE c.counselor.counselorId = :counselorId AND c.isActivated = true")
     List<Long> findChatIdsByCounselorId(Long counselorId);
 
-    @Query("SELECT c FROM Consult c WHERE c.customer.customerId = :customerId AND c.consultType = :consultType AND c.isPaid = true AND c.isActivated = true")
+    @Query("SELECT c FROM Consult c JOIN FETCH Payment p " +
+            "WHERE c.customer.customerId = :customerId AND c.consultType = :consultType AND " +
+            "p.isPaid = true AND c.isActivated = true")
     List<Consult> findByCustomerIdAndConsultTypeAndIsPaid(Long customerId, ConsultType consultType);
 
-    @Query("SELECT c FROM Consult c WHERE c.counselor.counselorId = :counselorId AND c.consultType = :consultType AND c.isPaid = true AND c.isActivated = true")
+    @Query("SELECT c FROM Consult c JOIN FETCH Payment p " +
+            "WHERE c.counselor.counselorId = :counselorId AND c.consultType = :consultType AND " +
+            "p.isPaid = true AND c.isActivated = true")
     List<Consult> findByCounselorIdAndConsultTypeAndIsPaid(Long counselorId, ConsultType consultType);
 
     Optional<Consult> findByChatAndIsActivatedIsTrue(Chat chat);

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -2,6 +2,7 @@ package com.example.sharemind.counselor.application;
 
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
+import com.example.sharemind.counselor.dto.response.CounselorGetForConsultResponse;
 import com.example.sharemind.searchWord.dto.request.SearchWordFindRequest;
 import com.example.sharemind.counselor.dto.response.CounselorGetInfoResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
@@ -28,4 +29,6 @@ public interface CounselorService {
                                                      String sortType);
 
     CounselorGetInfoResponse getCounselorMyInfo(Long customerId);
+
+    CounselorGetForConsultResponse getCounselorForConsultCreation(Long counselorId, String consultType);
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.sharemind.counselor.domain.ConsultCost;
 import com.example.sharemind.counselor.domain.ConsultTime;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
+import com.example.sharemind.counselor.dto.response.CounselorGetForConsultResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetInfoResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.counselor.exception.CounselorErrorCode;
@@ -183,6 +184,17 @@ public class CounselorServiceImpl implements CounselorService {
         }
 
         return CounselorGetInfoResponse.of(counselor);
+    }
+
+    @Override
+    public CounselorGetForConsultResponse getCounselorForConsultCreation(Long counselorId, String type) {
+        Counselor counselor = getCounselorByCounselorId(counselorId);
+        ConsultType consultType = ConsultType.getConsultTypeByName(type);
+        if (!counselor.getConsultTypes().contains(consultType)) {
+            throw new CounselorException(CounselorErrorCode.INVALID_CONSULT_TYPE);
+        }
+
+        return CounselorGetForConsultResponse.of(counselor, consultType);
     }
 
     private void checkDuplicateNickname(String nickname, Long counselorId) {

--- a/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetForConsultResponse.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetForConsultResponse.java
@@ -1,0 +1,54 @@
+package com.example.sharemind.counselor.dto.response;
+
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.global.content.ConsultCategory;
+import com.example.sharemind.global.content.ConsultType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class CounselorGetForConsultResponse {
+
+    @Schema(description = "상담사 아이디", example = "1")
+    private final Long counselorId;
+
+    @Schema(description = "상담사 닉네임", example = "이롸롸")
+    private final String nickname;
+
+    @Schema(description = "상담사 레벨", example = "1")
+    private final Integer level;
+
+    @Schema(description = "리뷰 평점", example = "3.5")
+    private final Double ratingAverage;
+
+    @Schema(description = "총 리뷰 수", example = "123")
+    private final Long totalReview;
+
+    @Schema(description = "상담 카테고리", example = "[\"연애갈등\", \"짝사랑\", \"남자심리\"]")
+    private final List<String> consultCategories;
+
+    @Schema(description = "상담 스타일", example = "팩폭")
+    private final String consultStyle;
+
+    @Schema(description = "선택한 상담 유형", example = "편지")
+    private final String consultType;
+
+    @Schema(description = "상담료", example = "10000")
+    private final Long cost;
+
+    public static CounselorGetForConsultResponse of(Counselor counselor, ConsultType consultType) {
+        List<String> consultCategories = counselor.getConsultCategories().stream()
+                .map(ConsultCategory::getDisplayName)
+                .toList();
+
+        return new CounselorGetForConsultResponse(counselor.getCounselorId(), counselor.getNickname(),
+                counselor.getLevel(), counselor.getRatingAverage(), counselor.getTotalReview(), consultCategories,
+                counselor.getConsultStyle().getDisplayName(), consultType.getDisplayName(),
+                counselor.getConsultCost(consultType));
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
+++ b/src/main/java/com/example/sharemind/counselor/exception/CounselorErrorCode.java
@@ -17,6 +17,7 @@ public enum CounselorErrorCode {
     CONSULT_TIME_OVERFLOW(HttpStatus.BAD_REQUEST, "한 요일에 설정 가능한 상담 가능 시간은 최대 2개입니다."),
     CONSULT_TIME_DUPLICATE(HttpStatus.CONFLICT, "설정한 상담 가능 시간이 서로 겹칩니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    INVALID_CONSULT_TYPE(HttpStatus.BAD_REQUEST, "상담사가 제공하는 상담 유형이 아닙니다."),
     COST_NOT_FOUND(HttpStatus.NOT_FOUND, "상담료 정보가 존재하지 않습니다."),
     COUNSELOR_SORT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정렬 방식이 존재하지 않습니다.");
 

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -2,6 +2,7 @@ package com.example.sharemind.counselor.presentation;
 
 import com.example.sharemind.counselor.application.CounselorService;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
+import com.example.sharemind.counselor.dto.response.CounselorGetForConsultResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetInfoResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
@@ -123,5 +124,29 @@ public class CounselorController {
     @GetMapping("/my-info")
     public ResponseEntity<CounselorGetInfoResponse> getCounselorMyInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(counselorService.getCounselorMyInfo(customUserDetails.getCustomer().getCustomerId()));
+    }
+
+    @Operation(summary = "상담 신청 시 필요한 상담사 정보 조회",
+            description = "- 상담 신청하기 페이지에서 필요한 상담사 정보 조회\n " +
+                    "- 주소 형식: /api/v1/counselors/consults/{counselorId}?consultType=letter")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "상담사가 제공하지 앟는 상담 유형",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 상담사 아이디/상담 유형/상담료",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "counselorId", description = "상담사 아이디"),
+            @Parameter(name = "consultType", description = "상담 유형(LETTER, CHAT)")
+    })
+    @GetMapping("/consults/{counselorId}")
+    public ResponseEntity<CounselorGetForConsultResponse> getCounselorForConsultCreation(@PathVariable Long counselorId,
+                                                                                         @RequestParam String consultType) {
+        return ResponseEntity.ok(counselorService.getCounselorForConsultCreation(counselorId, consultType));
     }
 }

--- a/src/main/java/com/example/sharemind/letter/domain/Letter.java
+++ b/src/main/java/com/example/sharemind/letter/domain/Letter.java
@@ -58,7 +58,12 @@ public class Letter extends BaseEntity {
         this.letterStatus = letterStatus;
 
         switch (this.letterStatus) {
-            case FIRST_ASKING, SECOND_ASKING -> {
+            case FIRST_ASKING -> {
+                updateCustomerReadId(messageId);
+                updateDeadline();
+                this.consult.updateConsultStatusOnGoing();
+            }
+            case SECOND_ASKING -> {
                 updateCustomerReadId(messageId);
                 updateDeadline();
             }
@@ -68,8 +73,7 @@ public class Letter extends BaseEntity {
             }
             case FINISH -> {
                 updateCounselorReadId(messageId);
-                this.consult.setReview();
-                this.consult.getCounselor().increaseTotalConsult();
+                this.consult.updateConsultStatusFinish();
             }
         }
     }

--- a/src/main/java/com/example/sharemind/payment/content/PaymentCounselorStatus.java
+++ b/src/main/java/com/example/sharemind/payment/content/PaymentCounselorStatus.java
@@ -1,0 +1,7 @@
+package com.example.sharemind.payment.content;
+
+public enum PaymentCounselorStatus {
+    COMPLETE,
+    ONGOING,
+    WAITING
+}

--- a/src/main/java/com/example/sharemind/payment/content/PaymentCustomerStatus.java
+++ b/src/main/java/com/example/sharemind/payment/content/PaymentCustomerStatus.java
@@ -1,0 +1,7 @@
+package com.example.sharemind.payment.content;
+
+public enum PaymentCustomerStatus {
+    PAYMENT_COMPLETE,
+    REFUND_WAITING,
+    REFUND_COMPLETE
+}

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -1,0 +1,60 @@
+package com.example.sharemind.payment.domain;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.global.common.BaseEntity;
+import com.example.sharemind.payment.content.PaymentCounselorStatus;
+import com.example.sharemind.payment.content.PaymentCustomerStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long paymentId;
+
+    @Column(nullable = false)
+    private String method;
+
+    @Column(name = "is_paid", nullable = false)
+    private Boolean isPaid;
+
+    @Column(name = "payment_counselor_status")
+    @Enumerated(EnumType.STRING)
+    private PaymentCounselorStatus counselorStatus;
+
+    @Column(name = "payment_customer_status")
+    @Enumerated(EnumType.STRING)
+    private PaymentCustomerStatus customerStatus;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @OneToOne(mappedBy = "payment", optional = false)
+    private Consult consult;
+
+    @Builder
+    public Payment(Consult consult) {
+        this.consult = consult;
+        this.method = "외부 결제";
+        this.isPaid = false;
+    }
+
+    public void updateIsPaidTrue() {
+        this.isPaid = true;
+        updatePaymentCustomerStatus(PaymentCustomerStatus.PAYMENT_COMPLETE);
+    }
+
+    public void updatePaymentCustomerStatus(PaymentCustomerStatus customerStatus) {
+        this.customerStatus = customerStatus;
+    }
+}


### PR DESCRIPTION
## 📄구현 내용
- Payment 엔티티 생성
  - 아까 디스코드에서 상의한 필드 외에 isPaid, approvedAt을 추가해보았습니다
    - isPaid는 원래 consult에 있던 필드인데, 결제 정보를 관리하는 엔티티를 따로 만들었으니 더 적합한 위치로 옮기는 것이 맞다고 판단하였습니다.
    - approvedAt은 상담사 정산 지급일자를 위한 필드입니다.

- Consult에 consultStatus, consultedAt 필드 추가
  - 아까 디스코드에서 상의한 필드 추가입니다.
  - consultStatus가 FINISH일 때 리뷰 생성, 총 상담 수 증가가 이루어지는 것 같아 로직들을 updateConsultStatusFinish 안에 묶어버렸습니다.
  - consultedAt은 아까 말씀드렸던대로 1. Chat, Letter 최초 생성 2. 실제 상담 시작 시에 변경되는데, 
  1은 updateIsPaidChat/Letter에서, 2는 updateConsultStatusOnGoing에서 바꿔주면 될 것 같아 updateConsultedAt은 private으로 두었습니다.

-> updateConsultStatusFinish 안에 로직 묶어버리면서 Chat쪽도 수정하게 되었습니다. updateConsultStatusOnGoing만 맞는 위치에 넣어주시면 될 것 같습니다!

## 📝기타 알림사항
- Payment는 상담 신청 시 Consult와 동시에 생성됩니다.
  - 피그마 기준 상담 신청하기에서 원래 생각했던 로직은 createConsult -> ConsultCreateResponse로 상담사 정보 반환 -> createPayment 였습니다. 
  그런데 이렇게 하면 결제까지 도달하지 않아 쓸모없어지는 Consult가 많을 것 같다는 생각이 들어 상담사 정보를 조회하는 getCounselorForConsultCreation을 따로 두고, getCounselorForConsultCreation -> createConsult의 로직으로 수정하였습니다.
