### PR TITLE
feat: 채팅방 웹소켓 연결 시 읽지 않은 아이디 갱신

### DIFF
--- a/src/main/java/com/example/sharemind/chat/application/ChatService.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatService.java
@@ -26,7 +26,9 @@ public interface ChatService {
 
     void validateChat(Chat chat, Boolean isCustomer, Long customerId);
 
-    void updateReadId(Long chatId, Long customerId, Boolean isCustomer);
+    void updateReadId(Chat chat, Long customerId, Boolean isCustomer);
 
     Chat getAndValidateChat(Long chatId, Boolean isCustomer, Long customerId);
+
+    void setChatInSessionRedis(Long chatId, Long customerId, Boolean isCustomer);
 }

--- a/src/main/java/com/example/sharemind/chat/application/ChatService.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatService.java
@@ -20,7 +20,7 @@ public interface ChatService {
     List<ChatLetterGetResponse> getChatInfoByCustomerId(Long customerId, Boolean isCustomer, Boolean filter,
                                                         String sortType);
 
-    void getAndSendChatStatus(Long chatId, ChatStatusUpdateRequest chatStatusUpdateRequest, Boolean isCustomer);
+    void getAndSendChatStatus(Long chatId, Map<String, Object> sessionAttributes, ChatStatusUpdateRequest chatStatusUpdateRequest, Boolean isCustomer);
 
     void validateNotFinishChat(Long chatId);
 

--- a/src/main/java/com/example/sharemind/chat/application/ChatService.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatService.java
@@ -31,4 +31,6 @@ public interface ChatService {
     Chat getAndValidateChat(Long chatId, Boolean isCustomer, Long customerId);
 
     void setChatInSessionRedis(Long chatId, Long customerId, Boolean isCustomer);
+
+    void leaveChatSession(Map<String, Object> sessionAttributes, Long chatId, Boolean isCustomer);
 }

--- a/src/main/java/com/example/sharemind/chat/application/ChatServiceImpl.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatServiceImpl.java
@@ -9,7 +9,6 @@ import com.example.sharemind.chat.dto.request.ChatStatusUpdateRequest;
 import com.example.sharemind.chat.dto.response.ChatGetConnectResponse;
 import com.example.sharemind.chat.dto.response.ChatGetStatusResponse;
 import com.example.sharemind.chat.dto.response.ChatNotifyEventResponse;
-import com.example.sharemind.chat.dto.response.ChatUpdateStatusResponse;
 import com.example.sharemind.chat.exception.ChatErrorCode;
 import com.example.sharemind.chat.exception.ChatException;
 import com.example.sharemind.chat.repository.ChatRepository;

--- a/src/main/java/com/example/sharemind/chat/application/ChatServiceImpl.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatServiceImpl.java
@@ -55,7 +55,7 @@ public class ChatServiceImpl implements ChatService {
     private final ChatConsultService chatConsultService;
     private final ApplicationEventPublisher publisher;
     private final RedisTemplate<String, List<Long>> redisTemplate;
-    private RedisTemplate<String, Map<Long, Integer>> sessionRedisTemplate;
+    private final RedisTemplate<String, Map<Long, Integer>> sessionRedisTemplate;
     private final ChatTaskScheduler chatTaskScheduler;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChatNoticeService chatNoticeService;

--- a/src/main/java/com/example/sharemind/chat/content/ChatRoomWebsocketStatus.java
+++ b/src/main/java/com/example/sharemind/chat/content/ChatRoomWebsocketStatus.java
@@ -4,11 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
-public enum ChatRoomStatus {
+public enum ChatRoomWebsocketStatus {
 
     @Schema(description = "채팅 생성")
     CHAT_ROOM_CREATE,
 
     @Schema(description = "채팅 끝")
-    CHAT_ROOM_FINISH
+    CHAT_ROOM_FINISH,
+
+    @Schema(description = "채팅 unread 메세지 0으로(전부 읽음) 갱신")
+    CHAT_READ_ALL
 }

--- a/src/main/java/com/example/sharemind/chat/domain/Chat.java
+++ b/src/main/java/com/example/sharemind/chat/domain/Chat.java
@@ -54,6 +54,16 @@ public class Chat extends BaseEntity {
         }
     }
 
+    public ChatStatus changeChatStatusForChatList() {
+        if (chatStatus == ChatStatus.SEND_REQUEST)
+            return ChatStatus.WAITING;
+        else if (chatStatus == ChatStatus.FIVE_MINUTE_LEFT || chatStatus == ChatStatus.TIME_OVER)
+            return ChatStatus.ONGOING;
+        else if (chatStatus == ChatStatus.COUNSELOR_CANCEL || chatStatus == ChatStatus.CUSTOMER_CANCEL)
+            return ChatStatus.FINISH;
+        return chatStatus;
+    }
+
     public void checkChatAuthority(Chat chat, Boolean isCustomer, Customer customer) {
         if (isCustomer) {
             if (chat.getConsult().getCustomer() != customer) {

--- a/src/main/java/com/example/sharemind/chat/domain/ChatNotifyEvent.java
+++ b/src/main/java/com/example/sharemind/chat/domain/ChatNotifyEvent.java
@@ -1,6 +1,6 @@
 package com.example.sharemind.chat.domain;
 
-import com.example.sharemind.chat.content.ChatRoomStatus;
+import com.example.sharemind.chat.content.ChatRoomWebsocketStatus;
 import lombok.*;
 
 @Getter
@@ -10,9 +10,9 @@ public class ChatNotifyEvent {
     private final Long chatId;
     private final Long customerId;
     private final Long counselorId;
-    private final ChatRoomStatus chatRoomStatus;
+    private final ChatRoomWebsocketStatus chatRoomWebsocketStatus;
 
-    public static ChatNotifyEvent of(Long chatId, Long customerId, Long counselorId, ChatRoomStatus chatRoomStatus) {
-        return new ChatNotifyEvent(chatId, customerId, counselorId, chatRoomStatus);
+    public static ChatNotifyEvent of(Long chatId, Long customerId, Long counselorId, ChatRoomWebsocketStatus chatRoomWebsocketStatus) {
+        return new ChatNotifyEvent(chatId, customerId, counselorId, chatRoomWebsocketStatus);
     }
 }

--- a/src/main/java/com/example/sharemind/chat/dto/response/ChatNotifyEventResponse.java
+++ b/src/main/java/com/example/sharemind/chat/dto/response/ChatNotifyEventResponse.java
@@ -1,6 +1,6 @@
 package com.example.sharemind.chat.dto.response;
 
-import com.example.sharemind.chat.content.ChatRoomStatus;
+import com.example.sharemind.chat.content.ChatRoomWebsocketStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -17,14 +17,14 @@ public class ChatNotifyEventResponse {
     @Schema(description = "채팅방 id")
     private final Long chatId;
 
-    @Schema(description = "채팅방 생성 시간")
+    @Schema(description = "이벤트 발생 시간")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 a HH시 mm분")
     private final LocalDateTime createTime;
 
     @Schema(description = "채팅 이벤트")
-    private final ChatRoomStatus chatRoomStatus;
+    private final ChatRoomWebsocketStatus chatRoomWebsocketStatus;
 
-    public static ChatNotifyEventResponse of(Long chatId, ChatRoomStatus chatRoomStatus) {
-        return new ChatNotifyEventResponse(chatId, LocalDateTime.now(), chatRoomStatus);
+    public static ChatNotifyEventResponse of(Long chatId, ChatRoomWebsocketStatus chatRoomWebsocketStatus) {
+        return new ChatNotifyEventResponse(chatId, LocalDateTime.now(), chatRoomWebsocketStatus);
     }
 }

--- a/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
+++ b/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
@@ -83,7 +83,7 @@ public class ChatController {
 
             chatService.validateChatWithWebSocket(chatId, sessionAttributes, true);
 
-            chatService.getAndSendChatStatus(chatId, chatStatusUpdateRequest, true);
+            chatService.getAndSendChatStatus(chatId, sessionAttributes, chatStatusUpdateRequest, true);
         } catch (ChatException | ConsultException e) {
             simpMessagingTemplate.convertAndSend("/queue/chattings/exception/customers/" + chatId, e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
@@ -100,7 +100,7 @@ public class ChatController {
 
             chatService.validateChatWithWebSocket(chatId, sessionAttributes, false);
 
-            chatService.getAndSendChatStatus(chatId, chatStatusUpdateRequest, false);
+            chatService.getAndSendChatStatus(chatId, sessionAttributes, chatStatusUpdateRequest, false);
         } catch (ChatException | ConsultException e) {
             simpMessagingTemplate.convertAndSend("/queue/chattings/exception/counselors/" + chatId, e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();

--- a/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
+++ b/src/main/java/com/example/sharemind/chat/presentation/ChatController.java
@@ -74,40 +74,6 @@ public class ChatController {
         return ResponseEntity.ok(chatInfoGetResponses);
     }
 
-    @Operation(summary = "상담사의 채팅 readId 갱신해주는 api", description = "처음 채팅방에 들어갔을 때, 호출해주시면 됩니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "채팅 목록 반환 성공"),
-            @ApiResponse(responseCode = "404", description = "1. 상담사 role을 가지지 않은 사람이 해당 api를 요청할 때"
-                    + "2. 채팅방이 존재하지 않을 때")
-    })
-    @Parameters({
-            @Parameter(name = "chatId", description = "채팅방 id"),
-            @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
-    })
-    @PatchMapping("/counselors/{chatId}")
-    public ResponseEntity<Void> updateCounselorReadId(@PathVariable Long chatId,
-                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        chatService.updateReadId(chatId, customUserDetails.getCustomer().getCustomerId(), false);
-        return ResponseEntity.ok().build();
-    }
-
-    @Operation(summary = "구매자 채팅 readId 갱신해주는 api", description = "처음 채팅방에 들어갔을 때, 호출해주시면 됩니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "채팅 목록 반환 성공"),
-            @ApiResponse(responseCode = "404", description = "1. 구매자 role을 가지지 않은 사람이 햏당 api를 요청할 때"
-                    + "2. 채팅방이 존재하지 않을 때")
-    })
-    @Parameters({
-            @Parameter(name = "chatId", description = "채팅방 id"),
-            @Parameter(name = "sortType", description = "정렬 방식(LATEST, UNREAD)")
-    })
-    @PatchMapping("/{chatId}")
-    public ResponseEntity<Void> updateCustomerReadId(@PathVariable Long chatId,
-                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        chatService.updateReadId(chatId, customUserDetails.getCustomer().getCustomerId(), true);
-        return ResponseEntity.ok().build();
-    }
-
     @MessageMapping("/api/v1/chat/customers/{chatId}")
     public ResponseEntity<Void> getAndSendCustomerChatStatus(@DestinationVariable Long chatId,
                                                              ChatStatusUpdateRequest chatStatusUpdateRequest,
@@ -153,6 +119,13 @@ public class ChatController {
     public ResponseEntity<Void> getAndSendCounselorChatIds(SimpMessageHeaderAccessor headerAccessor) {
         Map<String, Object> sessionAttributes = Objects.requireNonNull(headerAccessor.getSessionAttributes());
         chatService.getAndSendChatIdsByWebSocket(sessionAttributes, false);
+        return ResponseEntity.ok().build();
+    }
+
+    @MessageMapping("/api/v1/chat/customers/exit")
+    public ResponseEntity<Void> leaveCustomerSession(@DestinationVariable Long chatId, SimpMessageHeaderAccessor headerAccessor) {
+        Map<String, Object> sessionAttributes = Objects.requireNonNull(headerAccessor.getSessionAttributes());
+        chatService.leaveChatSession(sessionAttributes, chatId, true);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/chatMessage/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/chatMessage/application/ChatMessageServiceImpl.java
@@ -71,6 +71,11 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
         chatService.validateChat(chat, isCustomer, customerId);
 
+        if (messageId == 0) {//처음 들어왔을 때만 갱신
+            chatService.updateReadId(chat, customerId, isCustomer);
+
+            chatService.setChatInSessionRedis(chatId, customerId, isCustomer);
+        }
         List<ChatMessage> chatMessages = getChatMessageByPagination(chat, messageId);
         return chatMessages.stream()
                 .map(chatMessage -> ChatMessageGetResponse.of(chat, chatMessage))

--- a/src/main/java/com/example/sharemind/global/config/RedisConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.example.sharemind.global.config;
 
 import java.util.List;
+import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
@@ -44,6 +46,15 @@ public class RedisConfig {
     @Bean
     public RedisTemplate<String, Integer> countRedisTemplate() {
         RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Map<Long, Integer>> sessionRedisTemplate() {
+        RedisTemplate<String, Map<Long, Integer>> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 

--- a/src/main/java/com/example/sharemind/global/constants/Constants.java
+++ b/src/main/java/com/example/sharemind/global/constants/Constants.java
@@ -5,6 +5,9 @@ public class Constants {
     public static final String CUSTOMER_PREFIX = "customer: ";
     public static final String COUNSELOR_PREFIX = "counselor: ";
 
+    public static final String CUSTOMER_CHATTING_PREFIX = "customer chatting: "; // 현재 접속중인 방
+    public static final String COUNSELOR_CHATTING_PREFIX = "counselor chatting: ";
+
     public static final Integer CUSTOMER_ONGOING_CONSULT = 1;
     public static final Integer COUNSELOR_ONGOING_CONSULT = 3;
 

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -67,12 +67,12 @@ public class ChatLetterGetResponse {
         }
         if (chat.getChatStatus().equals(ChatStatus.WAITING)) {
             return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
-                    chat.getChatStatus().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()), nickname + "님께 고민내용을 남겨주세요. " + nickname + "님이 24시간 내에 채팅 요청을 드립니다.",
+                    chat.changeChatStatusForChatList().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()), nickname + "님께 고민내용을 남겨주세요. " + nickname + "님이 24시간 내에 채팅 요청을 드립니다.",
                     null, 0, reviewCompleted, chat.getConsult().getConsultId(),
                     IS_CHAT);
         }
         return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
-                chat.getChatStatus().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chatMessage.getUpdatedAt()),
+                chat.changeChatStatusForChatList().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chatMessage.getUpdatedAt()),
                 chatMessage.getContent(), chatMessage.getIsCustomer(), unreadMessageCount, reviewCompleted,
                 chat.getConsult().getConsultId(), IS_CHAT);
     }

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -67,16 +67,10 @@ public class ChatLetterGetResponse {
         }
         if (chat.getChatStatus().equals(ChatStatus.WAITING)) {
             return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
-                    chat.getChatStatus().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()), nickname + "님께 고민내용을 남겨주세요. "+nickname+"님이 24시간 내에 채팅 요청을 드립니다.",
+                    chat.getChatStatus().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()), nickname + "님께 고민내용을 남겨주세요. " + nickname + "님이 24시간 내에 채팅 요청을 드립니다.",
                     null, 0, reviewCompleted, chat.getConsult().getConsultId(),
                     IS_CHAT);
         }
-//        if (chatMessage == null) {
-//            return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
-//                    chat.getChatStatus().getDisplayName(), nickname, null, null,
-//                    null, null, reviewCompleted, chat.getConsult().getConsultId(),
-//                    IS_CHAT);
-//        } //todo: 아무말없이 채팅이 끝나는 경우를 고려해보아야함
         return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
                 chat.getChatStatus().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chatMessage.getUpdatedAt()),
                 chatMessage.getContent(), chatMessage.getIsCustomer(), unreadMessageCount, reviewCompleted,

--- a/src/main/java/com/example/sharemind/global/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/example/sharemind/global/websocket/WebSocketEventListener.java
@@ -1,6 +1,6 @@
 package com.example.sharemind.global.websocket;
 
-import com.example.sharemind.chat.content.ChatRoomStatus;
+import com.example.sharemind.chat.content.ChatRoomWebsocketStatus;
 import com.example.sharemind.chat.domain.ChatNotifyEvent;
 import com.example.sharemind.chat.domain.ChatUpdateStatusEvent;
 import com.example.sharemind.chat.dto.response.ChatNotifyEventResponse;
@@ -42,10 +42,10 @@ public class WebSocketEventListener {
                 + chatNotifyEvent.getCounselorId()); //todo: 로깅용으로 찍은 것.. 채팅 연결 후 삭제
         messageSendingOperations.convertAndSend(
                 "/queue/chattings/notifications/customers/" + chatNotifyEvent.getCustomerId(),
-                ChatNotifyEventResponse.of(chatNotifyEvent.getChatId(), ChatRoomStatus.CHAT_ROOM_CREATE));
+                ChatNotifyEventResponse.of(chatNotifyEvent.getChatId(), ChatRoomWebsocketStatus.CHAT_ROOM_CREATE));
         messageSendingOperations.convertAndSend(
                 "/queue/chattings/notifications/counselors/" + chatNotifyEvent.getCounselorId(),
-                ChatNotifyEventResponse.of(chatNotifyEvent.getChatId(), ChatRoomStatus.CHAT_ROOM_CREATE));
+                ChatNotifyEventResponse.of(chatNotifyEvent.getChatId(), ChatRoomWebsocketStatus.CHAT_ROOM_CREATE));
     }
 
     @EventListener


### PR DESCRIPTION
## 📄구현 내용
- 여러 탭 접속 시 한 탭에서 채팅방에 접속했을 때, 다른 탭에서도 읽음 처리 되도록 소켓 연결했습니다.
- 프론트에서 피드백 준 chatStatus 채팅 대기, 채팅 중, 채팅 종료 세 가지로 통일했습니다.
## 📝기타 알림사항
