### PR TITLE
feat: 진행 중인 상담 구현

### DIFF
--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -3,6 +3,7 @@ package com.example.sharemind.consult.application;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
+import com.example.sharemind.consult.dto.response.ConsultGetOngoingResponse;
 import com.example.sharemind.global.content.ConsultType;
 
 import java.util.List;
@@ -19,4 +20,6 @@ public interface ConsultService {
     List<Consult> getConsultsByCounselorIdAndConsultTypeAndIsPaid(Long counselorId, ConsultType consultType);
 
     Consult getConsultByChat(Chat chat);
+
+    ConsultGetOngoingResponse getOngoingConsults(Long customerId, Boolean isCustomer);
 }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.sharemind.consult.application;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
+import com.example.sharemind.consult.dto.response.ConsultGetOngoingResponse;
 import com.example.sharemind.consult.exception.ConsultErrorCode;
 import com.example.sharemind.consult.exception.ConsultException;
 import com.example.sharemind.consult.repository.ConsultRepository;
@@ -14,11 +15,19 @@ import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultType;
+import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
+import com.example.sharemind.letter.application.LetterConsultService;
+import com.example.sharemind.letter.dto.response.LetterGetOngoingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+
+import static com.example.sharemind.global.constants.Constants.COUNSELOR_ONGOING_CONSULT;
+import static com.example.sharemind.global.constants.Constants.CUSTOMER_ONGOING_CONSULT;
 
 @Service
 @Transactional(readOnly = true)
@@ -28,6 +37,7 @@ public class ConsultServiceImpl implements ConsultService {
     private final ConsultRepository consultRepository;
     private final CounselorService counselorService;
     private final CustomerService customerService;
+    private final LetterConsultService letterConsultService;
 
     @Transactional
     @Override
@@ -79,5 +89,22 @@ public class ConsultServiceImpl implements ConsultService {
     public Consult getConsultByChat(Chat chat) {
         return consultRepository.findByChatAndIsActivatedIsTrue(chat).orElseThrow(
                 () -> new ConsultException(ConsultErrorCode.CONSULT_NOT_FOUND, "chatId : " + chat.getChatId()));
+    }
+
+    @Override
+    public ConsultGetOngoingResponse getOngoingConsults(Long customerId, Boolean isCustomer) {
+        LetterGetOngoingResponse letterResponse = letterConsultService.getOngoingLetters(customerId, isCustomer);
+        // TODO chatResponse = ChatService.get~~~
+
+        Integer totalOngoing = letterResponse.getTotalOngoing(); // TODO + chatResponse.getTotalOngoing()
+        List<ChatLetterGetResponse> responses = new ArrayList<>();
+        responses.addAll(letterResponse.getLetters());
+        // TODO responses.addAll(chatResponse.getChats());
+
+        responses.sort(Comparator.comparing(ChatLetterGetResponse::getLatestMessageUpdatedAt).reversed());
+        int consultOffset = isCustomer ? CUSTOMER_ONGOING_CONSULT : COUNSELOR_ONGOING_CONSULT;
+        consultOffset = Math.min(consultOffset, responses.size());
+
+        return ConsultGetOngoingResponse.of(totalOngoing, responses.subList(0, consultOffset));
     }
 }

--- a/src/main/java/com/example/sharemind/consult/dto/response/ConsultGetOngoingResponse.java
+++ b/src/main/java/com/example/sharemind/consult/dto/response/ConsultGetOngoingResponse.java
@@ -1,0 +1,24 @@
+package com.example.sharemind.consult.dto.response;
+
+import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ConsultGetOngoingResponse {
+
+    @Schema(description = "진행 중인 상담 수")
+    private final Integer totalOngoing;
+
+    @Schema(description = "진행 중인 최근 상담")
+    private final List<ChatLetterGetResponse> responses;
+
+    public static ConsultGetOngoingResponse of(Integer totalOngoing, List<ChatLetterGetResponse> responses) {
+        return new ConsultGetOngoingResponse(totalOngoing, responses);
+    }
+}

--- a/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
+++ b/src/main/java/com/example/sharemind/consult/presentation/ConsultController.java
@@ -2,6 +2,7 @@ package com.example.sharemind.consult.presentation;
 
 import com.example.sharemind.consult.application.ConsultService;
 import com.example.sharemind.consult.dto.request.ConsultCreateRequest;
+import com.example.sharemind.consult.dto.response.ConsultGetOngoingResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import static com.example.sharemind.global.constants.Constants.IS_COUNSELOR;
+import static com.example.sharemind.global.constants.Constants.IS_CUSTOMER;
 
 @Tag(name = "Consult Controller", description = "상담 컨트롤러")
 @RestController
@@ -44,5 +48,27 @@ public class ConsultController {
                                                                @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         consultService.createConsult(consultCreateRequest, customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "상담사 진행 중인 상담 조회", description = "상담사 진행 중인 최근 상담 3개 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/counselors")
+    public ResponseEntity<ConsultGetOngoingResponse> getOngoingConsultsByCounselor(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(consultService.getOngoingConsults(customUserDetails.getCustomer().getCustomerId(),
+                IS_COUNSELOR));
+    }
+
+    @Operation(summary = "구매자 진행 중인 상담 조회", description = "구매자 진행 중인 최근 상담 1개 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/customers")
+    public ResponseEntity<ConsultGetOngoingResponse> getOngoingConsultsByCustomer(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(consultService.getOngoingConsults(customUserDetails.getCustomer().getCustomerId(),
+                IS_CUSTOMER));
     }
 }

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                                         "/counselor.html").permitAll()
                                 .requestMatchers("/api/v1/chats/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/chatMessages/counselors/**").hasRole(ROLE_COUNSELOR)
