### PR TITLE
fix: 상담사 최신 채팅 3개 불러오는 부분 수정

### DIFF
--- a/src/main/java/com/example/sharemind/chat/application/ChatConsultService.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatConsultService.java
@@ -71,10 +71,10 @@ public class ChatConsultService {
         List<ChatLetterGetResponse> chatLetterGetResponses = new ArrayList<>();
 
         for (Chat chat : recentChats) {
-            chatLetterGetResponses.add(createChatInfoGetResponse(chat, customer.getCustomerId(), true));
+            chatLetterGetResponses.add(createChatInfoGetResponse(chat, customer.getCustomerId(), isCustomer));
         }
         for (Chat chat : waitingChats) {
-            chatLetterGetResponses.add(createChatInfoGetResponse(chat, customer.getCustomerId(), true));
+            chatLetterGetResponses.add(createChatInfoGetResponse(chat, customer.getCustomerId(), isCustomer));
         }
         chatLetterGetResponses.sort(Comparator.comparing(ChatLetterGetResponse::getLatestMessageUpdatedAt).reversed());
         return chatLetterGetResponses.stream().limit(count).toList();

--- a/src/main/java/com/example/sharemind/chatMessage/dto/response/ChatMessageGetResponse.java
+++ b/src/main/java/com/example/sharemind/chatMessage/dto/response/ChatMessageGetResponse.java
@@ -3,6 +3,7 @@ package com.example.sharemind.chatMessage.dto.response;
 import com.example.sharemind.chat.domain.Chat;
 import com.example.sharemind.chatMessage.content.ChatMessageStatus;
 import com.example.sharemind.chatMessage.domain.ChatMessage;
+import com.example.sharemind.chatMessage.utils.ChatMessageUtil;
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.global.utils.TimeUtil;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -52,9 +53,8 @@ public class ChatMessageGetResponse {
                     chatMessage.getIsCustomer(), chatMessage.getMessageStatus(), TimeUtil.getChatSendRequestLeftTime(chatMessage.getCreatedAt()));
         }
         if (chatMessage.getMessageStatus() == ChatMessageStatus.FINISH) {
-            String nickname = chat.getConsult().getCounselor().getNickname();
             return new ChatMessageGetResponse(consult.getCustomer().getNickname(), consult.getCounselor().getNickname(),
-                    chatMessage.getMessageId(), nickname + chatMessage.getContent(), chatMessage.getUpdatedAt(),
+                    chatMessage.getMessageId(), ChatMessageUtil.getFinishMessage(chat, chatMessage.getContent()), chatMessage.getUpdatedAt(),
                     chatMessage.getIsCustomer(), chatMessage.getMessageStatus(), null);
         }
         return new ChatMessageGetResponse(consult.getCustomer().getNickname(), consult.getCounselor().getNickname(),

--- a/src/main/java/com/example/sharemind/chatMessage/utils/ChatMessageUtil.java
+++ b/src/main/java/com/example/sharemind/chatMessage/utils/ChatMessageUtil.java
@@ -1,0 +1,10 @@
+package com.example.sharemind.chatMessage.utils;
+
+import com.example.sharemind.chat.domain.Chat;
+
+public class ChatMessageUtil {
+    public static String getFinishMessage(Chat chat, String content) {
+        String nickname = chat.getConsult().getCounselor().getNickname();
+        return nickname + content;
+    }
+}

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -2,7 +2,9 @@ package com.example.sharemind.global.dto.response;
 
 import com.example.sharemind.chat.content.ChatStatus;
 import com.example.sharemind.chat.domain.Chat;
+import com.example.sharemind.chatMessage.content.ChatMessageStatus;
 import com.example.sharemind.chatMessage.domain.ChatMessage;
+import com.example.sharemind.chatMessage.utils.ChatMessageUtil;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.global.utils.*;
 import com.example.sharemind.letter.dto.response.LetterGetResponse;
@@ -62,18 +64,22 @@ public class ChatLetterGetResponse {
     public static ChatLetterGetResponse of(String nickname, int unreadMessageCount, Chat chat, Counselor counselor,
                                            ChatMessage chatMessage) {
         Boolean reviewCompleted = null;
-        if (chat.getChatStatus().equals(ChatStatus.FINISH)) {
-            reviewCompleted = chat.getConsult().getReview().getIsCompleted();
-        }
+
         if (chatMessage == null) {
             return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
-                    chat.changeChatStatusForChatList().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()), nickname + "님께 고민내용을 남겨주세요. " + nickname + "님이 24시간 내에 채팅 요청을 드립니다.",
+                    chat.changeChatStatusForChatList().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()), counselor.getNickname() + "님께 고민내용을 남겨주세요. " + counselor.getNickname() + "님이 24시간 내에 채팅 요청을 드립니다.",
                     null, 0, reviewCompleted, chat.getConsult().getConsultId(),
                     IS_CHAT);
         }
+        String chatMessageContent = chatMessage.getContent();
+        if (chat.getChatStatus().equals(ChatStatus.FINISH)) {
+            reviewCompleted = chat.getConsult().getReview().getIsCompleted();
+        }
+        if (chatMessage.getMessageStatus().equals(ChatMessageStatus.FINISH))
+            chatMessageContent = ChatMessageUtil.getFinishMessage(chat, chatMessageContent);
         return new ChatLetterGetResponse(chat.getChatId(), counselor.getConsultStyle().getDisplayName(),
                 chat.changeChatStatusForChatList().getDisplayName(), nickname, TimeUtil.getUpdatedAt(chatMessage.getUpdatedAt()),
-                chatMessage.getContent(), chatMessage.getIsCustomer(), unreadMessageCount, reviewCompleted,
+                chatMessageContent, chatMessage.getIsCustomer(), unreadMessageCount, reviewCompleted,
                 chat.getConsult().getConsultId(), IS_CHAT);
     }
 }


### PR DESCRIPTION
## 📄구현 내용
- counselor 사이드에서 구매자 닉네임이 아니라 자기 자신의 닉네임이 들어오는 오류 수정
- 테스트해보니 마지막 메세지 상담사 닉네임 누락 문제가 있어 수정
- 채팅 메세지 없는 경우, 질문을 남겨달라고 할 때 상대방 닉네임 들어가는 거에서 상담사 닉네임 들어가는 것으로 바꾸었습니다.
(~님께 고민내용을 남겨주세요. ~nickname 님이 24시간 내에 채팅 요청을 드립니다. 부분)

## 📝기타 알림사항
- finish 메세지의 경우 상담사의 닉네임이 바뀔 수 있어서 닉네임은 따로 db에 저장하지 않았습니다! 이때문에 dto 전달 시 다시 닉네임을 붙여서 넘겨줘야하는 부분이 있어, 이걸 util로 빼보았습니다. 의견 주시면 감사하겠습니다!