### PR TITLE
feat: 상담사 리스트 api 구현

### DIFF
--- a/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
+++ b/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
@@ -84,7 +84,7 @@ public class ChatController {
             @Parameter(name = "chatId", description = "채팅방 id"),
             @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
     })
-    @GetMapping("/counselors/{chatId}")
+    @PatchMapping("/counselors/{chatId}")
     public ResponseEntity<Void> updateCounselorReadId(@PathVariable Long chatId,
                                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         chatService.updateReadId(chatId, customUserDetails.getCustomer().getCustomerId(), false);
@@ -101,7 +101,7 @@ public class ChatController {
             @Parameter(name = "chatId", description = "채팅방 id"),
             @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
     })
-    @GetMapping("/{chatId}")
+    @PatchMapping("/{chatId}")
     public ResponseEntity<Void> updateCustomerReadId(@PathVariable Long chatId,
                                              @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         chatService.updateReadId(chatId, customUserDetails.getCustomer().getCustomerId(), true);

--- a/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
+++ b/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
@@ -34,42 +34,77 @@ public class ChatController {
     private final ChatService chatService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    @Operation(summary = "채팅 목록 반환", description = "유저가 속해 있는 채팅 목록을 전부 가져오는 api")
+    @Operation(summary = "상담사 채팅 목록 반환", description = "상담사가 속해 있는 채팅 목록을 전부 가져오는 api")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "채팅 목록 반환 성공"),
-            @ApiResponse(responseCode = "404", description = "1. 상담사 role을 가지지 않은 사람이 isCustomer=false로 api를 요청할 때"
+            @ApiResponse(responseCode = "404", description = "1. 상담사 role을 가지지 않은 사람이 이 api에 접근할 때"
                     + "2. sortType이 존재하지 않을 때")
     })
     @Parameters({
             @Parameter(name = "filter", description = "완료/취소된 상담 제외 여부"),
-            @Parameter(name = "isCustomer", description = "요청 주체가 구매자인지 판매자인지 여부"),
             @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
     })
-    @GetMapping()
-    public ResponseEntity<List<ChatLetterGetResponse>> getChatList(@RequestParam Boolean isCustomer,
-                                                                   @RequestParam Boolean filter,
-                                                                   @RequestParam String sortType,
-                                                                   @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    @GetMapping("/counselors")
+    public ResponseEntity<List<ChatLetterGetResponse>> getCounselorChatList(
+            @RequestParam Boolean filter,
+            @RequestParam String sortType,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         List<ChatLetterGetResponse> chatInfoGetResponses = chatService.getChatInfoByCustomerId(
-                customUserDetails.getCustomer().getCustomerId(), isCustomer, filter, sortType);
+                customUserDetails.getCustomer().getCustomerId(), false, filter, sortType);
         return ResponseEntity.ok(chatInfoGetResponses);
     }
 
-    @Operation(summary = "채팅 readId 갱신해주는 api", description = "처음 채팅방에 들어갔을 때, 호출해주시면 됩니다.")
+    @Operation(summary = "구매자 채팅 목록 반환", description = "구매자가 속해 있는 채팅 목록을 전부 가져오는 api")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "채팅 목록 반환 성공"),
-            @ApiResponse(responseCode = "404", description = "1. 상담사 role을 가지지 않은 사람이 isCustomer=false로 api를 요청할 때"
+            @ApiResponse(responseCode = "404", description = "1. 구매자 role을 가지지 않은 사람이 해당 api를 요청할 때"
+                    + "2. sortType이 존재하지 않을 때")
+    })
+    @Parameters({
+            @Parameter(name = "filter", description = "완료/취소된 상담 제외 여부"),
+            @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
+    })
+    @GetMapping("/customers")
+    public ResponseEntity<List<ChatLetterGetResponse>> getCustomerChatList(
+            @RequestParam Boolean filter,
+            @RequestParam String sortType,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        List<ChatLetterGetResponse> chatInfoGetResponses = chatService.getChatInfoByCustomerId(
+                customUserDetails.getCustomer().getCustomerId(), true, filter, sortType);
+        return ResponseEntity.ok(chatInfoGetResponses);
+    }
+
+    @Operation(summary = "상담사의 채팅 readId 갱신해주는 api", description = "처음 채팅방에 들어갔을 때, 호출해주시면 됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅 목록 반환 성공"),
+            @ApiResponse(responseCode = "404", description = "1. 상담사 role을 가지지 않은 사람이 해당 api를 요청할 때"
                     + "2. 채팅방이 존재하지 않을 때")
     })
     @Parameters({
             @Parameter(name = "chatId", description = "채팅방 id"),
-            @Parameter(name = "isCustomer", description = "요청 주체가 구매자인지 판매자인지 여부"),
+            @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
+    })
+    @GetMapping("/counselors/{chatId}")
+    public ResponseEntity<Void> updateCounselorReadId(@PathVariable Long chatId,
+                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        chatService.updateReadId(chatId, customUserDetails.getCustomer().getCustomerId(), false);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "구매자 채팅 readId 갱신해주는 api", description = "처음 채팅방에 들어갔을 때, 호출해주시면 됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅 목록 반환 성공"),
+            @ApiResponse(responseCode = "404", description = "1. 구매자 role을 가지지 않은 사람이 햏당 api를 요청할 때"
+                    + "2. 채팅방이 존재하지 않을 때")
+    })
+    @Parameters({
+            @Parameter(name = "chatId", description = "채팅방 id"),
             @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
     })
     @GetMapping("/{chatId}")
