### PR TITLE
feat: 구매자 임시저장 카테고리 조회, 상담사 권한 설정 구현

### DIFF
--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         requests -> requests.requestMatchers("/error", "/swagger-ui/**", "/api-docs/**",
                                         "/api/v1/auth/**", "/api/v1/emails/**").permitAll()
-                                .requestMatchers("/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
+                                .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()

--- a/src/main/java/com/example/sharemind/global/utils/TimeUtil.java
+++ b/src/main/java/com/example/sharemind/global/utils/TimeUtil.java
@@ -4,35 +4,36 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.time.temporal.ChronoUnit;
+import java.util.TimeZone;
 
 public class TimeUtil {
     public static String getUpdatedAt(LocalDateTime updatedAt) {
+        TimeZone timeZone = TimeZone.getTimeZone("Asia/Seoul");
         LocalDateTime now = LocalDateTime.now();
 
         if (ChronoUnit.YEARS.between(updatedAt, now) > 0) {
-            return updatedAt.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM));
+            return updatedAt.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+                    .withZone(timeZone.toZoneId()));
         } else if (ChronoUnit.DAYS.between(updatedAt, now) > 0) {
             if (ChronoUnit.DAYS.between(updatedAt, now) == 1) {
                 return "어제";
             } else {
-                return updatedAt.format(DateTimeFormatter.ofPattern("MM.dd"));
+                return updatedAt.format(DateTimeFormatter.ofPattern("MM.dd").withZone(timeZone.toZoneId()));
             }
-        } else if (ChronoUnit.HOURS.between(updatedAt, now) > 0) {
-            return updatedAt.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT));
-        } else if (ChronoUnit.MINUTES.between(updatedAt, now) > 0) {
-            return ChronoUnit.MINUTES.between(updatedAt, now) + "분 전";
         } else {
-            return "방금";
+            return updatedAt.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+                    .withZone(timeZone.toZoneId()));
         }
     }
 
     public static String getUpdatedAtForReview(LocalDateTime updatedAt) {
+        TimeZone timeZone = TimeZone.getTimeZone("Asia/Seoul");
         LocalDateTime now = LocalDateTime.now();
 
         if (ChronoUnit.YEARS.between(updatedAt, now) > 0) {
-            return updatedAt.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+            return updatedAt.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일").withZone(timeZone.toZoneId()));
         } else {
-            return updatedAt.format(DateTimeFormatter.ofPattern("MM월 dd일"));
+            return updatedAt.format(DateTimeFormatter.ofPattern("MM월 dd일").withZone(timeZone.toZoneId()));
         }
     }
 }

--- a/src/main/java/com/example/sharemind/letter/application/LetterService.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterService.java
@@ -1,6 +1,5 @@
 package com.example.sharemind.letter.application;
 
