### PR TITLE
feat: 구매자 결제 내역 조회, 어드민 환불 구현

### DIFF
--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -1,8 +1,8 @@
 package com.example.sharemind.admin.application;
 
 import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
+import com.example.sharemind.admin.dto.response.PaymentGetRefundWaitingResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
-import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 
 import java.util.List;
 
@@ -15,7 +15,7 @@ public interface AdminService {
 
     void updateProfileStatus(Long counselorId, Boolean isPassed);
 
-    List<PaymentGetCustomerResponse> getRefundWaitingPayments();
+    List<PaymentGetRefundWaitingResponse> getRefundWaitingPayments();
 
     void updatePaymentCustomerStatus(Long paymentId);
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -17,5 +17,5 @@ public interface AdminService {
 
     List<PaymentGetRefundWaitingResponse> getRefundWaitingPayments();
 
-    void updatePaymentCustomerStatus(Long paymentId);
+    void updateRefundComplete(Long paymentId);
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -1,13 +1,13 @@
 package com.example.sharemind.admin.application;
 
-import com.example.sharemind.admin.dto.response.ConsultsGetUnpaidResponse;
+import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 
 import java.util.List;
 
 public interface AdminService {
-    List<ConsultsGetUnpaidResponse> getUnpaidConsults();
+    List<ConsultGetUnpaidResponse> getUnpaidConsults();
 
     void updateIsPaid(Long consultId);
 

--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -2,6 +2,7 @@ package com.example.sharemind.admin.application;
 
 import com.example.sharemind.admin.dto.response.ConsultsGetUnpaidResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
+import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 
 import java.util.List;
 
@@ -13,4 +14,6 @@ public interface AdminService {
     List<CounselorGetProfileResponse> getPendingCounselors();
 
     void updateProfileStatus(Long counselorId, Boolean isPassed);
+
+    List<PaymentGetCustomerResponse> getRefundWaitingPayments();
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -16,4 +16,6 @@ public interface AdminService {
     void updateProfileStatus(Long counselorId, Boolean isPassed);
 
     List<PaymentGetCustomerResponse> getRefundWaitingPayments();
+
+    void updatePaymentCustomerStatus(Long paymentId);
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -118,6 +118,6 @@ public class AdminServiceImpl implements AdminService {
             throw new PaymentException(PaymentErrorCode.INVALID_REFUND_COMPLETE);
         }
 
-        payment.updateCustomerStatusToRefundComplete();
+        payment.updateCustomerStatusRefundComplete();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -118,6 +118,6 @@ public class AdminServiceImpl implements AdminService {
             throw new PaymentException(PaymentErrorCode.INVALID_REFUND_COMPLETE);
         }
 
-        payment.updatePaymentCustomerStatus(PaymentCustomerStatus.REFUND_COMPLETE);
+        payment.updateCustomerStatusToRefundComplete();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -18,6 +18,8 @@ import com.example.sharemind.customer.content.Role;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.letter.application.LetterService;
 import com.example.sharemind.letter.domain.Letter;
+import com.example.sharemind.payment.application.PaymentService;
+import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +34,7 @@ public class AdminServiceImpl implements AdminService {
     private final ConsultService consultService;
     private final LetterService letterService;
     private final ChatService chatService;
+    private final PaymentService paymentService;
     private final CounselorService counselorService;
     private final CustomerService customerService;
 
@@ -94,5 +97,12 @@ public class AdminServiceImpl implements AdminService {
                 customer.addRole(Role.ROLE_COUNSELOR);
             }
         }
+    }
+
+    @Override
+    public List<PaymentGetCustomerResponse> getRefundWaitingPayments() {
+        return paymentService.getRefundWaitingPayments().stream()
+                .map(PaymentGetCustomerResponse::of)
+                .toList();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.admin.application;
 
 import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
+import com.example.sharemind.admin.dto.response.PaymentGetRefundWaitingResponse;
 import com.example.sharemind.chat.application.ChatService;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.application.ConsultService;
@@ -21,7 +22,6 @@ import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.payment.application.PaymentService;
 import com.example.sharemind.payment.content.PaymentCustomerStatus;
 import com.example.sharemind.payment.domain.Payment;
-import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import com.example.sharemind.payment.exception.PaymentErrorCode;
 import com.example.sharemind.payment.exception.PaymentException;
 import lombok.RequiredArgsConstructor;
@@ -103,9 +103,9 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
-    public List<PaymentGetCustomerResponse> getRefundWaitingPayments() {
+    public List<PaymentGetRefundWaitingResponse> getRefundWaitingPayments() {
         return paymentService.getRefundWaitingPayments().stream()
-                .map(PaymentGetCustomerResponse::of)
+                .map(PaymentGetRefundWaitingResponse::of)
                 .toList();
     }
 

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -111,7 +111,7 @@ public class AdminServiceImpl implements AdminService {
 
     @Transactional
     @Override
-    public void updatePaymentCustomerStatus(Long paymentId) {
+    public void updateRefundComplete(Long paymentId) {
         Payment payment = paymentService.getPaymentByPaymentId(paymentId);
         if ((payment.getCustomerStatus() == null) ||
                 (!payment.getCustomerStatus().equals(PaymentCustomerStatus.REFUND_WAITING))) {

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -19,7 +19,11 @@ import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.letter.application.LetterService;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.payment.application.PaymentService;
+import com.example.sharemind.payment.content.PaymentCustomerStatus;
+import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
+import com.example.sharemind.payment.exception.PaymentErrorCode;
+import com.example.sharemind.payment.exception.PaymentException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,7 +51,6 @@ public class AdminServiceImpl implements AdminService {
 
     @Transactional
     public void updateIsPaid(Long consultId) {
-
         Consult consult = consultService.getConsultByConsultId(consultId);
         if (consult.getPayment().getIsPaid()) {
             throw new ConsultException(ConsultErrorCode.CONSULT_ALREADY_PAID, consultId.toString());
@@ -104,5 +107,17 @@ public class AdminServiceImpl implements AdminService {
         return paymentService.getRefundWaitingPayments().stream()
                 .map(PaymentGetCustomerResponse::of)
                 .toList();
+    }
+
+    @Transactional
+    @Override
+    public void updatePaymentCustomerStatus(Long paymentId) {
+        Payment payment = paymentService.getPaymentByPaymentId(paymentId);
+        if ((payment.getCustomerStatus() == null) ||
+                (!payment.getCustomerStatus().equals(PaymentCustomerStatus.REFUND_WAITING))) {
+            throw new PaymentException(PaymentErrorCode.INVALID_REFUND_COMPLETE);
+        }
+
+        payment.updatePaymentCustomerStatus(PaymentCustomerStatus.REFUND_COMPLETE);
     }
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.sharemind.admin.application;
 
-import com.example.sharemind.admin.dto.response.ConsultsGetUnpaidResponse;
+import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
 import com.example.sharemind.chat.application.ChatService;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.application.ConsultService;
@@ -43,9 +43,9 @@ public class AdminServiceImpl implements AdminService {
     private final CustomerService customerService;
 
     @Override
-    public List<ConsultsGetUnpaidResponse> getUnpaidConsults() {
+    public List<ConsultGetUnpaidResponse> getUnpaidConsults() {
         return consultService.getUnpaidConsults().stream()
-                .map(ConsultsGetUnpaidResponse::of)
+                .map(ConsultGetUnpaidResponse::of)
                 .toList();
     }
 

--- a/src/main/java/com/example/sharemind/admin/dto/response/ConsultGetUnpaidResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/ConsultGetUnpaidResponse.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class ConsultsGetUnpaidResponse {
+public class ConsultGetUnpaidResponse {
 
     @Schema(description = "상담 아이디")
     private final Long consultId;
@@ -30,8 +30,8 @@ public class ConsultsGetUnpaidResponse {
     @Schema(description = "상담 신청 일시")
     private final LocalDateTime createdAt;
 
-    public static ConsultsGetUnpaidResponse of(Consult consult) {
-        return new ConsultsGetUnpaidResponse(consult.getConsultId(), consult.getCustomer().getNickname(), consult.getCounselor().getNickname(),
+    public static ConsultGetUnpaidResponse of(Consult consult) {
+        return new ConsultGetUnpaidResponse(consult.getConsultId(), consult.getCustomer().getNickname(), consult.getCounselor().getNickname(),
                 consult.getConsultType().getDisplayName(), consult.getCost(), consult.getCreatedAt());
     }
 }

--- a/src/main/java/com/example/sharemind/admin/dto/response/PaymentGetRefundWaitingResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/PaymentGetRefundWaitingResponse.java
@@ -1,0 +1,54 @@
+package com.example.sharemind.admin.dto.response;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.payment.domain.Payment;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentGetRefundWaitingResponse {
+
+    @Schema(description = "결제 정보 아이디")
+    private final Long paymentId;
+
+    @Schema(description = "구매자 닉네임")
+    private final String customerNickname;
+
+    @Schema(description = "상담사 닉네임")
+    private final String counselorNickname;
+
+    @Schema(description = "상담 진행 상태", example = "상담 중")
+    private final String status;
+
+    @Schema(description = "상담 유형", example = "편지")
+    private final String consultType;
+
+    @Schema(description = "상담 날짜", example = "2023년 1월 29일", type = "string")
+    @JsonFormat(pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+    private final LocalDateTime consultedAt;
+
+    @Schema(description = "상담 금액", example = "12345")
+    private final Long cost;
+
+    @Schema(description = "구매 날짜", example = "2023년 1월 27일", type = "string")
+    @JsonFormat(pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+    private final LocalDateTime paidAt;
+
+    @Schema(description = "결제 수단", example = "외부 결제")
+    private final String method;
+
+    public static PaymentGetRefundWaitingResponse of(Payment payment) {
+        Consult consult = payment.getConsult();
+
+        return new PaymentGetRefundWaitingResponse(payment.getPaymentId(), consult.getCustomer().getNickname(),
+                consult.getCounselor().getNickname(), consult.getConsultStatus().name(),
+                consult.getConsultType().getDisplayName(), consult.getConsultedAt(), consult.getCost(),
+                payment.getCreatedAt(), payment.getMethod());
+    }
+}

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -2,9 +2,9 @@ package com.example.sharemind.admin.presentation;
 
 import com.example.sharemind.admin.application.AdminService;
 import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
+import com.example.sharemind.admin.dto.response.PaymentGetRefundWaitingResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
-import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -95,7 +95,7 @@ public class AdminController {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     @GetMapping("/refund-waiting")
-    public ResponseEntity<List<PaymentGetCustomerResponse>> getRefundWaitingPayments() {
+    public ResponseEntity<List<PaymentGetRefundWaitingResponse>> getRefundWaitingPayments() {
         return ResponseEntity.ok(adminService.getRefundWaitingPayments());
     }
 

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -4,6 +4,7 @@ import com.example.sharemind.admin.application.AdminService;
 import com.example.sharemind.admin.dto.response.ConsultsGetUnpaidResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
+import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -87,5 +88,14 @@ public class AdminController {
     public ResponseEntity<Void> updateProfileStatus(@PathVariable Long counselorId, @RequestParam Boolean isPassed) {
         adminService.updateProfileStatus(counselorId, isPassed);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "환불 예정 결제 정보 조회", description = "환불 예정 상태인 결제 정보 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/refund-waiting")
+    public ResponseEntity<List<PaymentGetCustomerResponse>> getRefundWaitingPayments() {
+        return ResponseEntity.ok(adminService.getRefundWaitingPayments());
     }
 }

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -1,7 +1,7 @@
 package com.example.sharemind.admin.presentation;
 
 import com.example.sharemind.admin.application.AdminService;
-import com.example.sharemind.admin.dto.response.ConsultsGetUnpaidResponse;
+import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
@@ -32,7 +32,7 @@ public class AdminController {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     @GetMapping("/unpaid-consults")
-    public ResponseEntity<List<ConsultsGetUnpaidResponse>> getUnpaidConsults() {
+    public ResponseEntity<List<ConsultGetUnpaidResponse>> getUnpaidConsults() {
         return ResponseEntity.ok(adminService.getUnpaidConsults());
     }
 

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -116,8 +116,8 @@ public class AdminController {
             @Parameter(name = "paymentId", description = "결제 아이디")
     })
     @PatchMapping("/refund-waiting/{paymentId}")
-    public ResponseEntity<Void> updatePaymentCustomerStatus(@PathVariable Long paymentId) {
-        adminService.updatePaymentCustomerStatus(paymentId);
+    public ResponseEntity<Void> updateRefundComplete(@PathVariable Long paymentId) {
+        adminService.updateRefundComplete(paymentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -98,4 +98,26 @@ public class AdminController {
     public ResponseEntity<List<PaymentGetCustomerResponse>> getRefundWaitingPayments() {
         return ResponseEntity.ok(adminService.getRefundWaitingPayments());
     }
+
+    @Operation(summary = "결제 환불 완료 수정",
+            description = "환불 예정인 결제를 환불 완료로 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "환불 예정 상태가 아닌 결제에 대한 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 결제 아이디로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "paymentId", description = "결제 아이디")
+    })
+    @PatchMapping("/refund-waiting/{paymentId}")
+    public ResponseEntity<Void> updatePaymentCustomerStatus(@PathVariable Long paymentId) {
+        adminService.updatePaymentCustomerStatus(paymentId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -92,6 +92,18 @@ public class Consult extends BaseEntity {
         this.payment.updateCustomerStatusRefundWaiting();
     }
 
+    public void updateConsultStatusCustomerCancel() {
+        this.consultStatus = ConsultStatus.CUSTOMER_CANCEL;
+
+        switch (this.consultType) {
+            /**
+             * TODO chat 상태 cancel로 변경
+             * case CHAT ->
+             */
+            case LETTER -> this.letter.updateLetterStatusCustomerCancel();
+        }
+    }
+
     public void updateIsPaidAndLetter(Letter letter) {
         validateConsultType(ConsultType.LETTER);
         setLetter(letter);

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -89,7 +89,7 @@ public class Consult extends BaseEntity {
     public void updateConsultStatusCounselorCancel() {
         this.consultStatus = ConsultStatus.COUNSELOR_CANCEL;
 
-        this.payment.updateCustomerStatusToRefundWaiting();
+        this.payment.updateCustomerStatusRefundWaiting();
     }
 
     public void updateIsPaidAndLetter(Letter letter) {

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -8,7 +8,6 @@ import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.content.ConsultType;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.chat.domain.Chat;
-import com.example.sharemind.payment.content.PaymentCustomerStatus;
 import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.review.domain.Review;
 import com.example.sharemind.customer.domain.Customer;
@@ -90,7 +89,7 @@ public class Consult extends BaseEntity {
     public void updateConsultStatusCounselorCancel() {
         this.consultStatus = ConsultStatus.COUNSELOR_CANCEL;
 
-        this.payment.updatePaymentCustomerStatus(PaymentCustomerStatus.REFUND_WAITING);
+        this.payment.updateCustomerStatusToRefundWaiting();
     }
 
     public void updateIsPaidAndLetter(Letter letter) {

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -40,5 +40,5 @@ public interface CounselorService {
 
     List<CounselorGetWishListResponse> getCounselorWishListByCustomer(WishListGetRequest wishListGetRequest, Long customerId);
 
-    CounselorGetMinderProfileResponse getCounselorMinderProfile(Long counselorId);
+    CounselorGetMinderProfileResponse getCounselorMinderProfile(Long counselorId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -203,10 +203,12 @@ public class CounselorServiceImpl implements CounselorService {
     }
 
     @Override
-    public CounselorGetMinderProfileResponse getCounselorMinderProfile(Long counselorId) {
+    public CounselorGetMinderProfileResponse getCounselorMinderProfile(Long counselorId, Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
         Counselor counselor = getCounselorByCounselorId(counselorId);
 
-        return CounselorGetMinderProfileResponse.of(counselor);
+        return CounselorGetMinderProfileResponse.of(counselor,
+                wishListCounselorService.getIsWishListByCustomerAndCounselor(customer, counselor));
     }
 
     private String getCounselorSortColumn(String sortType) {

--- a/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetMinderProfileResponse.java
+++ b/src/main/java/com/example/sharemind/counselor/dto/response/CounselorGetMinderProfileResponse.java
@@ -47,11 +47,14 @@ public class CounselorGetMinderProfileResponse {
     @Schema(description = "경험 소개")
     private final String experience;
 
-    public static CounselorGetMinderProfileResponse of(Counselor counselor) {
+    @Schema(description = "찜여부")
+    private final Boolean isWishList;
+
+    public static CounselorGetMinderProfileResponse of(Counselor counselor, Boolean isWishList) {
         return new CounselorGetMinderProfileResponse(counselor.getCounselorId(), counselor.getNickname(),
                 counselor.getLevel(), counselor.getTotalReview(), counselor.getRatingAverage(),
                 CounselorUtil.convertConsultCategories(counselor), counselor.getConsultStyle().getDisplayName(),
                 CounselorUtil.convertConsultTypes(counselor), CounselorUtil.convertConsultTimes(counselor),
-                CounselorUtil.convertConsultCosts(counselor), counselor.getExperience());
+                CounselorUtil.convertConsultCosts(counselor), counselor.getExperience(), isWishList);
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -221,7 +221,8 @@ public class CounselorController {
             @Parameter(name = "counselorId", description = "상담사 아이디")
     })
     @GetMapping("/{counselorId}")
-    public ResponseEntity<CounselorGetMinderProfileResponse> getCounselorMinderProfile(@PathVariable Long counselorId) {
-        return ResponseEntity.ok(counselorService.getCounselorMinderProfile(counselorId));
+    public ResponseEntity<CounselorGetMinderProfileResponse> getCounselorMinderProfile(@PathVariable Long counselorId,
+                                                                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(counselorService.getCounselorMinderProfile(counselorId, customUserDetails.getCustomer().getCustomerId()));
     }
 }

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -8,6 +8,7 @@ import com.example.sharemind.customer.exception.CustomerException;
 import com.example.sharemind.email.exception.EmailException;
 import com.example.sharemind.letter.exception.LetterException;
 import com.example.sharemind.letterMessage.exception.LetterMessageException;
+import com.example.sharemind.payment.exception.PaymentException;
 import com.example.sharemind.review.exception.ReviewException;
 import com.example.sharemind.wishList.exception.WishListException;
 import jakarta.validation.ConstraintViolationException;
@@ -87,6 +88,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(ReviewException.class)
     public ResponseEntity<CustomExceptionResponse> catchReviewException(ReviewException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(PaymentException.class)
+    public ResponseEntity<CustomExceptionResponse> catchPaymentException(PaymentException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/letter/domain/Letter.java
+++ b/src/main/java/com/example/sharemind/letter/domain/Letter.java
@@ -88,6 +88,10 @@ public class Letter extends BaseEntity {
         this.consult.updateConsultStatusCounselorCancel();
     }
 
+    public void updateLetterStatusCustomerCancel() {
+        this.letterStatus = LetterStatus.CUSTOMER_CANCEL;
+    }
+
     public void updateConsultCategory(ConsultCategory category) {
         validateConsultCategory(category);
 

--- a/src/main/java/com/example/sharemind/letter/exception/LetterErrorCode.java
+++ b/src/main/java/com/example/sharemind/letter/exception/LetterErrorCode.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 public enum LetterErrorCode {
 
     LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "편지(비실시간 상담) 정보가 존재하지 않습니다."),
-    LETTER_SORT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "편지 정렬 방식이 존재하지 않습니다."),
     CONSULT_CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "상담사가 제공하지 않은 상담 카테고리입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/sharemind/payment/application/PaymentService.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentService.java
@@ -1,9 +1,12 @@
 package com.example.sharemind.payment.application;
 
+import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 
 import java.util.List;
 
 public interface PaymentService {
     List<PaymentGetCustomerResponse> getPaymentsByCustomer(Long paymentId, String status, Long customerId);
+
+    List<Payment> getRefundWaitingPayments();
 }

--- a/src/main/java/com/example/sharemind/payment/application/PaymentService.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentService.java
@@ -6,6 +6,8 @@ import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import java.util.List;
 
 public interface PaymentService {
+    Payment getPaymentByPaymentId(Long paymentId);
+
     List<PaymentGetCustomerResponse> getPaymentsByCustomer(Long paymentId, String status, Long customerId);
 
     List<Payment> getRefundWaitingPayments();

--- a/src/main/java/com/example/sharemind/payment/application/PaymentService.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentService.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.payment.application;
+
+import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
+
+import java.util.List;
+
+public interface PaymentService {
+    List<PaymentGetCustomerResponse> getPaymentsByCustomer(Long paymentId, String status, Long customerId);
+}

--- a/src/main/java/com/example/sharemind/payment/application/PaymentService.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentService.java
@@ -10,5 +10,7 @@ public interface PaymentService {
 
     List<PaymentGetCustomerResponse> getPaymentsByCustomer(Long paymentId, String status, Long customerId);
 
+    void updateRefundWaitingByCustomer(Long paymentId, Long customerId);
+
     List<Payment> getRefundWaitingPayments();
 }

--- a/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
@@ -5,6 +5,8 @@ import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.content.PaymentCustomerStatus;
 import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
+import com.example.sharemind.payment.exception.PaymentErrorCode;
+import com.example.sharemind.payment.exception.PaymentException;
 import com.example.sharemind.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +26,12 @@ public class PaymentServiceImpl implements PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final CustomerService customerService;
+
+    @Override
+    public Payment getPaymentByPaymentId(Long paymentId) {
+        return paymentRepository.findByPaymentIdAndIsActivatedIsTrue(paymentId)
+                .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND, paymentId.toString()));
+    }
 
     @Override
     public List<PaymentGetCustomerResponse> getPaymentsByCustomer(Long paymentId, String status, Long customerId) {

--- a/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
@@ -50,6 +50,19 @@ public class PaymentServiceImpl implements PaymentService {
         return page.getContent();
     }
 
+    @Transactional
+    @Override
+    public void updateRefundWaitingByCustomer(Long paymentId, Long customerId) {
+        Payment payment = getPaymentByPaymentId(paymentId);
+        payment.checkUpdateAuthority(customerId);
+        if ((payment.getCustomerStatus() == null) ||
+                (!payment.getCustomerStatus().equals(PaymentCustomerStatus.PAYMENT_COMPLETE))) {
+            throw new PaymentException(PaymentErrorCode.INVALID_REFUND_WAITING, paymentId.toString());
+        }
+
+        payment.updateCustomerStatusRefundWaiting();
+    }
+
     @Override
     public List<Payment> getRefundWaitingPayments() {
         return paymentRepository.findAllByCustomerStatusAndIsActivatedIsTrue(PaymentCustomerStatus.REFUND_WAITING);

--- a/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.sharemind.payment.application;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.content.PaymentCustomerStatus;
+import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import com.example.sharemind.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
@@ -39,5 +40,10 @@ public class PaymentServiceImpl implements PaymentService {
                         .map(PaymentGetCustomerResponse::of);
 
         return page.getContent();
+    }
+
+    @Override
+    public List<Payment> getRefundWaitingPayments() {
+        return paymentRepository.findAllByCustomerStatusAndIsActivatedIsTrue(PaymentCustomerStatus.REFUND_WAITING);
     }
 }

--- a/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.sharemind.payment.application;
+
+import com.example.sharemind.customer.application.CustomerService;
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.payment.content.PaymentCustomerStatus;
+import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
+import com.example.sharemind.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService {
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final int PAYMENT_CUSTOMER_PAGE_SIZE = 4;
+
+    private final PaymentRepository paymentRepository;
+    private final CustomerService customerService;
+
+    @Override
+    public List<PaymentGetCustomerResponse> getPaymentsByCustomer(Long paymentId, String status, Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+        PaymentCustomerStatus customerStatus = PaymentCustomerStatus.getPaymentCustomerStatusByName(status);
+
+        Pageable pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, PAYMENT_CUSTOMER_PAGE_SIZE);
+        Page<PaymentGetCustomerResponse> page =
+                (paymentId == 0 ?
+                        paymentRepository.findAllByCustomerAndCustomerStatusAndIsActivatedIsTrue(
+                                customer, customerStatus, pageable) :
+                        paymentRepository.findAllByPaymentIdLessThanAndCustomerAndCustomerStatusAndIsActivatedIsTrue(
+                                paymentId, customer, customerStatus, pageable))
+                        .map(PaymentGetCustomerResponse::of);
+
+        return page.getContent();
+    }
+}

--- a/src/main/java/com/example/sharemind/payment/content/PaymentCustomerStatus.java
+++ b/src/main/java/com/example/sharemind/payment/content/PaymentCustomerStatus.java
@@ -1,7 +1,22 @@
 package com.example.sharemind.payment.content;
 
+import com.example.sharemind.payment.exception.PaymentErrorCode;
+import com.example.sharemind.payment.exception.PaymentException;
+
+import java.util.Arrays;
+
 public enum PaymentCustomerStatus {
     PAYMENT_COMPLETE,
     REFUND_WAITING,
-    REFUND_COMPLETE
+    REFUND_COMPLETE;
+
+    public static PaymentCustomerStatus getPaymentCustomerStatusByName(String name) {
+        return Arrays.stream(PaymentCustomerStatus.values())
+                .filter(customerStatus -> customerStatus.name().equalsIgnoreCase(name))
+                .findAny().orElseThrow(
+                        () -> new PaymentException(
+                                PaymentErrorCode.PAYMENT_CUSTOMER_STATUS_NOT_FOUND, name
+                        )
+                );
+    }
 }

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -51,10 +51,10 @@ public class Payment extends BaseEntity {
 
     public void updateIsPaidTrue() {
         this.isPaid = true;
-        updateCustomerStatusToPaymentComplete();
+        updateCustomerStatusPaymentComplete();
     }
 
-    public void updateCustomerStatusToPaymentComplete() {
+    public void updateCustomerStatusPaymentComplete() {
         this.customerStatus = PaymentCustomerStatus.PAYMENT_COMPLETE;
     }
 
@@ -62,7 +62,7 @@ public class Payment extends BaseEntity {
         this.customerStatus = PaymentCustomerStatus.REFUND_WAITING;
     }
 
-    public void updateCustomerStatusToRefundComplete() {
+    public void updateCustomerStatusRefundComplete() {
         this.customerStatus = PaymentCustomerStatus.REFUND_COMPLETE;
     }
 }

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -1,9 +1,12 @@
 package com.example.sharemind.payment.domain;
 
+import com.example.sharemind.consult.content.ConsultStatus;
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.payment.content.PaymentCounselorStatus;
 import com.example.sharemind.payment.content.PaymentCustomerStatus;
+import com.example.sharemind.payment.exception.PaymentErrorCode;
+import com.example.sharemind.payment.exception.PaymentException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -67,5 +70,11 @@ public class Payment extends BaseEntity {
 
     public void updateCustomerStatusRefundComplete() {
         this.customerStatus = PaymentCustomerStatus.REFUND_COMPLETE;
+    }
+
+    public void checkUpdateAuthority(Long customerId) {
+        if (!this.consult.getCustomer().getCustomerId().equals(customerId)) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_UPDATE_DENIED);
+        }
     }
 }

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -51,10 +51,18 @@ public class Payment extends BaseEntity {
 
     public void updateIsPaidTrue() {
         this.isPaid = true;
-        updatePaymentCustomerStatus(PaymentCustomerStatus.PAYMENT_COMPLETE);
+        updateCustomerStatusToPaymentComplete();
     }
 
-    public void updatePaymentCustomerStatus(PaymentCustomerStatus customerStatus) {
-        this.customerStatus = customerStatus;
+    public void updateCustomerStatusToPaymentComplete() {
+        this.customerStatus = PaymentCustomerStatus.PAYMENT_COMPLETE;
+    }
+
+    public void updateCustomerStatusToRefundWaiting() {
+        this.customerStatus = PaymentCustomerStatus.REFUND_WAITING;
+    }
+
+    public void updateCustomerStatusToRefundComplete() {
+        this.customerStatus = PaymentCustomerStatus.REFUND_COMPLETE;
     }
 }

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -58,7 +58,10 @@ public class Payment extends BaseEntity {
         this.customerStatus = PaymentCustomerStatus.PAYMENT_COMPLETE;
     }
 
-    public void updateCustomerStatusToRefundWaiting() {
+    public void updateCustomerStatusRefundWaiting() {
+        if (!this.consult.getConsultStatus().equals(ConsultStatus.COUNSELOR_CANCEL)) {
+            this.consult.updateConsultStatusCustomerCancel();
+        }
         this.customerStatus = PaymentCustomerStatus.REFUND_WAITING;
     }
 

--- a/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCustomerResponse.java
+++ b/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCustomerResponse.java
@@ -1,0 +1,50 @@
+package com.example.sharemind.payment.dto.response;
+
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.payment.domain.Payment;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentGetCustomerResponse {
+
+    @Schema(description = "결제 정보 아이디")
+    private final Long paymentId;
+
+    @Schema(description = "상담사 닉네임")
+    private final String nickname;
+
+    @Schema(description = "상담 진행 상태", example = "상담 중")
+    private final String status;
+
+    @Schema(description = "상담 유형", example = "편지")
+    private final String consultType;
+
+    @Schema(description = "상담 날짜", example = "2023년 1월 29일", type = "string")
+    @JsonFormat(pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+    private final LocalDateTime consultedAt;
+
+    @Schema(description = "상담 금액", example = "12345")
+    private final Long cost;
+
+    @Schema(description = "구매 날짜", example = "2023년 1월 27일", type = "string")
+    @JsonFormat(pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+    private final LocalDateTime paidAt;
+
+    @Schema(description = "결제 수단", example = "외부 결제")
+    private final String method;
+
+    public static PaymentGetCustomerResponse of(Payment payment) {
+        Consult consult = payment.getConsult();
+
+        return new PaymentGetCustomerResponse(payment.getPaymentId(), consult.getCounselor().getNickname(),
+                consult.getConsultStatus().getDisplayName(), consult.getConsultType().getDisplayName(),
+                consult.getConsultedAt(), consult.getCost(), payment.getCreatedAt(), payment.getMethod());
+    }
+}

--- a/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
@@ -8,7 +8,9 @@ public enum PaymentErrorCode {
 
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 내역이 존재하지 않습니다."),
     PAYMENT_CUSTOMER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "구매자 결제 내역 유형이 존재하지 않습니다."),
-    INVALID_REFUND_COMPLETE(HttpStatus.BAD_REQUEST, "환불 완료로 상태를 변경할 수 있는 결제가 아닙니다.");
+    INVALID_REFUND_WAITING(HttpStatus.BAD_REQUEST, "환불 예정으로 상태를 변경할 수 있는 결제가 아닙니다."),
+    INVALID_REFUND_COMPLETE(HttpStatus.BAD_REQUEST, "환불 완료로 상태를 변경할 수 있는 결제가 아닙니다."),
+    PAYMENT_UPDATE_DENIED(HttpStatus.FORBIDDEN, "결제 내역 수정 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum PaymentErrorCode {
 
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 내역이 존재하지 않습니다."),
-    PAYMENT_CUSTOMER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "구매자 결제 내역 유형이 존재하지 않습니다.");
+    PAYMENT_CUSTOMER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "구매자 결제 내역 유형이 존재하지 않습니다."),
+    INVALID_REFUND_COMPLETE(HttpStatus.BAD_REQUEST, "환불 완료로 상태를 변경할 수 있는 결제가 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.sharemind.payment.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum PaymentErrorCode {
+
+    PAYMENT_CUSTOMER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "구매자 결제 내역 유형이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    PaymentErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/example/sharemind/payment/exception/PaymentErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum PaymentErrorCode {
 
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 내역이 존재하지 않습니다."),
     PAYMENT_CUSTOMER_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "구매자 결제 내역 유형이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/sharemind/payment/exception/PaymentException.java
+++ b/src/main/java/com/example/sharemind/payment/exception/PaymentException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.payment.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentException extends RuntimeException {
+
+    private final PaymentErrorCode errorCode;
+
+    public PaymentException(PaymentErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/payment/exception/PaymentException.java
+++ b/src/main/java/com/example/sharemind/payment/exception/PaymentException.java
@@ -7,6 +7,11 @@ public class PaymentException extends RuntimeException {
 
     private final PaymentErrorCode errorCode;
 
+    public PaymentException(PaymentErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
     public PaymentException(PaymentErrorCode errorCode, String message) {
         super(errorCode.getMessage() + " : " + message);
         this.errorCode = errorCode;

--- a/src/main/java/com/example/sharemind/payment/presentation/PaymentController.java
+++ b/src/main/java/com/example/sharemind/payment/presentation/PaymentController.java
@@ -15,10 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -53,5 +50,31 @@ public class PaymentController {
                                                                                   @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(paymentService.getPaymentsByCustomer(paymentId, status,
                 customUserDetails.getCustomer().getCustomerId()));
+    }
+
+    @Operation(summary = "구매자 상담 취소 신청", description = "구매자가 상담 대기인 결제 내역 중 상담 취소 신청")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "취소 성공"),
+            @ApiResponse(responseCode = "400", description = "결제 완료 상태가 아닌 결제에 대한 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "취소 권한이 없는 결제에 대한 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 결제 정보",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "paymentId", description = "취소할 결제 정보 아이디")
+    })
+    @PatchMapping("/customers/{paymentId}")
+    public ResponseEntity<Void> updateRefundWaitingByCustomer(@PathVariable Long paymentId,
+                                                              @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        paymentService.updateRefundWaitingByCustomer(paymentId, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/payment/presentation/PaymentController.java
+++ b/src/main/java/com/example/sharemind/payment/presentation/PaymentController.java
@@ -1,0 +1,57 @@
+package com.example.sharemind.payment.presentation;
+
+import com.example.sharemind.global.exception.CustomExceptionResponse;
+import com.example.sharemind.global.jwt.CustomUserDetails;
+import com.example.sharemind.payment.application.PaymentService;
+import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Payment Controller", description = "구매자 결제 내역/판매자 수익 관리 컨트롤러")
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @Operation(summary = "구매자 결제 내역 조회", description = "- 구매자 결제 내역 조회\n " +
+            "- 주소 형식: /api/v1/payments/customers?status=payment_complete&paymentId=0")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공(없으면 빈 배열 반환)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 status",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "status",
+                    description = "PAYMENT_COMPLETE(결제 완료), REFUND_WAITING(환불 예정), REFUND_COMPLETE(환불 완료)"),
+            @Parameter(name = "paymentId", description = """
+                    - 조회 결과는 4개씩 반환하며, paymentId로 구분
+                    1. 최초 조회 요청이면 paymentId는 0
+                    2. 2번째 요청부터 paymentId는 직전 요청의 조회 결과 4개 중 마지막 paymentId""")
+    })
+    @GetMapping("/customers")
+    public ResponseEntity<List<PaymentGetCustomerResponse>> getPaymentsByCustomer(@RequestParam String status,
+                                                                                  @RequestParam Long paymentId,
+                                                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(paymentService.getPaymentsByCustomer(paymentId, status,
+                customUserDetails.getCustomer().getCustomerId()));
+    }
+}

--- a/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
@@ -10,9 +10,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByPaymentIdAndIsActivatedIsTrue(Long paymentId);
 
     @Query("SELECT p FROM Payment p JOIN FETCH p.consult c " +
             "WHERE c.customer = :customer AND p.customerStatus = :status AND p.isActivated = true " +

--- a/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
@@ -1,0 +1,26 @@
+package com.example.sharemind.payment.repository;
+
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.payment.content.PaymentCustomerStatus;
+import com.example.sharemind.payment.domain.Payment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    @Query("SELECT p FROM Payment p JOIN FETCH p.consult c " +
+            "WHERE c.customer = :customer AND p.customerStatus = :status AND p.isActivated = true " +
+            "ORDER BY p.paymentId DESC")
+    Page<Payment> findAllByCustomerAndCustomerStatusAndIsActivatedIsTrue(
+            Customer customer, PaymentCustomerStatus status, Pageable pageable);
+
+    @Query("SELECT p FROM Payment p JOIN FETCH p.consult c " +
+            "WHERE p.paymentId < :paymentId AND c.customer = :customer AND p.customerStatus = :status AND p.isActivated = true " +
+            "ORDER BY p.paymentId DESC")
+    Page<Payment> findAllByPaymentIdLessThanAndCustomerAndCustomerStatusAndIsActivatedIsTrue(
+            Long paymentId, Customer customer, PaymentCustomerStatus status, Pageable pageable);
+}

--- a/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
@@ -23,4 +25,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
             "ORDER BY p.paymentId DESC")
     Page<Payment> findAllByPaymentIdLessThanAndCustomerAndCustomerStatusAndIsActivatedIsTrue(
             Long paymentId, Customer customer, PaymentCustomerStatus status, Pageable pageable);
+
+    List<Payment> findAllByCustomerStatusAndIsActivatedIsTrue(PaymentCustomerStatus status);
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewService.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewService.java
@@ -9,11 +9,11 @@ import java.util.List;
 public interface ReviewService {
     void saveReview(ReviewSaveRequest reviewSaveRequest, Long customerId);
 
-    List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, Long cursorId, Long customerId);
+    List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, Long reviewId, Long customerId);
 
-    List<ReviewGetResponse> getReviewsByCounselor(Long cursorId, Long customerId);
+    List<ReviewGetResponse> getReviewsByCounselor(Long reviewId, Long customerId);
 
     List<ReviewGetShortResponse> getShortReviewsForCounselorHome(Long customerId);
 
-    List<ReviewGetShortResponse> getShortReviewsForCounselorProfile(Long cursorId, Long counselorId);
+    List<ReviewGetShortResponse> getShortReviewsForCounselorProfile(Long reviewId, Long counselorId);
 }

--- a/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/example/sharemind/review/application/ReviewServiceImpl.java
@@ -47,30 +47,30 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
-    public List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, Long cursorId, Long customerId) {
+    public List<ReviewGetResponse> getReviewsByCustomer(Boolean isCompleted, Long reviewId, Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
 
         Pageable pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, REVIEW_PAGE_SIZE);
         Page<ReviewGetResponse> page =
-                (cursorId == 0 ?
+                (reviewId == 0 ?
                         reviewRepository.findAllByCustomerAndIsCompleted(customer, isCompleted, pageable) :
                         reviewRepository.findAllByReviewIdLessThanAndCustomerAndIsCompleted(
-                                cursorId, customer, isCompleted, pageable))
+                                reviewId, customer, isCompleted, pageable))
                         .map(review -> ReviewGetResponse.of(review, IS_CUSTOMER));
 
         return page.getContent();
     }
 
     @Override
-    public List<ReviewGetResponse> getReviewsByCounselor(Long cursorId, Long customerId) {
+    public List<ReviewGetResponse> getReviewsByCounselor(Long reviewId, Long customerId) {
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
 
         Pageable pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, REVIEW_PAGE_SIZE);
         Page<ReviewGetResponse> page =
-                (cursorId == 0 ?
+                (reviewId == 0 ?
                         reviewRepository.findAllByCounselorAndIsCompletedIsTrue(counselor, pageable) :
                         reviewRepository.findAllByReviewIdLessThanAndCounselorAndIsCompletedIsTrue(
-                                cursorId, counselor, pageable))
+                                reviewId, counselor, pageable))
                         .map(review -> ReviewGetResponse.of(review, IS_COUNSELOR));
 
         return page.getContent();
@@ -86,15 +86,15 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
-    public List<ReviewGetShortResponse> getShortReviewsForCounselorProfile(Long cursorId, Long counselorId) {
+    public List<ReviewGetShortResponse> getShortReviewsForCounselorProfile(Long reviewId, Long counselorId) {
         Counselor counselor = counselorService.getCounselorByCounselorId(counselorId);
 
         Pageable pageable = PageRequest.of(DEFAULT_PAGE_NUMBER, REVIEW_PAGE_SIZE);
         Page<ReviewGetShortResponse> page =
-                (cursorId == 0 ?
+                (reviewId == 0 ?
                         reviewRepository.findAllByCounselorAndIsCompletedIsTrue(counselor, pageable) :
                         reviewRepository.findAllByReviewIdLessThanAndCounselorAndIsCompletedIsTrue(
-                                cursorId, counselor, pageable))
+                                reviewId, counselor, pageable))
                         .map(ReviewGetShortResponse::of);
 
         return page.getContent();

--- a/src/main/java/com/example/sharemind/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/example/sharemind/review/dto/response/ReviewGetResponse.java
@@ -37,7 +37,7 @@ public class ReviewGetResponse {
     private final String consultType;
 
     @Schema(description = "상담 날짜", example = "2024년 1월 12일", type = "string")
-    @JsonFormat(pattern = "yyyy년 MM월 dd일")
+    @JsonFormat(pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
     private final LocalDateTime consultedAt;
 
     @Schema(description = "상담료", example = "20000")
@@ -52,23 +52,17 @@ public class ReviewGetResponse {
     public static ReviewGetResponse of(Review review, Boolean isCustomer) {
         Consult consult = review.getConsult();
 
-        LocalDateTime consultedAt = null;
-        switch (consult.getConsultType()) {
-            case LETTER -> consultedAt = consult.getLetter().getCreatedAt();
-            case CHAT -> consultedAt = consult.getChat().getCreatedAt();
-        }
-
         if (isCustomer) {
             Counselor counselor = consult.getCounselor();
             return new ReviewGetResponse(review.getReviewId(), counselor.getNickname(),
                     counselor.getConsultStyle().getDisplayName(), counselor.getLevel(), counselor.getRatingAverage(),
-                    counselor.getTotalReview(), consult.getConsultType().getDisplayName(), consultedAt,
+                    counselor.getTotalReview(), consult.getConsultType().getDisplayName(), consult.getConsultedAt(),
                     consult.getCost(), review.getRating(), review.getComment());
         } else {
             String nickname = consult.getCustomer().getNickname().charAt(0) + "**";
             return new ReviewGetResponse(review.getReviewId(), nickname, null, null, null,
-                    null, consult.getConsultType().getDisplayName(), consultedAt, consult.getCost(),
-                    review.getRating(), review.getComment());
+                    null, consult.getConsultType().getDisplayName(), consult.getConsultedAt(),
+                    consult.getCost(), review.getRating(), review.getComment());
         }
     }
 }

--- a/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
+++ b/src/main/java/com/example/sharemind/review/presentation/ReviewController.java
@@ -57,7 +57,7 @@ public class ReviewController {
     }
 
     @Operation(summary = "구매자 리뷰 조회", description = "- 구매자 페이지 리뷰 관리 탭에서 리뷰 작성/남긴 리뷰에 해당하는 리뷰 리스트 조회\n " +
-            "- 주소 형식: /api/v1/reviews/customers?isCompleted=true&cursorId=0")
+            "- 주소 형식: /api/v1/reviews/customers?isCompleted=true&reviewId=0")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공(필요하지 않은 값은 null로 반환)"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
@@ -67,21 +67,21 @@ public class ReviewController {
     })
     @Parameters({
             @Parameter(name = "isCompleted", description = "조회하려는 리뷰가 작성 완료된 리뷰인지, 작성 전인 리뷰인지"),
-            @Parameter(name = "cursorId", description = """
-                    - 조회 결과는 3개씩 반환하며, cursorId로 구분
-                    1. 최초 조회 요청이면 cursorId는 0
-                    2. 2번째 요청부터 cursorId는 직전 요청의 조회 결과 3개 중 마지막 리뷰 아이디""")
+            @Parameter(name = "reviewId", description = """
+                    - 조회 결과는 3개씩 반환하며, reviewId로 구분
+                    1. 최초 조회 요청이면 reviewId는 0
+                    2. 2번째 요청부터 reviewId는 직전 요청의 조회 결과 3개 중 마지막 리뷰 아이디""")
     })
     @GetMapping("/customers")
     public ResponseEntity<List<ReviewGetResponse>> getReviewsByCustomer(@RequestParam Boolean isCompleted,
-                                                                        @RequestParam Long cursorId,
+                                                                        @RequestParam Long reviewId,
                                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.ok(reviewService.getReviewsByCustomer(isCompleted, cursorId,
+        return ResponseEntity.ok(reviewService.getReviewsByCustomer(isCompleted, reviewId,
                 customUserDetails.getCustomer().getCustomerId()));
     }
 
     @Operation(summary = "상담사 리뷰 조회", description = "- 상담사 페이지 받은 리뷰 탭에 해당하는 리뷰 리스트 조회\n " +
-            "- 주소 형식: /api/v1/reviews/counselors?cursorId=0")
+            "- 주소 형식: /api/v1/reviews/counselors?reviewId=0")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공(필요하지 않은 값은 null로 반환)"),
             @ApiResponse(responseCode = "403", description = "아직 프로필 심사가 완료되지 않은 상담사",
@@ -94,15 +94,15 @@ public class ReviewController {
             )
     })
     @Parameters({
-            @Parameter(name = "cursorId", description = """
-                    - 조회 결과는 3개씩 반환하며, cursorId로 구분
-                    1. 최초 조회 요청이면 cursorId는 0
-                    2. 2번째 요청부터 cursorId는 직전 요청의 조회 결과 3개 중 마지막 리뷰 아이디""")
+            @Parameter(name = "reviewId", description = """
+                    - 조회 결과는 3개씩 반환하며, reviewId로 구분
+                    1. 최초 조회 요청이면 reviewId는 0
+                    2. 2번째 요청부터 reviewId는 직전 요청의 조회 결과 3개 중 마지막 리뷰 아이디""")
     })
     @GetMapping("/counselors")
-    public ResponseEntity<List<ReviewGetResponse>> getReviewsByCounselor(@RequestParam Long cursorId,
+    public ResponseEntity<List<ReviewGetResponse>> getReviewsByCounselor(@RequestParam Long reviewId,
                                                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.ok(reviewService.getReviewsByCounselor(cursorId,
+        return ResponseEntity.ok(reviewService.getReviewsByCounselor(reviewId,
                 customUserDetails.getCustomer().getCustomerId()));
     }
 
@@ -126,7 +126,7 @@ public class ReviewController {
     }
 
     @Operation(summary = "상담사 프로필 후기 탭 리뷰 조회", description = "- 구매자 페이지 상담사 프로필 후기 탭에 해당하는 리뷰 리스트 조회\n " +
-            "- 주소 형식: /api/v1/reviews/{counselorId}?cursorId=0")
+            "- 주소 형식: /api/v1/reviews/{counselorId}?reviewId=0")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 상담사",
@@ -136,14 +136,14 @@ public class ReviewController {
     })
     @Parameters({
             @Parameter(name = "counselorId", description = "상담사 아이디"),
-            @Parameter(name = "cursorId", description = """
-                    - 조회 결과는 3개씩 반환하며, cursorId로 구분
-                    1. 최초 조회 요청이면 cursorId는 0
-                    2. 2번째 요청부터 cursorId는 직전 요청의 조회 결과 3개 중 마지막 리뷰 아이디""")
+            @Parameter(name = "reviewId", description = """
+                    - 조회 결과는 3개씩 반환하며, reviewId로 구분
+                    1. 최초 조회 요청이면 reviewId는 0
+                    2. 2번째 요청부터 reviewId는 직전 요청의 조회 결과 3개 중 마지막 리뷰 아이디""")
     })
     @GetMapping("/{counselorId}")
     public ResponseEntity<List<ReviewGetShortResponse>> getReviewsForCounselorProfile(@PathVariable Long counselorId,
-                                                                                      @RequestParam Long cursorId) {
-        return ResponseEntity.ok(reviewService.getShortReviewsForCounselorProfile(cursorId, counselorId));
+                                                                                      @RequestParam Long reviewId) {
+        return ResponseEntity.ok(reviewService.getShortReviewsForCounselorProfile(reviewId, counselorId));
     }
 }

--- a/src/main/java/com/example/sharemind/wishList/application/WishListCounselorService.java
+++ b/src/main/java/com/example/sharemind/wishList/application/WishListCounselorService.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.wishList.application;
 
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.wishList.domain.WishList;
@@ -52,5 +53,9 @@ public class WishListCounselorService {
                                 wishListGetRequest.getWishlistId(),
                                 pageable);
         return page.getContent();
+    }
+
+    public Boolean getIsWishListByCustomerAndCounselor(Customer customer, Counselor counselor) {
+        return wishListRepository.existsByCustomerAndCounselorAndIsActivatedIsTrue(customer, counselor);
     }
 }

--- a/src/main/java/com/example/sharemind/wishList/repository/WishListRepository.java
+++ b/src/main/java/com/example/sharemind/wishList/repository/WishListRepository.java
@@ -26,4 +26,6 @@ public interface WishListRepository extends JpaRepository<WishList, Long> {
                                                       Pageable pageable);
 
     Page<WishList> findByCustomerAndIsActivatedIsTrueOrderByUpdatedAtDesc(Customer customer, Pageable pageable);
+
+    Boolean existsByCustomerAndCounselorAndIsActivatedIsTrue(Customer customer, Counselor counselor);
 }


### PR DESCRIPTION
## 📄구현 내용
- 구매자 결제 내역 조회
  - PaymentCustomerStatus(결제 완료, 환불 예정, 환불 완료)에 알맞은 결과 반환
- 구매자 결제 내역 관련 어드민 기능
  - 환불 예정 결제 내역 조회
  - 환불 예정 결제를 환불 완료로 수정

## 📝기타 알림사항
- 리뷰 상담 날짜 consult의 consultedAt에서 가져오도록 수정
- 리뷰쪽 커서 페이지네이션에 쓰이는 아이디 워딩 수정(cursorId -> reviewId)
- 마인더 프로필 조회 시 찜 여부 포함해서 반환하도록 수정
- 어드민쪽은 처음부터 전체 리스트 반환으로 구현해둬서 이번에도 그냥 전체 리스트 반환하는 것으로 통일하였습니다. 나중에 리팩토링할 때 전체적으로 수정하면 좋을 것 같습니다~