### PR TITLE
feat: 일반적인 계정 설정 구현

### DIFF
--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -17,4 +17,6 @@ public interface AuthService {
     void updatePassword(AuthUpdatePasswordRequest authUpdatePasswordRequest, Long customerId);
 
     void quit(AuthQuitRequest authQuitRequest, Long customerId);
+
+    void signOut(AuthSignOutRequest authSignOutRequest);
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -15,4 +15,6 @@ public interface AuthService {
     Boolean getPasswordMatched(AuthGetPasswordMatchRequest authGetPasswordMatchRequest, Long customerId);
 
     void updatePassword(AuthUpdatePasswordRequest authUpdatePasswordRequest, Long customerId);
+
+    void quit(AuthQuitRequest authQuitRequest, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.auth.application;
 
+import com.example.sharemind.auth.dto.request.AuthGetPasswordMatchRequest;
 import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
@@ -13,4 +14,6 @@ public interface AuthService {
     TokenDto reissueToken(AuthReissueRequest authReissueRequest);
 
     void checkDuplicateEmail(String email);
+
+    Boolean getPasswordMatched(AuthGetPasswordMatchRequest authGetPasswordMatchRequest, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthService.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthService.java
@@ -1,9 +1,6 @@
 package com.example.sharemind.auth.application;
 
-import com.example.sharemind.auth.dto.request.AuthGetPasswordMatchRequest;
-import com.example.sharemind.auth.dto.request.AuthReissueRequest;
-import com.example.sharemind.auth.dto.request.AuthSignInRequest;
-import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import com.example.sharemind.auth.dto.request.*;
 import com.example.sharemind.auth.dto.response.TokenDto;
 
 public interface AuthService {
@@ -16,4 +13,6 @@ public interface AuthService {
     void checkDuplicateEmail(String email);
 
     Boolean getPasswordMatched(AuthGetPasswordMatchRequest authGetPasswordMatchRequest, Long customerId);
+
+    void updatePassword(AuthUpdatePasswordRequest authUpdatePasswordRequest, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -1,9 +1,6 @@
 package com.example.sharemind.auth.application;
 
-import com.example.sharemind.auth.dto.request.AuthGetPasswordMatchRequest;
-import com.example.sharemind.auth.dto.request.AuthReissueRequest;
-import com.example.sharemind.auth.dto.request.AuthSignInRequest;
-import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import com.example.sharemind.auth.dto.request.*;
 import com.example.sharemind.auth.dto.response.TokenDto;
 import com.example.sharemind.auth.exception.AuthErrorCode;
 import com.example.sharemind.auth.exception.AuthException;
@@ -81,5 +78,17 @@ public class AuthServiceImpl implements AuthService {
                 .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, customerId.toString()));
 
         return passwordEncoder.matches(authGetPasswordMatchRequest.getPassword(), customer.getPassword());
+    }
+
+    @Transactional
+    @Override
+    public void updatePassword(AuthUpdatePasswordRequest authUpdatePasswordRequest, Long customerId) {
+        Customer customer = customerRepository.findByCustomerIdAndIsActivatedIsTrue(customerId)
+                .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, customerId.toString()));
+        if (passwordEncoder.matches(authUpdatePasswordRequest.getPassword(), customer.getPassword())) {
+            throw new AuthException(AuthErrorCode.DUPLICATE_PASSWORD);
+        }
+
+        customer.updatePassword(passwordEncoder.encode(authUpdatePasswordRequest.getPassword()));
     }
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.auth.application;
 
+import com.example.sharemind.auth.dto.request.AuthGetPasswordMatchRequest;
 import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
@@ -28,7 +29,6 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     @Override
     public void signUp(AuthSignUpRequest authSignUpRequest) {
-
         if (customerRepository.existsByEmailAndIsActivatedIsTrue(authSignUpRequest.getEmail())) {
             throw new AuthException(AuthErrorCode.EMAIL_ALREADY_EXIST, authSignUpRequest.getEmail());
         }
@@ -39,7 +39,6 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public TokenDto signIn(AuthSignInRequest authSignInRequest) {
-
         Customer customer = customerRepository.findByEmailAndIsActivatedIsTrue(authSignInRequest.getEmail())
                 .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, authSignInRequest.getEmail()));
 
@@ -55,7 +54,6 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public TokenDto reissueToken(AuthReissueRequest authReissueRequest) {
-
         if(!tokenProvider.validateRefreshToken(authReissueRequest.getRefreshToken())) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
@@ -75,5 +73,13 @@ public class AuthServiceImpl implements AuthService {
         if (customerRepository.existsByEmailAndIsActivatedIsTrue(email)) {
             throw new AuthException(AuthErrorCode.EMAIL_ALREADY_EXIST, email);
         }
+    }
+
+    @Override
+    public Boolean getPasswordMatched(AuthGetPasswordMatchRequest authGetPasswordMatchRequest, Long customerId) {
+        Customer customer = customerRepository.findByCustomerIdAndIsActivatedIsTrue(customerId)
+                .orElseThrow(() -> new CustomerException(CustomerErrorCode.CUSTOMER_NOT_FOUND, customerId.toString()));
+
+        return passwordEncoder.matches(authGetPasswordMatchRequest.getPassword(), customer.getPassword());
     }
 }

--- a/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/example/sharemind/auth/application/AuthServiceImpl.java
@@ -130,6 +130,8 @@ public class AuthServiceImpl implements AuthService {
         Quit quit = quitRepository.save(authQuitRequest.toEntity());
         customer.setQuit(quit);
         customer.updateIsActivatedFalse();
+
+        signOut(AuthSignOutRequest.of(authQuitRequest.getAccessToken(), authQuitRequest.getRefreshToken()));
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthGetPasswordMatchRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthGetPasswordMatchRequest.java
@@ -1,0 +1,13 @@
+package com.example.sharemind.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AuthGetPasswordMatchRequest {
+
+    @Schema(description = "현재 비밀번호")
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    private String password;
+}

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthQuitRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthQuitRequest.java
@@ -17,6 +17,14 @@ public class AuthQuitRequest {
     @Size(max = 100, message = "선택사항은 최대 100자입니다.")
     private String longReason;
 
+    @Schema(description = "accessToken", example = "Bearer aasldkgjsalaksdjghlasdkjghslgjk")
+    @NotBlank(message = "accessToken은 공백일 수 없습니다.")
+    private String accessToken;
+
+    @Schema(description = "refreshToken", example = "lakjsdlhsakjghslgkjdhslgkjdshaglk")
+    @NotBlank(message = "refreshToken은 공백일 수 없습니다.")
+    private String refreshToken;
+
     public Quit toEntity() {
         return Quit.builder()
                 .shortReason(shortReason)

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthQuitRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthQuitRequest.java
@@ -1,0 +1,26 @@
+package com.example.sharemind.auth.dto.request;
+
+import com.example.sharemind.customer.domain.Quit;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class AuthQuitRequest {
+
+    @Schema(description = "탈퇴 사유", example = "사용을 잘 안 하게 돼요")
+    @NotBlank(message = "탈퇴 사유는 공백일 수 없습니다.")
+    private String shortReason;
+
+    @Schema(description = "선택사항", example = "상담사가 너무 재수없어서 안 쓰고 싶어요")
+    @Size(max = 100, message = "선택사항은 최대 100자입니다.")
+    private String longReason;
+
+    public Quit toEntity() {
+        return Quit.builder()
+                .shortReason(shortReason)
+                .longReason(longReason)
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignOutRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignOutRequest.java
@@ -2,9 +2,11 @@ package com.example.sharemind.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class AuthSignOutRequest {
 
     @Schema(description = "accessToken", example = "Bearer aasldkgjsalaksdjghlasdkjghslgjk")
@@ -14,4 +16,8 @@ public class AuthSignOutRequest {
     @Schema(description = "refreshToken", example = "lakjsdlhsakjghslgkjdhslgkjdshaglk")
     @NotBlank(message = "refreshToken은 공백일 수 없습니다.")
     private String refreshToken;
+
+    public static AuthSignOutRequest of(String accessToken, String refreshToken) {
+        return new AuthSignOutRequest(accessToken, refreshToken);
+    }
 }

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthSignOutRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthSignOutRequest.java
@@ -1,0 +1,17 @@
+package com.example.sharemind.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AuthSignOutRequest {
+
+    @Schema(description = "accessToken", example = "Bearer aasldkgjsalaksdjghlasdkjghslgjk")
+    @NotBlank(message = "accessToken은 공백일 수 없습니다.")
+    private String accessToken;
+
+    @Schema(description = "refreshToken", example = "lakjsdlhsakjghslgkjdhslgkjdshaglk")
+    @NotBlank(message = "refreshToken은 공백일 수 없습니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/example/sharemind/auth/dto/request/AuthUpdatePasswordRequest.java
+++ b/src/main/java/com/example/sharemind/auth/dto/request/AuthUpdatePasswordRequest.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class AuthUpdatePasswordRequest {
+
+    @Schema(description = "새 비밀번호")
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    @Pattern(regexp = "^(?!((?:[A-Za-z]+)|(?:[~!@#$%^&*()_+=]+)|(?:[0-9]+))$)[A-Za-z\\d~!@#$%^&*()_+=]{10,}$",
+            message = "비밀번호는 영문, 숫자, 특수문자 중 2가지 이상을 조합한 10자리 이상의 문자열이어야 합니다.")
+    private String password;
+}

--- a/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
@@ -9,6 +9,7 @@ public enum AuthErrorCode {
     EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 회원으로 등록된 이메일입니다."),
     INVALID_RECOVERY_EMAIL(HttpStatus.BAD_REQUEST, "로그인 이메일과 동일한 이메일은 복구 이메일로 사용할 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    DUPLICATE_PASSWORD(HttpStatus.BAD_REQUEST, "새 비밀번호가 현재 비밀번호와 동일합니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "access token이 이미 만료되었거나 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 이미 만료되었거나 올바르지 않습니다.");
 

--- a/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/sharemind/auth/exception/AuthErrorCode.java
@@ -10,6 +10,8 @@ public enum AuthErrorCode {
     INVALID_RECOVERY_EMAIL(HttpStatus.BAD_REQUEST, "로그인 이메일과 동일한 이메일은 복구 이메일로 사용할 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     DUPLICATE_PASSWORD(HttpStatus.BAD_REQUEST, "새 비밀번호가 현재 비밀번호와 동일합니다."),
+    INVALID_QUIT_CONSULT(HttpStatus.BAD_REQUEST, "미완료 상담이 있어 탈퇴할 수 없습니다."),
+    INVALID_QUIT_PAYMENT(HttpStatus.BAD_REQUEST, "처리되지 않은 환불금 또는 정산금이 있어 탈퇴할 수 없습니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "access token이 이미 만료되었거나 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh token이 이미 만료되었거나 올바르지 않습니다.");
 

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -106,4 +106,21 @@ public class AuthController {
         authService.updatePassword(authUpdatePasswordRequest, customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "회원 탈퇴",
+            description = "회원 탈퇴")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @ApiResponse(responseCode = "400",
+                    description = "1. 미완료 상담이 남아있음\n 2. 환불금/정산금 남아있음\n 3. 탈퇴 사유(shortReason) 공백으로 들어옴",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @PatchMapping("/quit")
+    public ResponseEntity<Void> quit(@Valid @RequestBody AuthQuitRequest authQuitRequest,
+                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        authService.quit(authQuitRequest, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -1,10 +1,7 @@
 package com.example.sharemind.auth.presentation;
 
 import com.example.sharemind.auth.application.AuthService;
-import com.example.sharemind.auth.dto.request.AuthGetPasswordMatchRequest;
-import com.example.sharemind.auth.dto.request.AuthReissueRequest;
-import com.example.sharemind.auth.dto.request.AuthSignInRequest;
-import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
+import com.example.sharemind.auth.dto.request.*;
 import com.example.sharemind.auth.dto.response.TokenDto;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
@@ -92,5 +89,21 @@ public class AuthController {
                                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(authService.getPasswordMatched(authGetPasswordMatchRequest,
                 customUserDetails.getCustomer().getCustomerId()));
+    }
+
+    @Operation(summary = "비밀번호 변경",
+            description = "비밀번호 변경")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 올바르지 않은 비밀번호 형식\n 2. 새 비밀번호가 현재 비밀번호와 동일",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @PatchMapping("/password")
+    public ResponseEntity<Void> updatePassword(@Valid @RequestBody AuthUpdatePasswordRequest authUpdatePasswordRequest,
+                                               @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        authService.updatePassword(authUpdatePasswordRequest, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -123,4 +123,15 @@ public class AuthController {
         authService.quit(authQuitRequest, customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "로그아웃",
+            description = "로그아웃")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    })
+    @PatchMapping("/signOut")
+    public ResponseEntity<Void> singOut(@Valid @RequestBody AuthSignOutRequest authSignOutRequest) {
+        authService.signOut(authSignOutRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -1,11 +1,13 @@
 package com.example.sharemind.auth.presentation;
 
 import com.example.sharemind.auth.application.AuthService;
+import com.example.sharemind.auth.dto.request.AuthGetPasswordMatchRequest;
 import com.example.sharemind.auth.dto.request.AuthReissueRequest;
 import com.example.sharemind.auth.dto.request.AuthSignInRequest;
 import com.example.sharemind.auth.dto.request.AuthSignUpRequest;
 import com.example.sharemind.auth.dto.response.TokenDto;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
+import com.example.sharemind.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,10 +18,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth Controller", description = "인증 컨트롤러")
 @RestController
@@ -76,5 +76,21 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity<TokenDto> reissueToken(@Valid @RequestBody AuthReissueRequest authReissueRequest) {
         return ResponseEntity.ok(authService.reissueToken(authReissueRequest));
+    }
+
+    @Operation(summary = "비밀번호 변경 시 현재 비밀번호 일치 여부 조회",
+            description = "비밀번호 변경 시 현재 비밀번호 일치 여부 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "비밀번호 값이 공백으로 들어옴",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @PostMapping("/password")
+    public ResponseEntity<Boolean> getPasswordMatched(@Valid @RequestBody AuthGetPasswordMatchRequest authGetPasswordMatchRequest,
+                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(authService.getPasswordMatched(authGetPasswordMatchRequest,
+                customUserDetails.getCustomer().getCustomerId()));
     }
 }

--- a/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sharemind/auth/presentation/AuthController.java
@@ -117,7 +117,7 @@ public class AuthController {
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             )
     })
-    @PatchMapping("/quit")
+    @DeleteMapping("/quit")
     public ResponseEntity<Void> quit(@Valid @RequestBody AuthQuitRequest authQuitRequest,
                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         authService.quit(authQuitRequest, customUserDetails.getCustomer().getCustomerId());

--- a/src/main/java/com/example/sharemind/auth/repository/TokenRepository.java
+++ b/src/main/java/com/example/sharemind/auth/repository/TokenRepository.java
@@ -7,11 +7,11 @@ import org.springframework.stereotype.Repository;
 import java.time.Duration;
 
 @Repository
-public class RefreshTokenRepository {
+public class TokenRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public RefreshTokenRepository(RedisTemplate<String, String> redisTemplate) {
+    public TokenRepository(RedisTemplate<String, String> redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 

--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -3,6 +3,8 @@ package com.example.sharemind.consult.application;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
 
 import java.util.List;
@@ -19,4 +21,8 @@ public interface ConsultService {
     List<Consult> getConsultsByCounselorIdAndConsultTypeAndIsPaid(Long counselorId, ConsultType consultType);
 
     Consult getConsultByChat(Chat chat);
+
+    Boolean checkWaitingOrOngoingExistsByCustomer(Customer customer);
+
+    Boolean checkWaitingOrOngoingExistsByCounselor(Counselor counselor);
 }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -80,4 +80,14 @@ public class ConsultServiceImpl implements ConsultService {
         return consultRepository.findByChatAndIsActivatedIsTrue(chat).orElseThrow(
                 () -> new ConsultException(ConsultErrorCode.CONSULT_NOT_FOUND, "chatId : " + chat.getChatId()));
     }
+
+    @Override
+    public Boolean checkWaitingOrOngoingExistsByCustomer(Customer customer) {
+        return consultRepository.findTopByConsultStatusIsWaitingOrOngoingAndCustomerAndIsPaid(customer) != null;
+    }
+
+    @Override
+    public Boolean checkWaitingOrOngoingExistsByCounselor(Counselor counselor) {
+        return consultRepository.findTopByConsultStatusIsWaitingOrOngoingAndCounselorAndIsPaid(counselor) != null;
+    }
 }

--- a/src/main/java/com/example/sharemind/consult/content/RefundStatus.java
+++ b/src/main/java/com/example/sharemind/consult/content/RefundStatus.java
@@ -1,7 +1,0 @@
-package com.example.sharemind.consult.content;
-
-public enum RefundStatus {
-    NO_REFUND,
-    CONSULT_CANCEL,
-    COUNSELOR_CANCEL,
-}

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -84,6 +84,7 @@ public class Consult extends BaseEntity {
         setReview();
 
         this.counselor.increaseTotalConsult();
+        this.payment.updateCounselorStatusConsultFinish();
     }
 
     public void updateConsultStatusCounselorCancel() {

--- a/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
+++ b/src/main/java/com/example/sharemind/consult/repository/ConsultRepository.java
@@ -2,6 +2,8 @@ package com.example.sharemind.consult.repository;
 
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -36,4 +38,14 @@ public interface ConsultRepository extends JpaRepository<Consult, Long> {
     List<Consult> findByCounselorIdAndConsultTypeAndIsPaid(Long counselorId, ConsultType consultType);
 
     Optional<Consult> findByChatAndIsActivatedIsTrue(Chat chat);
+
+    @Query("SELECT c FROM Consult c JOIN FETCH c.payment p " +
+            "WHERE (c.consultStatus = 'WAITING' OR c.consultStatus = 'ONGOING') AND c.customer = :customer AND " +
+            "p.isPaid = true AND c.isActivated = true")
+    Consult findTopByConsultStatusIsWaitingOrOngoingAndCustomerAndIsPaid(Customer customer);
+
+    @Query("SELECT c FROM Consult c JOIN FETCH c.payment p " +
+            "WHERE (c.consultStatus = 'WAITING' OR c.consultStatus = 'ONGOING') AND c.counselor = :counselor AND " +
+            "p.isPaid = true AND c.isActivated = true")
+    Consult findTopByConsultStatusIsWaitingOrOngoingAndCounselorAndIsPaid(Counselor counselor);
 }

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -75,6 +75,10 @@ public class Customer extends BaseEntity {
         }};
     }
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
     public void setCounselor(Counselor counselor) {
         this.counselor = counselor;
     }

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -5,7 +5,6 @@ import com.example.sharemind.auth.exception.AuthException;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.content.Role;
 import com.example.sharemind.global.common.BaseEntity;
-import com.example.sharemind.global.content.Bank;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
@@ -42,23 +41,17 @@ public class Customer extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(name = "optional_agreement")
-    private Boolean optionalAgreement;
-
-    private String account;
-
-    private Bank bank;
-
-    @Column(name = "account_holder")
-    private String accountHolder;
-
     @Email(message = "복구 이메일 형식이 올바르지 않습니다.")
     @Column(name = "recovery_email", nullable = false)
     private String recoveryEmail;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "counselor_id", unique = true)
     private Counselor counselor;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quit_id", unique = true)
+    private Quit quit;
 
     @Builder
     public Customer(String email, String password, String phoneNumber, String recoveryEmail) {
@@ -81,6 +74,10 @@ public class Customer extends BaseEntity {
 
     public void setCounselor(Counselor counselor) {
         this.counselor = counselor;
+    }
+
+    public void setQuit(Quit quit) {
+        this.quit = quit;
     }
 
     public void addRole(Role role) {

--- a/src/main/java/com/example/sharemind/customer/domain/Quit.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Quit.java
@@ -1,0 +1,33 @@
+package com.example.sharemind.customer.domain;
+
+import com.example.sharemind.global.common.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Quit extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "quit_id")
+    private Long quitId;
+
+    @Column(name = "short_reason", nullable = false)
+    private String shortReason;
+
+    @Size(max = 100, message = "선택사항은 최대 100자입니다.")
+    @Column(name = "long_reason")
+    private String longReason;
+
+    @Builder
+    public Quit(String shortReason, String longReason) {
+        this.shortReason = shortReason;
+        this.longReason = longReason;
+    }
+}

--- a/src/main/java/com/example/sharemind/customer/repository/QuitRepository.java
+++ b/src/main/java/com/example/sharemind/customer/repository/QuitRepository.java
@@ -1,0 +1,9 @@
+package com.example.sharemind.customer.repository;
+
+import com.example.sharemind.customer.domain.Quit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuitRepository extends JpaRepository<Quit, Long> {
+}

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -47,13 +47,14 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(HttpBasicConfigurer::disable)
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(
+                .authorizeHttpRequests( // TODO 여기 더 나은 방법이 있을 것 같은데 일단 동작은 하니까 두고 추후에 리팩토링...ㅠㅠ
                         requests -> requests.requestMatchers("/error", "/swagger-ui/**", "/api-docs/**",
-                                        "/api/v1/auth/**", "/api/v1/emails/**").permitAll()
-                                .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
-                                .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
+                                        "/api/v1/auth/signUp", "/api/v1/auth/signIn", "/api/v1/auth/reissue",
+                                        "/api/v1/emails/**").permitAll()
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()
+                                .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
+                                .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/api/v1/chats/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/chatMessages/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
+++ b/src/main/java/com/example/sharemind/global/jwt/TokenProvider.java
@@ -26,7 +26,7 @@ public class TokenProvider implements InitializingBean {
 
     private final CustomUserDetailsService customUserDetailsService;
 
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenRepository tokenRepository;
 
     private final String secret;
     private final Long accessExpirationTime;
@@ -34,12 +34,12 @@ public class TokenProvider implements InitializingBean {
     private Key key;
 
     public TokenProvider(CustomUserDetailsService customUserDetailsService,
-                         RefreshTokenRepository refreshTokenRepository,
+                         TokenRepository tokenRepository,
                          @Value("${jwt.secret}") String secret,
                          @Value("${jwt.access-expiration-time}") Long accessExpirationTime,
                          @Value("${jwt.refresh-expiration-time}") Long refreshExpirationTime) {
         this.customUserDetailsService = customUserDetailsService;
-        this.refreshTokenRepository = refreshTokenRepository;
+        this.tokenRepository = tokenRepository;
         this.secret = secret;
         this.accessExpirationTime = accessExpirationTime;
         this.refreshExpirationTime = refreshExpirationTime;
@@ -86,7 +86,7 @@ public class TokenProvider implements InitializingBean {
                 .compact();
 
         Duration duration = Duration.between(Instant.now(), expirationTime.toInstant());
-        refreshTokenRepository.save(email, refreshToken, duration);
+        tokenRepository.save(email, refreshToken, duration);
 
         return refreshToken;
     }
@@ -121,7 +121,7 @@ public class TokenProvider implements InitializingBean {
             Claims claims = parseClaims(refreshToken);
 
             String email = claims.getSubject();
-            String savedRefreshToken = refreshTokenRepository.findByKey(email);
+            String savedRefreshToken = tokenRepository.findByKey(email);
 
             return refreshToken.equals(savedRefreshToken);
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {

--- a/src/main/java/com/example/sharemind/payment/application/PaymentService.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentService.java
@@ -1,5 +1,7 @@
 package com.example.sharemind.payment.application;
 
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 
@@ -13,4 +15,8 @@ public interface PaymentService {
     void updateRefundWaitingByCustomer(Long paymentId, Long customerId);
 
     List<Payment> getRefundWaitingPayments();
+
+    Boolean checkRefundWaitingExists(Customer customer);
+
+    Boolean checkNotSettlementCompleteAndNotNoneExists(Counselor counselor);
 }

--- a/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.payment.application;
 
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.content.PaymentCustomerStatus;
@@ -66,5 +67,17 @@ public class PaymentServiceImpl implements PaymentService {
     @Override
     public List<Payment> getRefundWaitingPayments() {
         return paymentRepository.findAllByCustomerStatusAndIsActivatedIsTrue(PaymentCustomerStatus.REFUND_WAITING);
+    }
+
+    @Override
+    public Boolean checkRefundWaitingExists(Customer customer) {
+        return paymentRepository.existsByConsultCustomerAndCustomerStatusAndIsActivatedIsTrue(customer,
+                PaymentCustomerStatus.REFUND_WAITING);
+    }
+
+    @Override
+    public Boolean checkNotSettlementCompleteAndNotNoneExists(Counselor counselor) {
+        return paymentRepository.findTopByConsultCounselorAndCounselorStatusIsNotNoneAndFinishAndIsActivatedIsTrue(
+                counselor) != null;
     }
 }

--- a/src/main/java/com/example/sharemind/payment/content/PaymentCounselorStatus.java
+++ b/src/main/java/com/example/sharemind/payment/content/PaymentCounselorStatus.java
@@ -1,7 +1,9 @@
 package com.example.sharemind.payment.content;
 
 public enum PaymentCounselorStatus {
-    COMPLETE,
-    ONGOING,
-    WAITING
+    NONE,
+    CONSULT_FINISH,
+    SETTLEMENT_WAITING,
+    SETTLEMENT_ONGOING,
+    SETTLEMENT_COMPLETE
 }

--- a/src/main/java/com/example/sharemind/payment/content/PaymentCustomerStatus.java
+++ b/src/main/java/com/example/sharemind/payment/content/PaymentCustomerStatus.java
@@ -6,6 +6,7 @@ import com.example.sharemind.payment.exception.PaymentException;
 import java.util.Arrays;
 
 public enum PaymentCustomerStatus {
+    NONE,
     PAYMENT_COMPLETE,
     REFUND_WAITING,
     REFUND_COMPLETE;

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -31,11 +31,11 @@ public class Payment extends BaseEntity {
     @Column(name = "is_paid", nullable = false)
     private Boolean isPaid;
 
-    @Column(name = "payment_counselor_status")
+    @Column(name = "payment_counselor_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private PaymentCounselorStatus counselorStatus;
 
-    @Column(name = "payment_customer_status")
+    @Column(name = "payment_customer_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private PaymentCustomerStatus customerStatus;
 
@@ -50,11 +50,17 @@ public class Payment extends BaseEntity {
         this.consult = consult;
         this.method = "외부 결제";
         this.isPaid = false;
+        updateBothStatusNone();
     }
 
     public void updateIsPaidTrue() {
         this.isPaid = true;
         updateCustomerStatusPaymentComplete();
+    }
+
+    public void updateBothStatusNone() {
+        this.customerStatus = PaymentCustomerStatus.NONE;
+        this.counselorStatus = PaymentCounselorStatus.NONE;
     }
 
     public void updateCustomerStatusPaymentComplete() {
@@ -70,6 +76,10 @@ public class Payment extends BaseEntity {
 
     public void updateCustomerStatusRefundComplete() {
         this.customerStatus = PaymentCustomerStatus.REFUND_COMPLETE;
+    }
+
+    public void updateCounselorStatusConsultFinish() {
+        this.counselorStatus = PaymentCounselorStatus.CONSULT_FINISH;
     }
 
     public void checkUpdateAuthority(Long customerId) {

--- a/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/sharemind/payment/repository/PaymentRepository.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.payment.repository;
 
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.content.PaymentCustomerStatus;
 import com.example.sharemind.payment.domain.Payment;
@@ -29,4 +30,12 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
             Long paymentId, Customer customer, PaymentCustomerStatus status, Pageable pageable);
 
     List<Payment> findAllByCustomerStatusAndIsActivatedIsTrue(PaymentCustomerStatus status);
+
+    Boolean existsByConsultCustomerAndCustomerStatusAndIsActivatedIsTrue(Customer customer,
+                                                                  PaymentCustomerStatus status);
+
+    @Query("SELECT p FROM Payment p JOIN FETCH p.consult c " +
+            "WHERE (p.counselorStatus != 'NONE' AND p.counselorStatus != 'FINISH') AND c.counselor = :counselor AND " +
+            "p.isActivated = true")
+    Payment findTopByConsultCounselorAndCounselorStatusIsNotNoneAndFinishAndIsActivatedIsTrue(Counselor counselor);
 }


### PR DESCRIPTION
## 📄구현 내용
- 비밀번호 변경
- 회원 탈퇴
  - 처리되지 않은 환불금/정산금을 확인하는 로직에서 PaymentCounselorStatus, PaymentCustomerStatus 값을 검사합니다. 기존 Status들의 경우 nullable true로 두어 초기값이 null이었는데, 이렇게 두면 값 검사하기가 어려운 부분이 있어 둘다 nullable false로 변경 및 None을 추가해두었고, CounselorStatus에는 Consult_Finish도 추가하였습니다.
    - 결제 내역/수익 관리 페이지에 노출되지 않는 시점에 있는 Payment는 None으로 설정
    - 상담 종료 시 7일 후 수익 관리 페이지-정산 예정 탭에 노출되므로 상담 종료 직후~7일까지의 Payment는 Consult_Finish로 설정
- 로그아웃

## 📝기타 알림사항
