### PR TITLE
feat: 편지 환불 로직 구현

### DIFF
--- a/src/main/java/com/example/sharemind/SharemindApplication.java
+++ b/src/main/java/com/example/sharemind/SharemindApplication.java
@@ -3,8 +3,10 @@ package com.example.sharemind;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class SharemindApplication {
 

--- a/src/main/java/com/example/sharemind/consult/content/ConsultStatus.java
+++ b/src/main/java/com/example/sharemind/consult/content/ConsultStatus.java
@@ -8,7 +8,8 @@ public enum ConsultStatus {
     WAITING("상담 대기"),
     ONGOING("상담 중"),
     FINISH("상담 종료"),
-    CANCEL("상담 취소");
+    CUSTOMER_CANCEL("상담 취소"),
+    COUNSELOR_CANCEL("상담 취소");
 
     private final String displayName;
 

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -49,19 +49,19 @@ public class Consult extends BaseEntity {
     @Column(name = "consulted_at")
     private LocalDateTime consultedAt;
 
-    @OneToOne(cascade = CascadeType.PERSIST)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "review_id", unique = true)
     private Review review;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "letter_id", unique = true)
     private Letter letter;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_id", unique = true)
     private Chat chat;
 
-    @OneToOne(cascade = CascadeType.PERSIST)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "payment_id", unique = true)
     private Payment payment;
 
@@ -87,8 +87,8 @@ public class Consult extends BaseEntity {
         this.counselor.increaseTotalConsult();
     }
 
-    public void updateConsultStatusCancel() {
-        this.consultStatus = ConsultStatus.CANCEL;
+    public void updateConsultStatusCounselorCancel() {
+        this.consultStatus = ConsultStatus.COUNSELOR_CANCEL;
 
         this.payment.updatePaymentCustomerStatus(PaymentCustomerStatus.REFUND_WAITING);
     }

--- a/src/main/java/com/example/sharemind/letter/application/LetterService.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterService.java
@@ -14,6 +14,7 @@ public interface LetterService {
     Letter getLetterByLetterId(Long letterId);
 
     LetterGetCounselorCategoriesResponse getCounselorCategories(Long letterId);
+
     String getCustomerCategory(Long letterId);
 
     LetterGetNicknameCategoryResponse getCustomerNicknameAndCategory(Long letterId);

--- a/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
@@ -158,7 +158,7 @@ public class LetterServiceImpl implements LetterService {
                 .toList();
     }
 
-//    @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul") TODO 나중에 주석 해제... 아마 데모데이 전에?
+    @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
     @Transactional
     public void checkLettersDeadline() {
         letterRepository.findAll().stream()

--- a/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
@@ -160,7 +160,7 @@ public class LetterServiceImpl implements LetterService {
 
 //    @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul") TODO 나중에 주석 해제... 아마 데모데이 전에?
     @Transactional
-    public void checkLettersDeadLine() {
+    public void checkLettersDeadline() {
         letterRepository.findAll().stream()
                 .filter(letter -> ((letter.getLetterStatus() == LetterStatus.FIRST_ASKING) ||
                         (letter.getLetterStatus() == LetterStatus.FIRST_ANSWER) ||

--- a/src/main/java/com/example/sharemind/letter/content/LetterStatus.java
+++ b/src/main/java/com/example/sharemind/letter/content/LetterStatus.java
@@ -7,9 +7,11 @@ public enum LetterStatus {
     WAITING("상담 대기", "질문 대기"),
     FIRST_ASKING("답변 대기", "질문 도착"),
     FIRST_ANSWER("답변 도착", "질문 대기"),
+    FIRST_FINISH("상담 종료", "상담 종료"),
     SECOND_ASKING("답변 대기", "질문 도착"),
-    FINISH("상담 종료", "상담 종료"),
-    CANCEL("상담 취소", "상담 취소");
+    SECOND_FINISH("상담 종료", "상담 종료"),
+    COUNSELOR_CANCEL("상담 취소", "상담 취소"),
+    CUSTOMER_CANCEL("상담 취소", "상담 취소");
 
     private final String customerDisplayName;
     private final String counselorDisplayName;

--- a/src/main/java/com/example/sharemind/letter/domain/Letter.java
+++ b/src/main/java/com/example/sharemind/letter/domain/Letter.java
@@ -71,11 +71,21 @@ public class Letter extends BaseEntity {
                 updateCounselorReadId(messageId);
                 updateDeadline();
             }
-            case FINISH -> {
+            case SECOND_FINISH -> {
                 updateCounselorReadId(messageId);
                 this.consult.updateConsultStatusFinish();
             }
         }
+    }
+
+    public void updateLetterStatusFirstFinish() {
+        this.letterStatus = LetterStatus.FIRST_FINISH;
+        this.consult.updateConsultStatusFinish();
+    }
+
+    public void updateLetterStatusCounselorCancel() {
+        this.letterStatus = LetterStatus.COUNSELOR_CANCEL;
+        this.consult.updateConsultStatusCounselorCancel();
     }
 
     public void updateConsultCategory(ConsultCategory category) {

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
@@ -1,7 +1,7 @@
 package com.example.sharemind.letter.dto.response;
 
 import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
-import com.example.sharemind.global.utils.TimeUtil;
+import com.example.sharemind.global.utils.*;
 import com.example.sharemind.letter.content.LetterStatus;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.letterMessage.domain.LetterMessage;
@@ -47,7 +47,8 @@ public class LetterGetResponse {
         }
 
         Boolean reviewCompleted = null;
-        if (letter.getLetterStatus().equals(LetterStatus.FINISH)) {
+        if (letter.getLetterStatus().equals(LetterStatus.FIRST_FINISH) ||
+                letter.getLetterStatus().equals(LetterStatus.SECOND_FINISH)) {
             reviewCompleted = letter.getConsult().getReview().getIsCompleted();
         }
 

--- a/src/main/java/com/example/sharemind/letterMessage/content/LetterMessageType.java
+++ b/src/main/java/com/example/sharemind/letterMessage/content/LetterMessageType.java
@@ -13,7 +13,7 @@ public enum LetterMessageType {
     FIRST_QUESTION("질문", LetterStatus.FIRST_ASKING),
     FIRST_REPLY("답장", LetterStatus.FIRST_ANSWER),
     SECOND_QUESTION("추가 질문", LetterStatus.SECOND_ASKING),
-    SECOND_REPLY("추가 답장", LetterStatus.FINISH);
+    SECOND_REPLY("추가 답장", LetterStatus.SECOND_FINISH);
 
     private final String displayName;
     private final LetterStatus letterStatus;


### PR DESCRIPTION
## 📄구현 내용
- 편지 환불 로직 구현
  - 첫번째 질문/두번째 질문 후 24시간이 지나도 답장이 오지 않았을 경우
  - LetterStatus와 ConsultStatus 상담 취소로 상태 변경 및 Payment의 CustomerStatus 환불 예정으로 상태 변경
- 편지 자동 종료 구현
  - 첫번째 답장 후 24시간이 지나도 두번째 질문이 오지 않았을 경우
  - LetterStatus와 ConsultStatus 상담 종료로 상태 변경

## 📝기타 알림사항
- 테스트하다보니 디비에 더욱 세분화된 값이 찍히는 것이 나중에 정확한 사유를 파악하기에 좋을 것 같아 LetterStatus와 ConsultStatus를 세분화해보았습니다. 의견 부탁드립니다!
- 편지 자동 환불 및 종료를 진행하는 checkLettersDeadline은 1시간 간격으로 정각마다 실행되도록 설정하였습니다.
