### PR TITLE
feat: 편지 상담 상대방 닉네임 조회 구현

### DIFF
--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -184,7 +184,7 @@ public class CounselorController {
     @Operation(summary = "상담사 리스트 반환",
             description = """
                     - 카테고리 선택 || 들을 준비가 된 마인더들 페이지 상담사 리스트 반환
-                     - 주소 형식: /api/v1/counselors?sortType=POPULARITY
+                     - 주소 형식: /api/v1/counselors/all?sortType=POPULARITY
                      - 결과는 4개씩 반환하며, index는 페이지 번호 입니다(ex index 0 : id 0~3에 해당하는 값 반환 index 1: 4~7에 해당하는 값 반환)
                     - 해당하는 검색 결과가 없을 때(범위를 벗어난 인덱스 혹은 음수 인덱스)는 빈배열을 리턴합니다.
                     - 들을 준비가 된 마인더들(상담사 전체 리스트)조회의 경우, RequestBody에서 consultCategory를 빼고 넘겨주시면 됩니다.""")
@@ -196,7 +196,7 @@ public class CounselorController {
             )
     })
     @Parameter(name = "sortType", description = "LATEST: 최근순, POPULARITY: 인기순, STAR_RATING: 별점 평균 순")
-    @PatchMapping()
+    @PatchMapping("/all")
     public ResponseEntity<List<CounselorGetListResponse>> getCounselorsByCategory(
             @Valid @RequestBody CounselorGetRequest counselorGetRequest,
             @RequestParam String sortType,
@@ -220,7 +220,7 @@ public class CounselorController {
     @Parameters({
             @Parameter(name = "counselorId", description = "상담사 아이디")
     })
-    @GetMapping("/{counselorId}")
+    @GetMapping("/all/{counselorId}")
     public ResponseEntity<CounselorGetMinderProfileResponse> getCounselorMinderProfile(@PathVariable Long counselorId,
                                                                                        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(counselorService.getCounselorMinderProfile(counselorId, customUserDetails.getCustomer().getCustomerId()));

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -50,10 +50,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         requests -> requests.requestMatchers("/error", "/swagger-ui/**", "/api-docs/**",
                                         "/api/v1/auth/**", "/api/v1/emails/**").permitAll()
-                                .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
-                                .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
+                                .requestMatchers("/api/v1/counselors/all**", "/api/v1/searchWords/results**").permitAll()
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()
+                                .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
+                                .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/chats/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/chatMessages/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .anyRequest().authenticated()

--- a/src/main/java/com/example/sharemind/letter/application/LetterService.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterService.java
@@ -22,4 +22,6 @@ public interface LetterService {
     LetterGetDeadlineResponse getDeadline(Long letterId);
 
     List<ChatLetterGetResponse> getLetters(Boolean filter, Boolean isCustomer, String sortType, Long customerId);
+
+    String getOpponentNickname(Long letterId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterServiceImpl.java
@@ -158,6 +158,19 @@ public class LetterServiceImpl implements LetterService {
                 .toList();
     }
 
+    @Override
+    public String getOpponentNickname(Long letterId, Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+        Consult consult = getLetterByLetterId(letterId).getConsult();
+        if (consult.getCustomer().equals(customer)) {
+            return consult.getCounselor().getNickname();
+        } else if (consult.getCounselor().equals(customer.getCounselor())) {
+            return consult.getCustomer().getNickname();
+        } else {
+            throw new LetterException(LetterErrorCode.INVALID_LETTER_PARTICIPANT, customerId.toString());
+        }
+    }
+
     @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
     @Transactional
     public void checkLettersDeadline() {

--- a/src/main/java/com/example/sharemind/letter/exception/LetterErrorCode.java
+++ b/src/main/java/com/example/sharemind/letter/exception/LetterErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum LetterErrorCode {
 
     LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "편지(비실시간 상담) 정보가 존재하지 않습니다."),
+    INVALID_LETTER_PARTICIPANT(HttpStatus.FORBIDDEN, "편지의 참여자가 아닙니다."),
     CONSULT_CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "상담사가 제공하지 않은 상담 카테고리입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
+++ b/src/main/java/com/example/sharemind/letter/presentation/LetterController.java
@@ -142,4 +142,27 @@ public class LetterController {
     public ResponseEntity<LetterGetDeadlineResponse> getDeadline(@PathVariable Long letterId) {
         return ResponseEntity.ok(letterService.getDeadline(letterId));
     }
+
+    @Operation(summary = "편지 상대방 닉네임 조회",
+            description = "편지 상대방 닉네임 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "편지 참여자가 아님",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 편지 아이디로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "letterId", description = "편지 아이디")
+    })
+    @GetMapping("/nickname/{letterId}")
+    public ResponseEntity<String> getOpponentNickname(@PathVariable Long letterId,
+                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(letterService.getOpponentNickname(letterId,
+                customUserDetails.getCustomer().getCustomerId()));
+    }
 }

--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.sharemind.letterMessage.application;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.letter.application.LetterService;
+import com.example.sharemind.letter.content.LetterStatus;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.letterMessage.content.LetterMessageType;
 import com.example.sharemind.letterMessage.domain.LetterMessage;
@@ -139,6 +140,9 @@ public class LetterMessageServiceImpl implements LetterMessageService {
             case 4 -> recentType = LetterMessageType.SECOND_REPLY.getDisplayName();
         }
 
-        return LetterMessageGetRecentTypeResponse.of(recentType);
+        Boolean isCanceled = letter.getLetterStatus().equals(LetterStatus.COUNSELOR_CANCEL) ||
+                letter.getLetterStatus().equals(LetterStatus.CUSTOMER_CANCEL);
+
+        return LetterMessageGetRecentTypeResponse.of(recentType, isCanceled);
     }
 }

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetRecentTypeResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetRecentTypeResponse.java
@@ -12,7 +12,10 @@ public class LetterMessageGetRecentTypeResponse {
     @Schema(description = "마지막으로 작성된 메시지 종류", example = "추가 질문")
     private final String recentType;
 
-    public static LetterMessageGetRecentTypeResponse of(String recentType) {
-        return new LetterMessageGetRecentTypeResponse(recentType);
+    @Schema(description = "상담 취소 여부")
+    private final Boolean isCanceled;
+
+    public static LetterMessageGetRecentTypeResponse of(String recentType, Boolean isCanceled) {
+        return new LetterMessageGetRecentTypeResponse(recentType, isCanceled);
     }
 }

--- a/src/main/java/com/example/sharemind/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/example/sharemind/review/dto/response/ReviewGetResponse.java
@@ -59,10 +59,9 @@ public class ReviewGetResponse {
                     counselor.getTotalReview(), consult.getConsultType().getDisplayName(), consult.getConsultedAt(),
                     consult.getCost(), review.getRating(), review.getComment());
         } else {
-            String nickname = consult.getCustomer().getNickname().charAt(0) + "**";
-            return new ReviewGetResponse(review.getReviewId(), nickname, null, null, null,
-                    null, consult.getConsultType().getDisplayName(), consult.getConsultedAt(),
-                    consult.getCost(), review.getRating(), review.getComment());
+            return new ReviewGetResponse(review.getReviewId(), consult.getCustomer().getNickname(), null,
+                    null, null, null, consult.getConsultType().getDisplayName(),
+                    consult.getConsultedAt(), consult.getCost(), review.getRating(), review.getComment());
         }
     }
 }

--- a/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
+++ b/src/main/java/com/example/sharemind/review/dto/response/ReviewGetShortResponse.java
@@ -27,9 +27,7 @@ public class ReviewGetShortResponse {
     private final String updatedAt;
 
     public static ReviewGetShortResponse of(Review review) {
-        String nickname = review.getConsult().getCustomer().getNickname().charAt(0) + "**";
-
-        return new ReviewGetShortResponse(review.getReviewId(), nickname, review.getRating(), review.getComment(),
-                TimeUtil.getUpdatedAtForReview(review.getUpdatedAt()));
+        return new ReviewGetShortResponse(review.getReviewId(), review.getConsult().getCustomer().getNickname(),
+                review.getRating(), review.getComment(), TimeUtil.getUpdatedAtForReview(review.getUpdatedAt()));
     }
 }


### PR DESCRIPTION
## 📄구현 내용
- 편지 상담 상대방 닉네임 조회
- 리뷰 작성자 닉네임 마스킹 처리 해제
- 전체 공개 권한 api 설정
  - 이미 되어있던 api들 외에 추가적으로 permitAll 설정한 api는 상담사 리스트 반환, 구매자 페이지에서 마인더 프로필 조회,  검색 결과 반환입니다.
    - 검색 결과 반환의 경우 기존의 주소로도 권한 설정이 가능해 따로 수정하지 않았습니다.
    - 나머지 api 2개는 다른 상담사 api들과 주소가 많이 섞여있어 prefix에 all을 추가하였습니다.
- 편지 진행 상태 조회 시 상담 취소 여부 반환 추가

## 📝기타 알림사항
