### PR TITLE
fix: notice 메세지 상담사에게 알람 안가는 문제 해결 

### DIFF
--- a/src/main/java/com/example/sharemind/chat/application/ChatNoticeService.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatNoticeService.java
@@ -3,42 +3,47 @@ package com.example.sharemind.chat.application;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.chatMessage.content.ChatMessageStatus;
 import com.example.sharemind.chatMessage.domain.ChatMessage;
+import com.example.sharemind.chatMessage.dto.response.ChatMessageWebSocketResponse;
 import com.example.sharemind.chatMessage.exception.ChatMessageErrorCode;
 import com.example.sharemind.chatMessage.exception.ChatMessageException;
 import com.example.sharemind.chatMessage.repository.ChatMessageRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChatNoticeService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     @Transactional
     public void createChatNoticeMessage(Chat chat, ChatMessageStatus chatMessageStatus) {
+        ChatMessage chatMessage = null;
         if (chatMessageStatus == ChatMessageStatus.SEND_REQUEST) {
-            ChatMessage chatMessage = new ChatMessage(chat, false, chat.getConsult().getCustomer().getNickname() + "님, 지금 바로 상담을 시작할까요?", chatMessageStatus);
-            chatMessageRepository.save(chatMessage);
+            chatMessage = new ChatMessage(chat, false, chat.getConsult().getCustomer().getNickname() + "님, 지금 바로 상담을 시작할까요?", chatMessageStatus);
         } else if (chatMessageStatus == ChatMessageStatus.START) {
             updateSendRequestMessageIsActivatedFalse(chat);
-            ChatMessage chatMessage = new ChatMessage(chat, false, "상담이 시작되었어요.\n" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a HH시 mm분")), chatMessageStatus);
-            chatMessageRepository.save(chatMessage);
+            chatMessage = new ChatMessage(chat, true, "상담이 시작되었어요.\n" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a HH시 mm분")), chatMessageStatus);
         } else if (chatMessageStatus == ChatMessageStatus.FIVE_MINUTE_LEFT) {
-            ChatMessage chatMessage = new ChatMessage(chat, false, "상담 종료까지 5분 남았어요.\n" + chat.getStartedAt().plusMinutes(30).format(DateTimeFormatter.ofPattern("a hh시 mm분")), chatMessageStatus);
-            chatMessageRepository.save(chatMessage);
+            chatMessage = new ChatMessage(chat, null, "상담 종료까지 5분 남았어요.\n" + chat.getStartedAt().plusMinutes(30).format(DateTimeFormatter.ofPattern("a hh시 mm분")), chatMessageStatus);
         } else if (chatMessageStatus == ChatMessageStatus.TIME_OVER) {
-            ChatMessage chatMessage = new ChatMessage(chat, false, "상담 시간이 모두 마무리 되었어요.\n상담이 정상적으로 종료되었다면 상담 종료 버튼을 눌러 주세요.\n*신고접수가 되지 않은 상담 건은 7일 후 자동으로 거래가 확정됩니다.", chatMessageStatus);
-            chatMessageRepository.save(chatMessage);
+            chatMessage = new ChatMessage(chat, null, "상담 시간이 모두 마무리 되었어요.\n상담이 정상적으로 종료되었다면 상담 종료 버튼을 눌러 주세요.\n*신고접수가 되지 않은 상담 건은 7일 후 자동으로 거래가 확정됩니다.", chatMessageStatus);
         } else if (chatMessageStatus == ChatMessageStatus.FINISH) {
-            ChatMessage chatMessage = new ChatMessage(chat, false, "님과의 상담이 만족스러우셨나요? 후기를 남겨주시면 더 나은 서비스를 위해 큰 도움이 되어요.", chatMessageStatus);
+            chatMessage = new ChatMessage(chat, null, "님과의 상담이 만족스러우셨나요? 후기를 남겨주시면 더 나은 서비스를 위해 큰 도움이 되어요.", chatMessageStatus);
+        }
+        if (chatMessage != null) {
             chatMessageRepository.save(chatMessage);
+            String opponentNickname = getOpponentNickname(chat, chatMessage.getIsCustomer());
+            sendChatNoticeMessage(chatMessage, opponentNickname, chat.getChatId());
         }
     }
 
@@ -48,5 +53,23 @@ public class ChatNoticeService {
         if (chatMessage == null)
             throw new ChatMessageException(ChatMessageErrorCode.SEND_REQUEST_STATUS_NOT_FOUND);
         chatMessage.updateIsActivatedFalse();
+    }
+
+    private void sendChatNoticeMessage(ChatMessage chatMessage, String opponentNickname, Long chatId) {
+        ChatMessageWebSocketResponse chatMessageWebSocketResponse = ChatMessageWebSocketResponse.of(opponentNickname, chatMessage.getContent(), chatMessage.getIsCustomer());
+        simpMessagingTemplate.convertAndSend("/queue/chatMessages/counselors/" + chatId, chatMessageWebSocketResponse);
+        simpMessagingTemplate.convertAndSend("/queue/chatMessages/customers/" + chatId, chatMessageWebSocketResponse);
+
+        log.info("Message [{}] send by member: {} to chatting room: {}", chatMessage.getContent(),
+                opponentNickname, chatId);
+    }
+
+    private String getOpponentNickname(Chat chat, Boolean isCustomer) {
+        if (isCustomer == null)
+            return null;
+        else if (isCustomer)
+            return chat.getConsult().getCounselor().getNickname();
+        else
+            return chat.getConsult().getCustomer().getNickname();
     }
 }

--- a/src/main/java/com/example/sharemind/chat/application/ChatNoticeService.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatNoticeService.java
@@ -56,11 +56,14 @@ public class ChatNoticeService {
     }
 
     private void sendChatNoticeMessage(ChatMessage chatMessage, String opponentNickname, Long chatId) {
-        ChatMessageWebSocketResponse chatMessageWebSocketResponse = ChatMessageWebSocketResponse.of(opponentNickname, chatMessage.getContent(), chatMessage.getIsCustomer());
+        String content = chatMessage.getContent();
+        if (chatMessage.getMessageStatus() == ChatMessageStatus.FINISH)
+            content = chatMessage.getChat().getConsult().getCounselor().getNickname() + content;
+        ChatMessageWebSocketResponse chatMessageWebSocketResponse = ChatMessageWebSocketResponse.of(opponentNickname, content, chatMessage.getIsCustomer());
         simpMessagingTemplate.convertAndSend("/queue/chatMessages/counselors/" + chatId, chatMessageWebSocketResponse);
         simpMessagingTemplate.convertAndSend("/queue/chatMessages/customers/" + chatId, chatMessageWebSocketResponse);
 
-        log.info("Message [{}] send by member: {} to chatting room: {}", chatMessage.getContent(),
+        log.info("Message [{}] send by member: {} to chatting room: {}", content,
                 opponentNickname, chatId);
     }
 

--- a/src/main/java/com/example/sharemind/chatMessage/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/chatMessage/application/ChatMessageServiceImpl.java
@@ -41,17 +41,16 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
         createChatMessage(chatMessageCreateRequest, chatId, isCustomer);
 
-        sendChatMessage(chatMessageCreateRequest, chatId, isCustomer, nickname);
+        sendChatMessage(chatMessageCreateRequest.getContent(), chatId, isCustomer, nickname);
     }
 
-    private void sendChatMessage(ChatMessageCreateRequest chatMessageCreateRequest, Long chatId, Boolean isCustomer,
+    private void sendChatMessage(String content, Long chatId, Boolean isCustomer,
                                  String nickname) {
-        ChatMessageWebSocketResponse chatMessageWebSocketResponse = ChatMessageWebSocketResponse.of(nickname,
-                chatMessageCreateRequest.getContent(), isCustomer);
+        ChatMessageWebSocketResponse chatMessageWebSocketResponse = ChatMessageWebSocketResponse.of(nickname, content, isCustomer);
         simpMessagingTemplate.convertAndSend("/queue/chatMessages/counselors/" + chatId, chatMessageWebSocketResponse);
         simpMessagingTemplate.convertAndSend("/queue/chatMessages/customers/" + chatId, chatMessageWebSocketResponse);
 
-        log.info("Message [{}] send by member: {} to chatting room: {}", chatMessageCreateRequest.getContent(),
+        log.info("Message [{}] send by member: {} to chatting room: {}", content,
                 nickname, chatId);
     }
 

--- a/src/main/java/com/example/sharemind/chatMessage/domain/ChatMessage.java
+++ b/src/main/java/com/example/sharemind/chatMessage/domain/ChatMessage.java
@@ -20,7 +20,7 @@ public class ChatMessage extends BaseEntity {
     @JoinColumn(name = "chat_id")
     private Chat chat;
 
-    @Column(name = "is_customer", nullable = false)
+    @Column(name = "is_customer")
     private Boolean isCustomer;
 
     @Column(columnDefinition = "TEXT", nullable = false)

--- a/src/main/java/com/example/sharemind/chatMessage/dto/response/ChatMessageGetResponse.java
+++ b/src/main/java/com/example/sharemind/chatMessage/dto/response/ChatMessageGetResponse.java
@@ -55,6 +55,12 @@ public class ChatMessageGetResponse {
                     chatMessage.getMessageId(), chatMessage.getContent(), chatMessage.getUpdatedAt(),
                     chatMessage.getIsCustomer(), chatMessage.getMessageStatus(), String.format("%02d:%02d", minutes, seconds));
         }
+        if (chatMessage.getMessageStatus() == ChatMessageStatus.FINISH) {
+            String nickname = chat.getConsult().getCounselor().getNickname();
+            return new ChatMessageGetResponse(consult.getCustomer().getNickname(), consult.getCounselor().getNickname(),
+                    chatMessage.getMessageId(), nickname + chatMessage.getContent(), chatMessage.getUpdatedAt(),
+                    chatMessage.getIsCustomer(), chatMessage.getMessageStatus(), null);
+        }
         return new ChatMessageGetResponse(consult.getCustomer().getNickname(), consult.getCounselor().getNickname(),
                 chatMessage.getMessageId(), chatMessage.getContent(), chatMessage.getUpdatedAt(),
                 chatMessage.getIsCustomer(), chatMessage.getMessageStatus(), null);

--- a/src/main/java/com/example/sharemind/chatMessage/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/sharemind/chatMessage/repository/ChatMessageRepository.java
@@ -6,12 +6,14 @@ import com.example.sharemind.chatMessage.domain.ChatMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     ChatMessage findTopByChatOrderByUpdatedAtDesc(Chat chat);
 
+    @Query("SELECT COUNT(cm) FROM ChatMessage cm WHERE cm.chat = :chat AND cm.messageId > :lastReadMessageId AND (:isCustomer IS NULL OR cm.isCustomer = :isCustomer)")
     int countByChatAndMessageIdGreaterThanAndIsCustomer(Chat chat, Long lastReadMessageId, Boolean isCustomer);
 
     Page<ChatMessage> findByChatAndIsActivatedTrueAndMessageIdLessThanOrderByMessageIdDesc(Chat chat, Long messageId, Pageable pageable);

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -65,7 +65,7 @@ public class ChatLetterGetResponse {
         if (chat.getChatStatus().equals(ChatStatus.FINISH)) {
             reviewCompleted = chat.getConsult().getReview().getIsCompleted();
         }
-        if (chat.getChatStatus().equals(ChatStatus.WAITING)) {
+        if (chatMessage == null) {
             return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
                     chat.changeChatStatusForChatList().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()), nickname + "님께 고민내용을 남겨주세요. " + nickname + "님이 24시간 내에 채팅 요청을 드립니다.",
                     null, 0, reviewCompleted, chat.getConsult().getConsultId(),


### PR DESCRIPTION
## 📄구현 내용
- notice 메세지 상담사에게 알람 안가는 문제 해결
- 알림메세지 모두에게 전송하도록 수정
- chat 끝나고 리뷰 요청 시 닉네임 추가

## 📝기타 알림사항
- chatMessage 부분 notice 메세지가 판매자, 구매자 모두에게 전달되어야하는 경우가 있습니다 -> 해당 부분 처리를 위해 전체 전달 알림 메세지는 isCustomer 필드 null로 처리하였습니다.
- 현재 채팅방 상태 변환 메세지(ex 종료 5분 전)가 구매자에게만 나는 오류가 있습니다 해당 부분 고쳐서 올리겠습니다.
- 알림메세지 모두에게 전송하도록 수정하도록 웹소켓 부분 수정했습니다.
- chat 끝나고 리뷰 요청 시 닉네임 누락되어있길래 해당 부분 닉네임 추가해서 리턴해주었습니다.
- chat 자꾸 ongoing 중인데 send_request로 판단되는 문제가 있었습니다(이유 : ChatTaskScheduler 에 Chat이 객체 상태로 전달되어 생기는 문제여서 시간이 지난 후 다시 chat 객체 가져오도록 수정하였습니다)
- 중간중간 로그 찍은 부분이 있는데, 내일 QA 후 정상동작 확인되면 삭제하겠습니다!