### PR TITLE
feat: 일대다 비공개 상담 결제 여부 처리하는 어드민 api 구현

### DIFF
--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface AdminService {
     List<ConsultGetUnpaidResponse> getUnpaidConsults();
 
-    void updateIsPaid(Long consultId);
+    void updateConsultIsPaid(Long consultId);
 
     List<CounselorGetProfileResponse> getPendingCounselors();
 
@@ -26,4 +26,6 @@ public interface AdminService {
     void updateSettlementComplete(Long paymentId);
 
     List<PostGetUnpaidPrivateResponse> getUnpaidPrivatePosts();
+
+    void updatePostIsPaid(Long postId);
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -3,6 +3,7 @@ package com.example.sharemind.admin.application;
 import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
 import com.example.sharemind.admin.dto.response.PaymentGetRefundWaitingResponse;
 import com.example.sharemind.admin.dto.response.PaymentGetSettlementOngoingResponse;
+import com.example.sharemind.admin.dto.response.PostGetUnpaidPrivateResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 
 import java.util.List;
@@ -23,4 +24,6 @@ public interface AdminService {
     List<PaymentGetSettlementOngoingResponse> getSettlementOngoingPayments();
 
     void updateSettlementComplete(Long paymentId);
+
+    List<PostGetUnpaidPrivateResponse> getUnpaidPrivatePosts();
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -28,6 +28,9 @@ import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.exception.PaymentErrorCode;
 import com.example.sharemind.payment.exception.PaymentException;
 import com.example.sharemind.post.application.PostService;
+import com.example.sharemind.post.domain.Post;
+import com.example.sharemind.post.exception.PostErrorCode;
+import com.example.sharemind.post.exception.PostException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,7 +58,7 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Transactional
-    public void updateIsPaid(Long consultId) {
+    public void updateConsultIsPaid(Long consultId) {
         Consult consult = consultService.getConsultByConsultId(consultId);
         if (consult.getPayment().getIsPaid()) {
             throw new ConsultException(ConsultErrorCode.CONSULT_ALREADY_PAID, consultId.toString());
@@ -148,5 +151,16 @@ public class AdminServiceImpl implements AdminService {
         return postService.getUnpaidPrivatePosts().stream()
                 .map(PostGetUnpaidPrivateResponse::of)
                 .toList();
+    }
+
+    @Transactional
+    @Override
+    public void updatePostIsPaid(Long postId) {
+        Post post = postService.getPostByPostId(postId);
+        if (post.getIsPaid()) {
+            throw new PostException(PostErrorCode.POST_ALREADY_PAID, postId.toString());
+        }
+
+        post.updateIsPaid();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.sharemind.admin.application;
 import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
 import com.example.sharemind.admin.dto.response.PaymentGetRefundWaitingResponse;
 import com.example.sharemind.admin.dto.response.PaymentGetSettlementOngoingResponse;
+import com.example.sharemind.admin.dto.response.PostGetUnpaidPrivateResponse;
 import com.example.sharemind.chat.application.ChatService;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.consult.application.ConsultService;
@@ -26,6 +27,7 @@ import com.example.sharemind.payment.content.PaymentCustomerStatus;
 import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.exception.PaymentErrorCode;
 import com.example.sharemind.payment.exception.PaymentException;
+import com.example.sharemind.post.application.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +45,7 @@ public class AdminServiceImpl implements AdminService {
     private final PaymentService paymentService;
     private final CounselorService counselorService;
     private final CustomerService customerService;
+    private final PostService postService;
 
     @Override
     public List<ConsultGetUnpaidResponse> getUnpaidConsults() {
@@ -138,5 +141,12 @@ public class AdminServiceImpl implements AdminService {
         }
 
         payment.updateCounselorStatusSettlementComplete();
+    }
+
+    @Override
+    public List<PostGetUnpaidPrivateResponse> getUnpaidPrivatePosts() {
+        return postService.getUnpaidPrivatePosts().stream()
+                .map(PostGetUnpaidPrivateResponse::of)
+                .toList();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/dto/response/PostGetUnpaidPrivateResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/PostGetUnpaidPrivateResponse.java
@@ -1,0 +1,46 @@
+package com.example.sharemind.admin.dto.response;
+
+import com.example.sharemind.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostGetUnpaidPrivateResponse {
+
+    @Schema(description = "일대다 상담 아이디")
+    private final Long postId;
+
+    @Schema(description = "구매자 닉네임")
+    private final String customerName;
+
+    @Schema(description = "상담료")
+    private final Long cost;
+
+    @Schema(description = "상담 공개 여부")
+    private final Boolean isPublic;
+
+    @Schema(description = "상담 신청 일시")
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public PostGetUnpaidPrivateResponse(Long postId, String customerName, Long cost,
+            Boolean isPublic, LocalDateTime createdAt) {
+        this.postId = postId;
+        this.customerName = customerName;
+        this.cost = cost;
+        this.isPublic = isPublic;
+        this.createdAt = createdAt;
+    }
+
+    public static PostGetUnpaidPrivateResponse of(Post post) {
+        return PostGetUnpaidPrivateResponse.builder()
+                .postId(post.getPostId())
+                .customerName(post.getCustomer().getNickname())
+                .cost(post.getCost())
+                .isPublic(post.getIsPublic())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -54,8 +54,8 @@ public class AdminController {
             @Parameter(name = "consultId", description = "상담 아이디")
     })
     @PatchMapping("/unpaid-consults/{consultId}")
-    public ResponseEntity<Void> updateIsPaid(@PathVariable Long consultId) {
-        adminService.updateIsPaid(consultId);
+    public ResponseEntity<Void> updateConsultIsPaid(@PathVariable Long consultId) {
+        adminService.updateConsultIsPaid(consultId);
         return ResponseEntity.ok().build();
     }
 
@@ -161,5 +161,26 @@ public class AdminController {
     @GetMapping("/unpaid-posts")
     public ResponseEntity<List<PostGetUnpaidPrivateResponse>> getUnpaidPrivatePosts() {
         return ResponseEntity.ok(adminService.getUnpaidPrivatePosts());
+    }
+
+    @Operation(summary = "일대다 비공개 상담 결제 여부 수정", description = "결제 여부(isPaid)가 false인 일대다 상담을 true로 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 결제 완료된 상담",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 일대다 상담 아이디로 요청됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "일대다 상담 아이디")
+    })
+    @PatchMapping("/unpaid-posts/{postId}")
+    public ResponseEntity<Void> updatePostIsPaid(@PathVariable Long postId) {
+        adminService.updatePostIsPaid(postId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -4,6 +4,7 @@ import com.example.sharemind.admin.application.AdminService;
 import com.example.sharemind.admin.dto.response.ConsultGetUnpaidResponse;
 import com.example.sharemind.admin.dto.response.PaymentGetRefundWaitingResponse;
 import com.example.sharemind.admin.dto.response.PaymentGetSettlementOngoingResponse;
+import com.example.sharemind.admin.dto.response.PostGetUnpaidPrivateResponse;
 import com.example.sharemind.counselor.dto.response.CounselorGetProfileResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +29,7 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    @Operation(summary = "미결제 상담 리스트 조회", description = "결제 여부(isPaid)가 false인 consult 리스트 조회")
+    @Operation(summary = "미결제 상담(편지/채팅) 리스트 조회", description = "결제 여부(isPaid)가 false인 consult 리스트 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
@@ -37,7 +38,7 @@ public class AdminController {
         return ResponseEntity.ok(adminService.getUnpaidConsults());
     }
 
-    @Operation(summary = "상담 결제 여부 수정", description = "결제 여부(isPaid)가 false인 consult를 true로 수정")
+    @Operation(summary = "상담(편지/채팅) 결제 여부 수정", description = "결제 여부(isPaid)가 false인 consult를 true로 수정")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "이미 결제 완료된 상담",
@@ -151,5 +152,14 @@ public class AdminController {
     public ResponseEntity<Void> updateSettlementComplete(@PathVariable Long paymentId) {
         adminService.updateSettlementComplete(paymentId);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "미결제 일대다 상담 리스트 조회", description = "결제 여부(isPaid)가 false인 일대다 상담 리스트 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/unpaid-posts")
+    public ResponseEntity<List<PostGetUnpaidPrivateResponse>> getUnpaidPrivatePosts() {
+        return ResponseEntity.ok(adminService.getUnpaidPrivatePosts());
     }
 }

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -10,6 +10,7 @@ import com.example.sharemind.email.exception.EmailException;
 import com.example.sharemind.letter.exception.LetterException;
 import com.example.sharemind.letterMessage.exception.LetterMessageException;
 import com.example.sharemind.payment.exception.PaymentException;
+import com.example.sharemind.post.exception.PostException;
 import com.example.sharemind.review.exception.ReviewException;
 import com.example.sharemind.wishList.exception.WishListException;
 import jakarta.validation.ConstraintViolationException;
@@ -103,6 +104,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(PaymentException.class)
     public ResponseEntity<CustomExceptionResponse> catchPaymentException(PaymentException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(PostException.class)
+    public ResponseEntity<CustomExceptionResponse> catchPostException(PostException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -1,8 +1,12 @@
 package com.example.sharemind.post.application;
 
+import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
+import java.util.List;
 
 public interface PostService {
 
     void createPost(PostCreateRequest postCreateRequest, Long customerId);
+
+    List<Post> getUnpaidPrivatePosts();
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -9,4 +9,6 @@ public interface PostService {
     void createPost(PostCreateRequest postCreateRequest, Long customerId);
 
     List<Post> getUnpaidPrivatePosts();
+
+    Post getPostByPostId(Long postId);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -2,7 +2,6 @@ package com.example.sharemind.post.application;
 
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
-import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +20,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public void createPost(PostCreateRequest postCreateRequest, Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
-        ConsultCategory consultCategory = ConsultCategory.getConsultCategoryByName(
-                postCreateRequest.getConsultCategory());
 
-        postRepository.save(postCreateRequest.toEntity(customer, consultCategory));
+        postRepository.save(postCreateRequest.toEntity(customer));
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -2,8 +2,10 @@ package com.example.sharemind.post.application;
 
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.repository.PostRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,5 +24,10 @@ public class PostServiceImpl implements PostService {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
 
         postRepository.save(postCreateRequest.toEntity(customer));
+    }
+
+    @Override
+    public List<Post> getUnpaidPrivatePosts() {
+        return postRepository.findAllByIsPaidIsFalseAndIsActivatedIsTrue();
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -4,6 +4,8 @@ import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
+import com.example.sharemind.post.exception.PostErrorCode;
+import com.example.sharemind.post.exception.PostException;
 import com.example.sharemind.post.repository.PostRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +31,11 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<Post> getUnpaidPrivatePosts() {
         return postRepository.findAllByIsPaidIsFalseAndIsActivatedIsTrue();
+    }
+
+    @Override
+    public Post getPostByPostId(Long postId) {
+        return postRepository.findByPostIdAndIsActivatedIsTrue(postId).orElseThrow(
+                () -> new PostException(PostErrorCode.POST_NOT_FOUND, postId.toString()));
     }
 }

--- a/src/main/java/com/example/sharemind/post/content/PostStatus.java
+++ b/src/main/java/com/example/sharemind/post/content/PostStatus.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PostStatus {
 
+    WAITING("상담 대기"),
     PROCEEDING("상담 진행 중"),
     COMPLETED("상담 마감"),
     REPORTED("신고로 인한 게시 중단");

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -73,6 +73,10 @@ public class Post extends BaseEntity {
         setIsPaid(isPublic);
     }
 
+    public void updateIsPaid() {
+        this.isPaid = true;
+    }
+
     private void setIsPaid(Boolean isPublic) {
         if (isPublic) {
             this.isPaid = true;

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -34,15 +34,13 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "customer_id")
     private Customer customer;
 
-    @Column(name = "consult_category", nullable = false)
+    @Column(name = "consult_category")
     @Enumerated(EnumType.STRING)
     private ConsultCategory consultCategory;
 
-    @Column(nullable = false)
     private String title;
 
     @Size(max = 1000, message = "상담 내용은 최대 1000자입니다.")
-    @Column(nullable = false)
     private String content;
 
     @Column(nullable = false)
@@ -65,15 +63,11 @@ public class Post extends BaseEntity {
     private Boolean isPaid;
 
     @Builder
-    public Post(Customer customer, ConsultCategory consultCategory, String title, String content,
-            Long cost, Boolean isPublic) {
+    public Post(Customer customer, Long cost, Boolean isPublic) {
         this.customer = customer;
-        this.consultCategory = consultCategory;
-        this.title = title;
-        this.content = content;
         this.cost = cost;
         this.isPublic = isPublic;
-        this.postStatus = PostStatus.PROCEEDING;
+        this.postStatus = PostStatus.WAITING;
         this.totalLike = 0L;
         this.totalComment = 0L;
         setIsPaid(isPublic);

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -76,6 +76,14 @@ public class Post extends BaseEntity {
         this.postStatus = PostStatus.PROCEEDING;
         this.totalLike = 0L;
         this.totalComment = 0L;
-        this.isPaid = false;
+        setIsPaid(isPublic);
+    }
+
+    private void setIsPaid(Boolean isPublic) {
+        if (isPublic) {
+            this.isPaid = true;
+        } else {
+            this.isPaid = false;
+        }
     }
 }

--- a/src/main/java/com/example/sharemind/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/sharemind/post/dto/request/PostCreateRequest.java
@@ -1,29 +1,13 @@
 package com.example.sharemind.post.dto.request;
 
 import com.example.sharemind.customer.domain.Customer;
-import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class PostCreateRequest {
-
-    @Schema(description = "선택한 상담 카테고리", example = "BOREDOM")
-    @NotBlank(message = "상담 카테고리는 공백일 수 없습니다.")
-    private String consultCategory;
-
-    @Schema(description = "상담 제목", example = "남자친구의 심리가 궁금해요")
-    @NotBlank(message = "상담 제목은 공백일 수 없습니다.")
-    private String title;
-
-    @Schema(description = "상담 내용", example = "안녕하세요 어쩌구저쩌구~")
-    @NotBlank(message = "상담 내용은 공백일 수 없습니다.")
-    @Size(max = 1000, message = "상담 내용은 최대 1000자입니다.")
-    private String content;
 
     @Schema(description = "상담료")
     @NotNull(message = "상담료는 공백일 수 없습니다.")
@@ -33,12 +17,9 @@ public class PostCreateRequest {
     @NotNull(message = "상담 공개 여부는 공백일 수 없습니다.")
     private Boolean isPublic;
 
-    public Post toEntity(Customer customer, ConsultCategory consultCategory) {
+    public Post toEntity(Customer customer) {
         return Post.builder()
                 .customer(customer)
-                .consultCategory(consultCategory)
-                .title(title)
-                .content(content)
                 .cost(cost)
                 .isPublic(isPublic)
                 .build();

--- a/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
+++ b/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.post.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorCode {
+
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "일대다 상담이 존재하지 않습니다."),
+    POST_ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제 완료된 일대다 상담입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/sharemind/post/exception/PostException.java
+++ b/src/main/java/com/example/sharemind/post/exception/PostException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.post.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PostException extends RuntimeException {
+
+    private final PostErrorCode errorCode;
+
+    public PostException(PostErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -28,15 +28,15 @@ public class PostController {
 
     private final PostService postService;
 
-    @Operation(summary = "일대다 상담 질문 생성", description = "일대다 상담 질문 생성")
+    @Operation(summary = "일대다 상담 질문 신청", description = "일대다 상담 질문 신청")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "201", description = "신청 성공"),
             @ApiResponse(responseCode = "400",
-                    description = "1. 요청 값 중 공백이 존재\n 2. 질문 글자수 초과",
+                    description = "요청 값 중 공백이 존재",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             ),
-            @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 회원\n 2. 존재하지 않는 상담 카테고리로 요청됨\n",
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             )

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -2,11 +2,14 @@ package com.example.sharemind.post.repository;
 
 import com.example.sharemind.post.domain.Post;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findByPostIdAndIsActivatedIsTrue(Long postId);
 
     List<Post> findAllByIsPaidIsFalseAndIsActivatedIsTrue();
 }

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -1,10 +1,12 @@
 package com.example.sharemind.post.repository;
 
 import com.example.sharemind.post.domain.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    List<Post> findAllByIsPaidIsFalseAndIsActivatedIsTrue();
 }


### PR DESCRIPTION
## 📄구현 내용
- 일대다 상담 공개/비공개 여부에 따라 isPaid 설정
- 미결제 일대다 비공개 상담 리스트 조회하는 api 구현
- 일대다 비공개 상담 결제 여부 수정하는 api 구현

## 📝기타 알림사항
- 상담(편지, 채팅)의 로직과 비슷하게 'isPaid false인 일대다 상담 생성 -> 결제 완료 변경 후 상담 작성 가능'의 형식으로 가기 위해 이전에 이미 머지했던 일대다 상담 생성 로직에서 질문 작성 관련 필드를 제외하였습니다.
  - qa 때 회의에서 이야기 나왔던대로 일대다 상담도 임시저장 기능이 도입되는 등 질문 작성쪽 로직이 간단하지는 않을 것 같아 이 pr 이후 다른 이슈로 분리하여 구현하도록 하겠습니다.
- 기억하실지 모르겠지만 이전에 responseDto도 builder 도입하는 식으로 리팩토링하면 좋겠다고 말씀드렸었는데 저희 리팩토링 기간을 따로 잡는 건 아마 먼 미래(...)가 될 것 같아 일단 당장 구현하는 것부터는 바로 builder 사용하는 식으로 구현하였습니다.
- 비슷한 맥락으로 이건 따로 말씀드린 적은 없는 부분인데, enum에서는 직접 생성자 작성하지 않고 requiredArgsConstructor 사용하는 쪽으로 리팩토링하고 싶었는데 이것도 위와 같은 사유로 이번 pr부터 당장 적용해보았습니다. 의견 부탁드립니다!