### PR TITLE
refactor: 일대다 상담 질문 단건 조회 리팩토링

### DIFF
--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.example.sharemind.global.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -54,6 +55,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/counselors/all/**", "/api/v1/searchWords/results", "/api/v1/reviews/all/**").permitAll()
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/posts/{postId}").permitAll()
                                 .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/chats/counselors/**").hasRole(ROLE_COUNSELOR)

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -19,7 +19,7 @@ public interface PostService {
 
     PostGetIsSavedResponse getIsSaved(Long postId);
 
-    PostGetResponse getPost(Long postId);
+    PostGetResponse getPost(Long postId, Long customerId);
 
     List<PostGetResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -69,8 +69,15 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostGetResponse getPost(Long postId) {
-        return PostGetResponse.of(getPostByPostId(postId));
+    public PostGetResponse getPost(Long postId, Long customerId) {
+        Post post = getPostByPostId(postId);
+
+        if (customerId != 0) {
+            customerService.getCustomerByCustomerId(customerId);
+        }
+        post.checkReadAuthority(customerId);
+
+        return PostGetResponse.of(post);
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -75,7 +75,7 @@ public class PostServiceImpl implements PostService {
         if (customerId != 0) {
             customerService.getCustomerByCustomerId(customerId);
         }
-        post.checkReadAuthority(customerId);
+        post.checkReadAuthority(customerId); // TODO: 비공개 상담에 답변 단 판매자도 볼 수 있게 해야함
 
         return PostGetResponse.of(post);
     }

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -102,6 +102,12 @@ public class Post extends BaseEntity {
         }
     }
 
+    public void checkReadAuthority(Long customerId) {
+        if (!this.isPublic && !this.customer.getCustomerId().equals(customerId)) {
+            throw new PostException(PostErrorCode.POST_ACCESS_DENIED);
+        }
+    }
+
     private void setIsPaid(Boolean isPublic) {
         if (isPublic) {
             this.isPaid = true;

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetResponse.java
@@ -12,9 +12,6 @@ public class PostGetResponse {
     @Schema(description = "일대다 질문 아이디")
     private final Long postId;
 
-    @Schema(description = "상담 카테고리", example = "연애갈등")
-    private final String consultCategory;
-
     @Schema(description = "제목")
     private final String title;
 
@@ -30,34 +27,34 @@ public class PostGetResponse {
     @Schema(description = "스크랩 수")
     private final Long totalScrap;
 
+    @Schema(description = "답변 수")
+    private final Long totalComment;
+
     @Schema(description = "마지막 업데이트 일시", example = "8분 전")
     private final String updatedAt;
 
     @Builder
-    public PostGetResponse(Long postId, String consultCategory, String title, String content,
-            Boolean isPublic, Long totalLike, Long totalScrap, String updatedAt) {
+    public PostGetResponse(Long postId, String title, String content, Boolean isPublic,
+            Long totalLike, Long totalScrap, Long totalComment, String updatedAt) {
         this.postId = postId;
-        this.consultCategory = consultCategory;
         this.title = title;
         this.content = content;
         this.isPublic = isPublic;
         this.totalLike = totalLike;
         this.totalScrap = totalScrap;
+        this.totalComment = totalComment;
         this.updatedAt = updatedAt;
     }
 
     public static PostGetResponse of(Post post) {
-        String consultCategory = post.getConsultCategory() == null ? null
-                : post.getConsultCategory().getDisplayName();
-
         return PostGetResponse.builder()
                 .postId(post.getPostId())
-                .consultCategory(consultCategory)
                 .title(post.getTitle())
                 .content(post.getContent())
                 .isPublic(post.getIsPublic())
                 .totalLike(post.getTotalLike())
                 .totalScrap(post.getTotalScrap())
+                .totalComment(post.getTotalComment())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
                 .build();
     }
@@ -65,12 +62,12 @@ public class PostGetResponse {
     public static PostGetResponse ofIsNotCompleted(Post post) {
         return PostGetResponse.builder()
                 .postId(post.getPostId())
-                .consultCategory(null)
                 .title(null)
                 .content(null)
                 .isPublic(post.getIsPublic())
                 .totalLike(post.getTotalLike())
                 .totalScrap(post.getTotalScrap())
+                .totalComment(post.getTotalComment())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
                 .build();
     }

--- a/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
+++ b/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
@@ -11,6 +11,7 @@ public enum PostErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "일대다 상담이 존재하지 않습니다."),
     POST_ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제 완료된 일대다 상담입니다."),
     POST_MODIFY_DENIED(HttpStatus.FORBIDDEN, "일대다 상담 질문 작성 권한이 없습니다."),
+    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "일대다 상담 질문 접근 권한이 없습니다."),
     POST_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 일대다 상담 질문이 최종 제출되었습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -99,9 +99,14 @@ public class PostController {
         return ResponseEntity.ok(postService.getIsSaved(postId));
     }
 
-    @Operation(summary = "일대다 상담 질문 단건 조회", description = "일대다 상담 질문 단건 조회")
+    @Operation(summary = "일대다 상담 질문 단건 조회",
+            description = "- 일대다 상담 질문 단건 조회\n - 로그인한 사용자일 경우 헤더에 accessToken을 넣어주세요")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 상담(다른 회원의 비공개 상담 접근 시도)",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 일대다 질문 아이디로 요청됨",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
@@ -111,8 +116,10 @@ public class PostController {
             @Parameter(name = "postId", description = "일대다 질문 아이디")
     })
     @GetMapping("/{postId}")
-    public ResponseEntity<PostGetResponse> getPost(@PathVariable Long postId) {
-        return ResponseEntity.ok(postService.getPost(postId));
+    public ResponseEntity<PostGetResponse> getPost(@PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(postService.getPost(postId,
+                customUserDetails == null ? 0 : customUserDetails.getCustomer().getCustomerId()));
     }
 
     @Operation(summary = "구매자 본인 일대다 상담 리스트 조회", description = """


### PR DESCRIPTION
## 📄구현 내용
- response dto 필드 수정
  - 월요일 회의 내용 기반으로 상담 카테고리 필드 삭제, 답변 수 필드 추가
- 비공개 상담에 대한 접근 권한 검증 로직 추가
  - 단건 조회 시 비공개 상담은 구매자 본인과 답변 단 판매자들만 볼 수 있도록 검증 로직을 구현하려고 합니다.
  지금은 구매자 본인 검증 로직만 구현해두었고, 판매자 접근 검증은 Comment쪽 작업 중이실 것 같아 추후 추가하도록 하겠습니다.

## 📝기타 알림사항