-import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.letter.dto.response.LetterGetCounselorCategoriesResponse;
@@ -20,5 +19,5 @@ public interface LetterService {
 
     LetterGetDeadlineResponse getDeadline(Long letterId);
 
-    List<ChatLetterGetResponse> getLetters(Boolean filter, Boolean isCustomer, String sortType, Customer customer);
+    List<ChatLetterGetResponse> getLetters(Boolean filter, Boolean isCustomer, String sortType, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/letter/application/LetterService.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterService.java
@@ -14,6 +14,7 @@ public interface LetterService {
     Letter getLetterByLetterId(Long letterId);
 
     LetterGetCounselorCategoriesResponse getCounselorCategories(Long letterId);
+    String getCustomerCategory(Long letterId);
 
     LetterGetNicknameCategoryResponse getCustomerNicknameAndCategory(Long letterId);
 

--- a/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.counselor.exception.CounselorErrorCode;
 import com.example.sharemind.counselor.exception.CounselorException;
+import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
 import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
@@ -38,6 +39,7 @@ public class LetterServiceImpl implements LetterService {
     private static final Boolean IS_COMPLETED = true;
     private static final Integer FINISH_AT_FIRST_MESSAGES = 2;
 
+    private final CustomerService customerService;
     private final ConsultService consultService;
     private final LetterRepository letterRepository;
     private final LetterMessageRepository letterMessageRepository;
@@ -80,7 +82,8 @@ public class LetterServiceImpl implements LetterService {
     }
 
     @Override
-    public List<ChatLetterGetResponse> getLetters(Boolean filter, Boolean isCustomer, String letterSortType, Customer customer) {
+    public List<ChatLetterGetResponse> getLetters(Boolean filter, Boolean isCustomer, String letterSortType, Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
         ChatLetterSortType sortType = ChatLetterSortType.getSortTypeByName(letterSortType);
 
         List<Consult> consults;

--- a/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
@@ -68,6 +68,13 @@ public class LetterServiceImpl implements LetterService {
     }
 
     @Override
+    public String getCustomerCategory(Long letterId) {
+        Letter letter = getLetterByLetterId(letterId);
+
+        return letter.getConsultCategory().getDisplayName();
+    }
+
+    @Override
     public LetterGetNicknameCategoryResponse getCustomerNicknameAndCategory(Long letterId) {
         Letter letter = getLetterByLetterId(letterId);
 

--- a/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
+++ b/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
@@ -43,12 +43,28 @@ public class LetterController {
     @Parameters({
             @Parameter(name = "letterId", description = "편지 아이디")
     })
-    @GetMapping("/categories/{letterId}")
+    @GetMapping("/counselor-categories/{letterId}")
     public ResponseEntity<LetterGetCounselorCategoriesResponse> getCounselorCategories(@PathVariable Long letterId) {
         return ResponseEntity.ok(letterService.getCounselorCategories(letterId));
     }
 
-    @Operation(summary = "구매자 닉네임, 상담 카테고리 조회", description = "판매자 답장 시 상단에 뜨는 구매자 닉네임, 상담 카테고리 조회")
+    @Operation(summary = "구매자 임시저장 카테고리 조회", description = "구매자가 첫번째 질문 임시저장 시 선택한 카테고리 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 편지 아이디로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "letterId", description = "편지 아이디")
+    })
+    @GetMapping("/customer-category/{letterId}")
+    public ResponseEntity<String> getCustomerCategory(@PathVariable Long letterId) {
+        return ResponseEntity.ok(letterService.getCustomerCategory(letterId));
+    }
+
+    @Operation(summary = "판매자 답장 페이지 구매자 닉네임, 상담 카테고리 조회", description = "판매자 답장 시 상단에 뜨는 구매자 닉네임, 상담 카테고리 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "판매 정보 등록되지 않은 상담사",

--- a/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
+++ b/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
@@ -27,6 +27,8 @@ import java.util.List;
 @RequestMapping("/api/v1/letters")
 @RequiredArgsConstructor
 public class LetterController {
+    private static final Boolean IS_CUSTOMER = true;
+    private static final Boolean IS_COUNSELOR = false;
 
     private final LetterService letterService;
 
@@ -49,6 +51,10 @@ public class LetterController {
     @Operation(summary = "구매자 닉네임, 상담 카테고리 조회", description = "판매자 답장 시 상단에 뜨는 구매자 닉네임, 상담 카테고리 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "판매 정보 등록되지 않은 상담사",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 편지 아이디로 요청됨",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
@@ -57,12 +63,13 @@ public class LetterController {
     @Parameters({
             @Parameter(name = "letterId", description = "편지 아이디")
     })
-    @GetMapping("/customer-info/{letterId}")
+    @GetMapping("/counselors/customer-info/{letterId}")
     public ResponseEntity<LetterGetNicknameCategoryResponse> getCustomerNicknameAndCategory(@PathVariable Long letterId) {
         return ResponseEntity.ok(letterService.getCustomerNicknameAndCategory(letterId));
     }
 
-    @Operation(summary = "편지 리스트 조회", description = "편지 리스트 조회, 주소 형식: /api/v1/letters?filter=true&isCustomer=false&sortType=latest")
+    @Operation(summary = "구매자 편지 리스트 조회", description = "- 구매자 편지 리스트 조회\n " +
+            "- 주소 형식: /api/v1/letters/customers?filter=true&sortType=latest")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공(아직 메시지가 존재하지 않는 경우 updatedAt과 recentContent는 null)"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 정렬 방식으로 요청됨",
@@ -72,13 +79,35 @@ public class LetterController {
     })
     @Parameters({
             @Parameter(name = "filter", description = "완료/취소된 상담 제외 여부"),
-            @Parameter(name = "isCustomer", description = "요청 주체가 구매자인지 판매자인지 여부"),
             @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
     })
-    @GetMapping
-    public ResponseEntity<List<ChatLetterGetResponse>> getLetters(@RequestParam Boolean filter, @RequestParam Boolean isCustomer, @RequestParam String sortType,
+    @GetMapping("/customers")
+    public ResponseEntity<List<ChatLetterGetResponse>> getLettersByCustomer(@RequestParam Boolean filter, @RequestParam String sortType,
+                                                                            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(letterService.getLetters(filter, IS_CUSTOMER, sortType, customUserDetails.getCustomer().getCustomerId()));
+    }
+
+    @Operation(summary = "상담사 편지 리스트 조회", description = "- 상담사 편지 리스트 조회\n " +
+            "- 주소 형식: /api/v1/letters/counselors?filter=true&sortType=latest")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공(아직 메시지가 존재하지 않는 경우 updatedAt과 recentContent는 null)"),
+            @ApiResponse(responseCode = "403", description = "판매 정보 등록되지 않은 상담사",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 정렬 방식으로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "filter", description = "완료/취소된 상담 제외 여부"),
+            @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
+    })
+    @GetMapping("/counselors")
+    public ResponseEntity<List<ChatLetterGetResponse>> getLetters(@RequestParam Boolean filter, @RequestParam String sortType,
                                            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.ok(letterService.getLetters(filter, isCustomer, sortType, customUserDetails.getCustomer()));
+        return ResponseEntity.ok(letterService.getLetters(filter, IS_COUNSELOR, sortType, customUserDetails.getCustomer().getCustomerId()));
     }
 
     @Operation(summary = "편지 마감기한 조회",


### PR DESCRIPTION
## 📄구현 내용
- 구매자 임시저장 카테고리 조회
  - 임시저장 내역 불러올 때 구매자가 선택한 카테고리도 불러올 수 있으면 좋겠다는 디자인 파트 요청으로 만들게 되었습니다.
- 상담사 권한 설정
  - COUNSELOR 권한 얻었을 때만 접근 가능한 api 구분
    - LetterController의 편지 리스트 조회, 판매자 페이지에 필요한 구매자 닉네임, 카테고리 조회 api에 작업하였습니다.
- TimeUtil getUpdatedAt 로직 수정
  - 방금, ~분 전 삭제

## 📝기타 알림사항