+                                .requestMatchers("/api/v1/consults/counselors").hasRole(ROLE_COUNSELOR)
                                 .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer

--- a/src/main/java/com/example/sharemind/global/constants/Constants.java
+++ b/src/main/java/com/example/sharemind/global/constants/Constants.java
@@ -4,4 +4,13 @@ public class Constants {
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String CUSTOMER_PREFIX = "customer: ";
     public static final String COUNSELOR_PREFIX = "counselor: ";
+
+    public static final Integer CUSTOMER_ONGOING_CONSULT = 1;
+    public static final Integer COUNSELOR_ONGOING_CONSULT = 3;
+
+    public static final Boolean IS_CUSTOMER = true;
+    public static final Boolean IS_COUNSELOR = false;
+
+    public static final Boolean IS_CHAT = true;
+    public static final Boolean IS_LETTER = false;
 }

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -11,6 +11,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import static com.example.sharemind.global.constants.Constants.IS_CHAT;
+import static com.example.sharemind.global.constants.Constants.IS_LETTER;
+
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatLetterGetResponse {
@@ -45,11 +48,15 @@ public class ChatLetterGetResponse {
     @Schema(description = "상담 아이디")
     private final Long consultId;
 
+    @Schema(description = "채팅/편지 여부")
+    private final Boolean isChat;
+
     public static ChatLetterGetResponse of(LetterGetResponse letterGetResponse) {
         return new ChatLetterGetResponse(letterGetResponse.getLetterId(), letterGetResponse.getConsultStyle(),
                 letterGetResponse.getLetterStatus(), letterGetResponse.getOpponentName(),
                 letterGetResponse.getUpdatedAt(), letterGetResponse.getRecentContent(), null,
-                null, letterGetResponse.getReviewCompleted(), letterGetResponse.getConsultId());
+                null, letterGetResponse.getReviewCompleted(), letterGetResponse.getConsultId(),
+                IS_LETTER);
     }
 
     public static ChatLetterGetResponse of(String nickname, int unreadMessageCount, Chat chat, Counselor counselor,
@@ -62,11 +69,12 @@ public class ChatLetterGetResponse {
         if (chatMessage == null) {
             return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
                     chat.getChatStatus().getDisplayName(), nickname, null, null,
-                    null, null, reviewCompleted, chat.getConsult().getConsultId());
+                    null, null, reviewCompleted, chat.getConsult().getConsultId(),
+                    IS_CHAT);
         }
         return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
                 chat.getChatStatus().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chatMessage.getUpdatedAt()),
                 chatMessage.getContent(), chatMessage.getIsCustomer(), unreadMessageCount, reviewCompleted,
-                chat.getConsult().getConsultId());
+                chat.getConsult().getConsultId(), IS_CHAT);
     }
 }