-    public ResponseEntity<Void> updateReadId(@PathVariable Long chatId, @RequestParam Boolean isCustomer,
+    public ResponseEntity<Void> updateCustomerReadId(@PathVariable Long chatId,
                                              @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        chatService.updateReadId(chatId, customUserDetails.getCustomer().getCustomerId(), isCustomer);
+        chatService.updateReadId(chatId, customUserDetails.getCustomer().getCustomerId(), true);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/sharemind/chatMessage/presentation/ChatMessageController.java
+++ b/src/main/java/com/example/sharemind/chatMessage/presentation/ChatMessageController.java
@@ -43,7 +43,7 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    @Operation(summary = "채팅 메세지 조회", description = "채팅방에 해당하는 채팅메세지 리턴해주는 함수"
+    @Operation(summary = "상담사의 채팅 메세지 조회", description = "채팅방에 해당하는 채팅메세지 리턴해주는 함수"
             + "- 주소 형식 : /api/v1/chatMessages/{chatId}?isCustomer=true&messageId=0"
             + "해당하는 메세지가 없을 경우 빈배열 리턴")
     @ApiResponses({
@@ -54,19 +54,41 @@ public class ChatMessageController {
             )
     })
     @Parameters({
-            @Parameter(name = "isCustomer", description = "구매자이면 true"),
             @Parameter(name = "messageId", description = """
                     1. messageId를 기준으로 그보다 index가 작은 것에서 11개 리턴
                     2. 처음 요청을 할 때, 즉 messageId를 모를 때는 0으로 요청부탁드립니다.""")
     })
-    @GetMapping("/{chatId}")
-    public ResponseEntity<List<ChatMessageGetResponse>> getChatMessage(@PathVariable Long chatId,
-                                                                       @RequestParam Long messageId,
-                                                                       @RequestParam Boolean isCustomer,
-                                                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    @GetMapping("/counselors/{chatId}")
+    public ResponseEntity<List<ChatMessageGetResponse>> getCounselorChatMessage(@PathVariable Long chatId,
+                                                                                @RequestParam Long messageId,
+                                                                                @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(
                 chatMessageService.getChatMessage(chatId, messageId, customUserDetails.getCustomer().getCustomerId(),
-                        isCustomer));
+                        false));
+    }
+
+    @Operation(summary = "구매자 채팅 메세지 조회", description = "채팅방에 해당하는 채팅메세지 리턴해주는 함수"
+            + "- 주소 형식 : /api/v1/chatMessages/{chatId}?isCustomer=true&messageId=0"
+            + "해당하는 메세지가 없을 경우 빈배열 리턴")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 채팅 아이디로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "messageId", description = """
+                    1. messageId를 기준으로 그보다 index가 작은 것에서 11개 리턴
+                    2. 처음 요청을 할 때, 즉 messageId를 모를 때는 0으로 요청부탁드립니다.""")
+    })
+    @GetMapping("/customers/{chatId}")
+    public ResponseEntity<List<ChatMessageGetResponse>> getCustomerChatMessage(@PathVariable Long chatId,
+                                                                               @RequestParam Long messageId,
+                                                                               @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(
+                chatMessageService.getChatMessage(chatId, messageId, customUserDetails.getCustomer().getCustomerId(),
+                        true));
     }
 
     @MessageMapping("/api/v1/chatMessages/customers/{chatId}")

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -2,9 +2,11 @@ package com.example.sharemind.counselor.application;
 
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.dto.request.CounselorGetRequest;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
 import com.example.sharemind.counselor.dto.response.CounselorGetBannerResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetForConsultResponse;