--- a/src/main/java/com/example/sharemind/letter/application/LetterConsultService.java
+++ b/src/main/java/com/example/sharemind/letter/application/LetterConsultService.java
@@ -1,0 +1,86 @@
+package com.example.sharemind.letter.application;
+
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.exception.CounselorErrorCode;
+import com.example.sharemind.counselor.exception.CounselorException;
+import com.example.sharemind.customer.application.CustomerService;
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
+import com.example.sharemind.letter.domain.Letter;
+import com.example.sharemind.letter.dto.response.LetterGetOngoingResponse;
+import com.example.sharemind.letter.dto.response.LetterGetResponse;
+import com.example.sharemind.letter.repository.LetterRepository;
+import com.example.sharemind.letterMessage.content.LetterMessageType;
+import com.example.sharemind.letterMessage.domain.LetterMessage;
+import com.example.sharemind.letterMessage.exception.LetterMessageErrorCode;
+import com.example.sharemind.letterMessage.exception.LetterMessageException;
+import com.example.sharemind.letterMessage.repository.LetterMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.sharemind.global.constants.Constants.COUNSELOR_ONGOING_CONSULT;
+import static com.example.sharemind.global.constants.Constants.CUSTOMER_ONGOING_CONSULT;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LetterConsultService {
+    private static final Boolean IS_COMPLETED = true;
+
+    private final CustomerService customerService;
+    private final LetterRepository letterRepository;
+    private final LetterMessageRepository letterMessageRepository;
+
+    public LetterGetOngoingResponse getOngoingLetters(Long customerId, Boolean isCustomer) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+        List<Letter> letters;
+        if (isCustomer) {
+            letters = letterRepository.findAllByConsultCustomerAndLetterStatusOngoingOrderByUpdatedAtDesc(
+                    customer);
+        } else {
+            Counselor counselor = customer.getCounselor();
+            if (counselor == null) {
+                throw new CounselorException(CounselorErrorCode.COUNSELOR_NOT_FOUND);
+            }
+
+            letters = letterRepository.findAllByConsultCounselorAndLetterStatusOngoingOrderByUpdatedAtDesc(
+                    counselor);
+        }
+
+        int consultOffset = isCustomer ? CUSTOMER_ONGOING_CONSULT : COUNSELOR_ONGOING_CONSULT;
+        List<ChatLetterGetResponse> chatLetterGetResponses = new ArrayList<>();
+        for (int i = 0; i < consultOffset; i++) {
+            try {
+                Letter letter = letters.get(i);
+                chatLetterGetResponses.add(LetterGetResponse.of(letter, getRecentMessage(letter), isCustomer));
+            } catch (IndexOutOfBoundsException ignored) {
+            }
+        }
+
+        return LetterGetOngoingResponse.of(letters.size(), chatLetterGetResponses);
+    }
+
+    private LetterMessage getRecentMessage(Letter letter) {
+        LetterMessageType recentType = null;
+        switch (letterMessageRepository.countByLetterAndIsCompletedIsTrueAndIsActivatedIsTrue(letter)) {
+            case 0 -> {
+                return null;
+            }
+            case 1 -> recentType = LetterMessageType.FIRST_QUESTION;
+            case 2 -> recentType = LetterMessageType.FIRST_REPLY;
+            case 3 -> recentType = LetterMessageType.SECOND_QUESTION;
+            case 4 -> recentType = LetterMessageType.SECOND_REPLY;
+        }
+
+        return getRecentMessageWithMessageType(letter, recentType);
+    }
+
+    private LetterMessage getRecentMessageWithMessageType(Letter letter, LetterMessageType messageType) {
+        return letterMessageRepository.findByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(letter, messageType, IS_COMPLETED)
+                .orElseThrow(() -> new LetterMessageException(LetterMessageErrorCode.LETTER_MESSAGE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetOngoingResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetOngoingResponse.java
@@ -1,0 +1,19 @@
+package com.example.sharemind.letter.dto.response;
+
+import com.example.sharemind.global.dto.response.ChatLetterGetResponse;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class LetterGetOngoingResponse {
+    private final Integer totalOngoing;
+    private final List<ChatLetterGetResponse> letters;
+
+    public static LetterGetOngoingResponse of(Integer totalOngoing, List<ChatLetterGetResponse> letters) {
+        return new LetterGetOngoingResponse(totalOngoing, letters);
+    }
+}

--- a/src/main/java/com/example/sharemind/letter/repository/LetterRepository.java
+++ b/src/main/java/com/example/sharemind/letter/repository/LetterRepository.java
@@ -1,12 +1,30 @@
 package com.example.sharemind.letter.repository;
 
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.letter.domain.Letter;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface LetterRepository extends JpaRepository<Letter, Long> {
     Optional<Letter> findByLetterIdAndIsActivatedIsTrue(Long letterId);
+
+    @Query("SELECT l FROM Letter l JOIN FETCH l.consult c " +
+            "WHERE c.customer = :customer AND " +
+            "(l.letterStatus = 'WAITING' OR l.letterStatus = 'FIRST_ASKING' OR l.letterStatus = 'FIRST_ANSWER' OR " +
+            "l.letterStatus = 'SECOND_ASKING') AND l.isActivated = true " +
+            "ORDER BY l.updatedAt DESC")
+    List<Letter> findAllByConsultCustomerAndLetterStatusOngoingOrderByUpdatedAtDesc(Customer customer);
+
+    @Query("SELECT l FROM Letter l JOIN FETCH l.consult c " +
+            "WHERE c.counselor = :counselor AND " +
+            "(l.letterStatus = 'WAITING' OR l.letterStatus = 'FIRST_ASKING' OR l.letterStatus = 'FIRST_ANSWER' OR " +
+            "l.letterStatus = 'SECOND_ASKING') AND l.isActivated = true " +
+            "ORDER BY l.updatedAt DESC")
+    List<Letter> findAllByConsultCounselorAndLetterStatusOngoingOrderByUpdatedAtDesc(Counselor counselor);
 }

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetResponse.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.letterMessage.dto.response;
 
+import com.example.sharemind.global.utils.TimeUtil;
 import com.example.sharemind.letterMessage.domain.LetterMessage;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,12 +27,16 @@ public class LetterMessageGetResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 a HH시 mm분")
     private final LocalDateTime updatedAt;
 
+    @Schema(description = "작성 일시, 메시지 존재하지 않으면 null", example = "8분 전")
+    private final String updatedAt2;
+
     public static LetterMessageGetResponse of(LetterMessage letterMessage) {
         return new LetterMessageGetResponse(letterMessage.getMessageId(), letterMessage.getMessageType().getDisplayName(),
-                letterMessage.getContent(), letterMessage.getUpdatedAt());
+                letterMessage.getContent(), letterMessage.getUpdatedAt(),
+                TimeUtil.getUpdatedAt(letterMessage.getUpdatedAt()));
     }
 
     public static LetterMessageGetResponse of() {
-        return new LetterMessageGetResponse(null, null, null, null);
+        return new LetterMessageGetResponse(null, null, null, null, null);
     }
 }

--- a/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetResponse.java
+++ b/src/main/java/com/example/sharemind/letterMessage/dto/response/LetterMessageGetResponse.java
@@ -27,7 +27,7 @@ public class LetterMessageGetResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 a HH시 mm분")
     private final LocalDateTime updatedAt;
 
-    @Schema(description = "작성 일시, 메시지 존재하지 않으면 null", example = "8분 전")
+    @Schema(description = "작성 일시, 메시지 존재하지 않으면 null", example = "01.12")
     private final String updatedAt2;
 
     public static LetterMessageGetResponse of(LetterMessage letterMessage) {


### PR DESCRIPTION
## 📄구현 내용
- 진행 중인 상담
  - letterService, chatService에서 구매자/판매자 여부에 따라 필요한 수만큼 최근 진행 상담 조회 후 consultService에서 최종적으로 진행 중인 상담 넘겨주도록 로직 구현
  - 순환 참조 문제로 letterConsultService 생성
  - 클릭 시 해당 상담으로 넘어가는 로직을 위해 ChatLetterGetResponse에 채팅/편지 여부 나타내는 필드 추가
- LetterMessageGetResponse에 updatedAt 다른 형식 값 추가
  - 피그마 기준 판매자가 답장할 때 상단에 뜨는 질문의 업데이트 일시 표시를 위함

## 📝기타 알림사항