+import com.example.sharemind.counselor.dto.response.CounselorGetListResponse;
 import com.example.sharemind.searchWord.dto.request.SearchWordFindRequest;
 import com.example.sharemind.counselor.dto.response.CounselorGetInfoResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
@@ -35,4 +37,7 @@ public interface CounselorService {
     CounselorGetForConsultResponse getCounselorForConsultCreation(Long counselorId, String consultType);
 
     CounselorGetBannerResponse getCounselorChatBanner(Chat chat);
- }
+
+    List<CounselorGetListResponse> getCounselorsByCategory(Long customerId, String sortType,
+                                                           CounselorGetRequest counselorGetRequest);
+}

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -35,4 +35,4 @@ public interface CounselorService {
     CounselorGetForConsultResponse getCounselorForConsultCreation(Long counselorId, String consultType);
 
     CounselorGetBannerResponse getCounselorChatBanner(Chat chat);
-}
+ }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -167,15 +167,15 @@ public class CounselorServiceImpl implements CounselorService {
 
     private List<Counselor> getCounselorByCategoryWithPagination(CounselorGetRequest counselorGetRequest,
                                                                  String sortType) {
-        ConsultCategory consultCategory = ConsultCategory.getConsultCategoryByName(
-                counselorGetRequest.getConsultCategory());
         String sortColumn = getCounselorSortColumn(sortType);
-
         Pageable pageable = PageRequest.of(counselorGetRequest.getIndex(), COUNSELOR_PAGE,
                 Sort.by(sortColumn).descending());
         if (counselorGetRequest.getConsultCategory() == null) {
             return counselorRepository.findByLevelAndStatus(pageable).getContent();
         }
+
+        ConsultCategory consultCategory = ConsultCategory.getConsultCategoryByName(
+                counselorGetRequest.getConsultCategory());
         return counselorRepository.findByConsultCategoryAndLevelAndStatus(consultCategory, pageable).getContent();
     }
 

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.sharemind.counselor.content.ProfileStatus;
 import com.example.sharemind.counselor.domain.ConsultCost;
 import com.example.sharemind.counselor.domain.ConsultTime;
 import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.dto.request.CounselorGetRequest;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
 import com.example.sharemind.counselor.dto.response.CounselorGetForConsultResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetInfoResponse;
@@ -159,6 +160,20 @@ public class CounselorServiceImpl implements CounselorService {
     @Override
     public List<Counselor> getEvaluationPendingConsults() {
         return counselorRepository.findAllByProfileStatusIsEvaluationPendingAndIsActivatedIsTrue();
+    }
+
+    private List<Counselor> getCounselorByCategoryWithPagination(CounselorGetRequest counselorGetRequest,
+                                                                 String sortType) {
+        ConsultCategory consultCategory = ConsultCategory.getConsultCategoryByName(
+                counselorGetRequest.getConsultCategory());
+        String sortColumn = getCounselorSortColumn(sortType);
+
+        Pageable pageable = PageRequest.of(counselorGetRequest.getIndex(), COUNSELOR_PAGE,
+                Sort.by(sortColumn).descending());
+        if (counselorGetRequest.getConsultCategory() == null) {
+            return counselorRepository.findByLevelAndStatus(pageable).getContent();
+        }
+        return counselorRepository.findByConsultCategoryAndLevelAndStatus(consultCategory, pageable).getContent();
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/counselor/dto/request/CounselorGetRequest.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/request/CounselorGetRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class CounselorGetRequest {
 
-    @Schema(description = "상담 카테고리", example = "연애갈등")
+    @Schema(description = "상담 카테고리", example = "DATING")
     private String consultCategory;
 
     @Schema(description = "페이지 번호 index 0이면 0~3번째 값 반환, 1이면 4~7번째 값 반환", example = "0")

--- a/src/main/java/com/example/sharemind/counselor/dto/request/CounselorGetRequest.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/request/CounselorGetRequest.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.counselor.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CounselorGetRequest {
+
+    @Schema(description = "상담 카테고리", example = "연애갈등")
+    private String consultCategory;
+
+    @Schema(description = "페이지 번호 index 0이면 0~3번째 값 반환, 1이면 4~7번째 값 반환", example = "0")
+    @NotNull
+    private int index;
+}

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -190,7 +190,8 @@ public class CounselorController {
                     - 카테고리 선택 || 들을 준비가 된 마인더들 페이지 상담사 리스트 반환
                      - 주소 형식: /api/v1/counselors?sortType=POPULARITY
                      - 결과는 4개씩 반환하며, index는 페이지 번호 입니다(ex index 0 : id 0~3에 해당하는 값 반환 index 1: 4~7에 해당하는 값 반환)
-                    - 해당하는 검색 결과가 없을 때(범위를 벗어난 인덱스 혹은 음수 인덱스)는 빈배열을 리턴합니다.""")
+                    - 해당하는 검색 결과가 없을 때(범위를 벗어난 인덱스 혹은 음수 인덱스)는 빈배열을 리턴합니다.
+                    - 들을 준비가 된 마인더들(상담사 전체 리스트)조회의 경우, RequestBody에서 consultCategory를 빼고 넘겨주시면 됩니다.""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "1. sortType이 잘못된 경우 2. RequestBody의 카테고리가 잘못도니 경우",

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -200,7 +200,7 @@ public class CounselorController {
             )
     })
     @Parameter(name = "sortType", description = "LATEST: 최근순, POPULARITY: 인기순, STAR_RATING: 별점 평균 순")
-    @GetMapping()
+    @PatchMapping()
     public ResponseEntity<List<CounselorGetListResponse>> getCounselorsByCategory(
             @Valid @RequestBody CounselorGetRequest counselorGetRequest,
             @RequestParam String sortType,

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -3,9 +3,11 @@ package com.example.sharemind.counselor.presentation;
 import com.example.sharemind.chat.application.ChatService;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.counselor.dto.request.CounselorGetRequest;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
 import com.example.sharemind.counselor.dto.response.CounselorGetForConsultResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetInfoResponse;
+import com.example.sharemind.counselor.dto.response.CounselorGetListResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetBannerResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
@@ -19,6 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -135,8 +138,7 @@ public class CounselorController {
     }
 
     @Operation(summary = "구매자 채팅창 위에 떠있는 상담사 정보를 불러오기 위한 것",
-            description = "- 구매자 채팅창 위에 떠있는 상담사 정보를 불러오기 위한 것\n " +
-                    "- 주소 형식: /api/v1/counselors/consults/{chatId}?isCustomer=true")
+            description = "- 주소 형식: /api/v1/counselors/consults/{chatId}?isCustomer=true")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 chat 2. 채팅방에 해당 유저가 없을 때"
@@ -180,5 +182,14 @@ public class CounselorController {
     public ResponseEntity<CounselorGetForConsultResponse> getCounselorForConsultCreation(@PathVariable Long counselorId,
                                                                                          @RequestParam String consultType) {
         return ResponseEntity.ok(counselorService.getCounselorForConsultCreation(counselorId, consultType));
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<CounselorGetListResponse>> getCounselorsByCategory(
+            @Valid @RequestBody CounselorGetRequest counselorGetRequest,
+            @RequestParam String sortType,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(counselorService.getCounselorsByCategory(customUserDetails.getCustomer()
+                .getCustomerId(), sortType, counselorGetRequest));
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
+++ b/src/main/java/com/example/sharemind/counselor/repository/CounselorRepository.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.counselor.repository;
 
 import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.global.content.ConsultCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,11 @@ public interface CounselorRepository extends JpaRepository<Counselor, Long> {
 
     @Query("SELECT c FROM Counselor c WHERE (c.nickname LIKE %:word% OR c.experience LIKE %:word% OR c.introduction LIKE %:word%) AND c.level >= 1 AND c.isActivated = true AND c.profileStatus = 'EVALUATION_COMPLETE'")
     Page<Counselor> findByWordAndLevelAndStatus(String word, Pageable pageable);
+
+
+    @Query("SELECT c FROM Counselor c WHERE :category MEMBER OF c.consultCategories AND c.level >= 1 AND c.isActivated = true AND c.profileStatus = 'EVALUATION_COMPLETE'")
+    Page<Counselor> findByConsultCategoryAndLevelAndStatus(ConsultCategory category, Pageable pageable);
+
+    @Query("SELECT c FROM Counselor c WHERE c.level >= 1 AND c.isActivated = true AND c.profileStatus = 'EVALUATION_COMPLETE'")
+    Page<Counselor> findByLevelAndStatus(Pageable pageable);
 }

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()
+                                .requestMatchers("/api/v1/chats/counselors/**").hasRole(ROLE_COUNSELOR)
+                                .requestMatchers("/api/v1/chatMessages/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer


### PR DESCRIPTION
## 📄구현 내용
- 정렬 기준에 따라 상담사 목록을 전달해주는 api 생성
- 페이지네이션을 이용하여 한 번에 4개씩 전달
- 카테고리 별로 상담사 목록 전달해주는 api 생성
## 📝기타 알림사항
- 카테고리 별로 상담사 받아오는 것과 들을 준비가 된 상담사(모든 상담사 조회)같이 구현했습니다