### PR TITLE
feat: 일대다 상담 미답변 질문 조회 및 답변 기능 구현

### DIFF
--- a/src/main/java/com/example/sharemind/comment/application/CommentService.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentService.java
@@ -6,7 +6,7 @@ import com.example.sharemind.comment.dto.response.CommentGetResponse;
 import java.util.List;
 
 public interface CommentService {
-    List<CommentGetResponse> getCommentsByPost(Long postId);
+    List<CommentGetResponse> getCommentsByPost(Long postId, Long customerId);
 
     void createComment(CommentCreateRequest commentCreateRequest, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentService.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentService.java
@@ -1,9 +1,12 @@
 package com.example.sharemind.comment.application;
 
+import com.example.sharemind.comment.dto.request.CommentCreateRequest;
 import com.example.sharemind.comment.dto.response.CommentGetResponse;
 
 import java.util.List;
 
 public interface CommentService {
     List<CommentGetResponse> getCommentsByPost(Long postId);
+
+    void createComment(CommentCreateRequest commentCreateRequest, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentService.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentService.java
@@ -1,4 +1,9 @@
 package com.example.sharemind.comment.application;
 
+import com.example.sharemind.comment.dto.response.CommentGetResponse;
+
+import java.util.List;
+
 public interface CommentService {
+    List<CommentGetResponse> getCommentsByPost(Long postId);
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentService.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentService.java
@@ -1,0 +1,4 @@
+package com.example.sharemind.comment.application;
+
+public interface CommentService {
+}

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -30,7 +30,7 @@ public class CommentServiceImpl implements CommentService {
     public List<CommentGetResponse> getCommentsByPost(Long postId) {
         Post post = postService.getProceedingPost(postId);
 
-        List<Comment> comments = commentRepository.findByPostAndActivatedIsTrue(post);
+        List<Comment> comments = commentRepository.findByPostAndIsActivatedIsTrue(post);
         return comments.stream()
                 .map(CommentGetResponse::of)
                 .toList();
@@ -44,7 +44,7 @@ public class CommentServiceImpl implements CommentService {
 
         commentRepository.save(commentCreateRequest.toEntity(post, counselor));
 
-        List<Comment> comments = commentRepository.findByPostAndActivatedIsTrue(post);
+        List<Comment> comments = commentRepository.findByPostAndIsActivatedIsTrue(post);
         if (comments.size() == MAX_COMMENTS)
             post.updatePostStatus(PostStatus.COMPLETED);
     }

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -1,0 +1,11 @@
+package com.example.sharemind.comment.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+}

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.sharemind.comment.repository.CommentRepository;
 import com.example.sharemind.counselor.application.CounselorService;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.post.application.PostService;
+import com.example.sharemind.post.content.PostStatus;
 import com.example.sharemind.post.domain.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,8 @@ public class CommentServiceImpl implements CommentService {
     private final CounselorService counselorService;
     private final CommentRepository commentRepository;
 
+    private static final Integer MAX_COMMENTS = 5;
+
     @Override
     public List<CommentGetResponse> getCommentsByPost(Long postId) {
         Post post = postService.getProceedingPost(postId);
@@ -38,6 +41,11 @@ public class CommentServiceImpl implements CommentService {
     public void createComment(CommentCreateRequest commentCreateRequest, Long customerId) {
         Post post = postService.getProceedingPost(commentCreateRequest.getPostId());
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
+
         commentRepository.save(commentCreateRequest.toEntity(post, counselor));
+
+        List<Comment> comments = commentRepository.findByPostAndActivatedIsTrue(post);
+        if (comments.size() == MAX_COMMENTS)
+            post.updatePostStatus(PostStatus.COMPLETED);
     }
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -1,8 +1,11 @@
 package com.example.sharemind.comment.application;
 
 import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.comment.dto.request.CommentCreateRequest;
 import com.example.sharemind.comment.dto.response.CommentGetResponse;
 import com.example.sharemind.comment.repository.CommentRepository;
+import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.post.application.PostService;
 import com.example.sharemind.post.domain.Post;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +20,24 @@ import java.util.List;
 public class CommentServiceImpl implements CommentService {
 
     private final PostService postService;
+    private final CounselorService counselorService;
     private final CommentRepository commentRepository;
 
     @Override
     public List<CommentGetResponse> getCommentsByPost(Long postId) {
-        Post post = postService.getPostByPostId(postId);
+        Post post = postService.getProceedingPost(postId);
 
         List<Comment> comments = commentRepository.findByPostAndActivatedIsTrue(post);
         return comments.stream()
                 .map(CommentGetResponse::of)
                 .toList();
+    }
+
+    @Transactional
+    @Override
+    public void createComment(CommentCreateRequest commentCreateRequest, Long customerId) {
+        Post post = postService.getProceedingPost(commentCreateRequest.getPostId());
+        Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
+        commentRepository.save(commentCreateRequest.toEntity(post, counselor));
     }
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -1,11 +1,31 @@
 package com.example.sharemind.comment.application;
 
+import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.comment.dto.response.CommentGetResponse;
+import com.example.sharemind.comment.repository.CommentRepository;
+import com.example.sharemind.post.application.PostService;
+import com.example.sharemind.post.domain.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
+
+    private final PostService postService;
+    private final CommentRepository commentRepository;
+
+    @Override
+    public List<CommentGetResponse> getCommentsByPost(Long postId) {
+        Post post = postService.getPostByPostId(postId);
+
+        List<Comment> comments = commentRepository.findByPostAndActivatedIsTrue(post);
+        return comments.stream()
+                .map(CommentGetResponse::of)
+                .toList();
+    }
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -30,7 +30,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public List<CommentGetResponse> getCommentsByPost(Long postId, Long customerId) {
-        Post post = checkAndGetCounselorPost(postId, customerId);
+        Post post = postService.checkAndGetCounselorPost(postId, customerId);
 
         List<Comment> comments = commentRepository.findByPostAndIsActivatedIsTrue(post);
         return comments.stream()
@@ -41,7 +41,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     @Override
     public void createComment(CommentCreateRequest commentCreateRequest, Long customerId) {
-        Post post = checkAndGetCounselorPost(commentCreateRequest.getPostId(), customerId);
+        Post post = postService.checkAndGetCounselorPost(commentCreateRequest.getPostId(), customerId);
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
 
         if (commentRepository.findByPostAndCounselorAndIsActivatedIsTrue(post, counselor) != null)
@@ -52,11 +52,5 @@ public class CommentServiceImpl implements CommentService {
         List<Comment> comments = commentRepository.findByPostAndIsActivatedIsTrue(post);
         if (comments.size() == MAX_COMMENTS)
             post.updatePostStatus(PostStatus.COMPLETED);
-    }
-
-    private Post checkAndGetCounselorPost(Long postId, Long customerId) {
-        if (postService.checkCounselorReadAuthority(postId, customerId))
-            return postService.getPostByPostId(postId);
-        return postService.getProceedingPost(postId);
     }
 }

--- a/src/main/java/com/example/sharemind/comment/domain/Comment.java
+++ b/src/main/java/com/example/sharemind/comment/domain/Comment.java
@@ -1,0 +1,38 @@
+package com.example.sharemind.comment.domain;
+
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.global.common.BaseEntity;
+import com.example.sharemind.post.domain.Post;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "counselor_id")
+    private Counselor counselor;
+
+    @Size(max = 500, message = "상담 답변은 최대 500자입니다.")
+    private String content;
+
+    @Column(name = "is_chosen", nullable = false)
+    private Boolean isChosen;
+
+    @Column(name = "total_like", nullable = false)
+    private Long totalLike;
+}

--- a/src/main/java/com/example/sharemind/comment/domain/Comment.java
+++ b/src/main/java/com/example/sharemind/comment/domain/Comment.java
@@ -6,6 +6,7 @@ import com.example.sharemind.post.domain.Post;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,4 +36,13 @@ public class Comment extends BaseEntity {
 
     @Column(name = "total_like", nullable = false)
     private Long totalLike;
+
+    @Builder
+    public Comment(Post post, Counselor counselor, String content) {
+        this.post = post;
+        this.counselor = counselor;
+        this.content = content;
+        isChosen = false;
+        totalLike = 0L;
+    }
 }

--- a/src/main/java/com/example/sharemind/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/example/sharemind/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,27 @@
+package com.example.sharemind.comment.dto.request;
+
+import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CommentCreateRequest {
+
+    @Schema(description = "상담 id")
+    @NotNull
+    private Long postId;
+
+    @Schema(description = "content")
+    private String content;
+
+    public Comment toEntity(Post post, Counselor counselor) {
+        return Comment.builder()
+                .post(post)
+                .counselor(counselor)
+                .content(getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/example/sharemind/comment/dto/request/CommentCreateRequest.java
@@ -21,7 +21,7 @@ public class CommentCreateRequest {
         return Comment.builder()
                 .post(post)
                 .counselor(counselor)
-                .content(getContent())
+                .content(content)
                 .build();
     }
 }

--- a/src/main/java/com/example/sharemind/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/example/sharemind/comment/dto/response/CommentGetResponse.java
@@ -18,15 +18,19 @@ public class CommentGetResponse {
     @Schema(description = "좋아요 수")
     private final Long totalLike;
 
-    @Schema(description = "마지막 업데이트 일시", example = "11시 10분")
+    @Schema(description = "마지막 업데이트 일시", example = "오전 11:10")
     private final String updatedAt;
 
+    @Schema(description =  "채택 여부", example="true")
+    private final Boolean isChosen;
+
     @Builder
-    public CommentGetResponse(String nickName, String content, Long totalLike, String updatedAt) {
+    public CommentGetResponse(String nickName, String content, Long totalLike, String updatedAt, Boolean isChosen) {
         this.nickName = nickName;
         this.content = content;
         this.totalLike = totalLike;
         this.updatedAt = updatedAt;
+        this.isChosen = isChosen;
     }
 
     public static CommentGetResponse of(Comment comment) {
@@ -35,6 +39,7 @@ public class CommentGetResponse {
                 .content(comment.getContent())
                 .totalLike(comment.getTotalLike())
                 .updatedAt(TimeUtil.getUpdatedAt(comment.getUpdatedAt()))
+                .isChosen(comment.getIsChosen())
                 .build();
     }
 }

--- a/src/main/java/com/example/sharemind/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/example/sharemind/comment/dto/response/CommentGetResponse.java
@@ -1,0 +1,40 @@
+package com.example.sharemind.comment.dto.response;
+
+import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.global.utils.TimeUtil;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentGetResponse {
+
+    @Schema(description = "상담사 닉네임")
+    private final String nickName;
+
+    @Schema(description = "답변 내용")
+    private final String content;
+
+    @Schema(description = "좋아요 수")
+    private final Long totalLike;
+
+    @Schema(description = "마지막 업데이트 일시", example = "11시 10분")
+    private final String updatedAt;
+
+    @Builder
+    public CommentGetResponse(String nickName, String content, Long totalLike, String updatedAt) {
+        this.nickName = nickName;
+        this.content = content;
+        this.totalLike = totalLike;
+        this.updatedAt = updatedAt;
+    }
+
+    public static CommentGetResponse of(Comment comment) {
+        return CommentGetResponse.builder()
+                .nickName(comment.getCounselor().getNickname())
+                .content(comment.getContent())
+                .totalLike(comment.getTotalLike())
+                .updatedAt(TimeUtil.getUpdatedAt(comment.getUpdatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/example/sharemind/comment/exception/CommentErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.sharemind.comment.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommentErrorCode {
+
+    COMMENT_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "상담사 당 댓글은 한 번만 작성할 수 있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    CommentErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/sharemind/comment/exception/CommentException.java
+++ b/src/main/java/com/example/sharemind/comment/exception/CommentException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.comment.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CommentException extends RuntimeException {
+
+    private final CommentErrorCode errorCode;
+
+    public CommentException(CommentErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -53,7 +53,7 @@ public class CommentController {
             - 상담사 사이드 일대다 상담 댓글 작성 API
             - 주소 형식: /api/v1/comments/counselors""")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "201", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담 2. 마감된 상담 중 상담사 본인이 답변을 작성하지 않은 상담 3. 이미 답변을 작성한 상담",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -53,7 +53,7 @@ public class CommentController {
             - 상담사 사이드 일대다 상담 댓글 작성 API
             - 주소 형식: /api/v1/comments/counselors""")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "조회 성공"),
+            @ApiResponse(responseCode = "201", description = "댓글 생성 성공"),
             @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담 2. 마감된 상담 중 상담사 본인이 답변을 작성하지 않은 상담 3. 이미 답변을 작성한 상담",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -1,13 +1,27 @@
 package com.example.sharemind.comment.presentation;
 
+import com.example.sharemind.comment.application.CommentService;
+import com.example.sharemind.comment.dto.response.CommentGetResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Comment Controller", description = "일대다 상담 답변 관리 컨트롤러")
 @RestController
 @RequestMapping("/api/v1/comments")
 @RequiredArgsConstructor
 public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/counselors/{postId}")
+    public ResponseEntity<List<CommentGetResponse>> getCounselorComments(@PathVariable Long postId) {
+        return ResponseEntity.ok(commentService.getCommentsByPost(postId));
+    }
 }

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -21,8 +21,9 @@ public class CommentController {
     private final CommentService commentService;
 
     @GetMapping("/counselors/{postId}")
-    public ResponseEntity<List<CommentGetResponse>> getCounselorComments(@PathVariable Long postId) {
-        return ResponseEntity.ok(commentService.getCommentsByPost(postId));
+    public ResponseEntity<List<CommentGetResponse>> getCounselorComments(@PathVariable Long postId,
+         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(commentService.getCommentsByPost(postId, customUserDetails.getCustomer().getCustomerId()));
     }
 
     @PostMapping("/counselors")

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -6,6 +6,7 @@ import com.example.sharemind.comment.dto.response.CommentGetResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +31,6 @@ public class CommentController {
     public ResponseEntity<Void> createComments(@RequestBody CommentCreateRequest commentCreateRequest,
            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         commentService.createComment(commentCreateRequest, customUserDetails.getCustomer().getCustomerId());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -1,0 +1,13 @@
+package com.example.sharemind.comment.presentation;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Comment Controller", description = "일대다 상담 답변 관리 컨트롤러")
+@RestController
+@RequestMapping("/api/v1/comments")
+@RequiredArgsConstructor
+public class CommentController {
+}

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -3,7 +3,15 @@ package com.example.sharemind.comment.presentation;
 import com.example.sharemind.comment.application.CommentService;
 import com.example.sharemind.comment.dto.request.CommentCreateRequest;
 import com.example.sharemind.comment.dto.response.CommentGetResponse;
+import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,12 +29,36 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    @Operation(summary = "상담사 사이드 일대다 상담 질문 단건의 댓글 조회", description = """
+            - 상담사가 일대다 상담 질문에 대답하기 위한 상담 질문 단건의 댓글 조회
+            - 주소 형식: /api/v1/comments/counselors/1""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담 2. 마감된 상담 중 상담사 본인이 답변을 작성하지 않은 상담",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = """
+                    - 일대다 상담 ID""")
+    })
     @GetMapping("/counselors/{postId}")
     public ResponseEntity<List<CommentGetResponse>> getCounselorComments(@PathVariable Long postId,
          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(commentService.getCommentsByPost(postId, customUserDetails.getCustomer().getCustomerId()));
     }
 
+    @Operation(summary = "상담사 사이드 일대다 상담 댓글 작성", description = """
+            - 상담사 사이드 일대다 상담 댓글 작성 API
+            - 주소 형식: /api/v1/comments/counselors""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담 2. 마감된 상담 중 상담사 본인이 답변을 작성하지 않은 상담 3. 이미 답변을 작성한 상담",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
     @PostMapping("/counselors")
     public ResponseEntity<Void> createComments(@RequestBody CommentCreateRequest commentCreateRequest,
            @AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -1,14 +1,14 @@
 package com.example.sharemind.comment.presentation;
 
 import com.example.sharemind.comment.application.CommentService;
+import com.example.sharemind.comment.dto.request.CommentCreateRequest;
 import com.example.sharemind.comment.dto.response.CommentGetResponse;
+import com.example.sharemind.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,5 +23,12 @@ public class CommentController {
     @GetMapping("/counselors/{postId}")
     public ResponseEntity<List<CommentGetResponse>> getCounselorComments(@PathVariable Long postId) {
         return ResponseEntity.ok(commentService.getCommentsByPost(postId));
+    }
+
+    @PostMapping("/counselors")
+    public ResponseEntity<Void> createComments(@RequestBody CommentCreateRequest commentCreateRequest,
+           @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        commentService.createComment(commentCreateRequest, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByPostAndActivatedIsTrue(Post post);
+    List<Comment> findByPostAndIsActivatedIsTrue(Post post);
 }

--- a/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.example.sharemind.comment.repository;
+
+import com.example.sharemind.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
@@ -1,10 +1,13 @@
 package com.example.sharemind.comment.repository;
 
 import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-
+    List<Comment> findByPostAndActivatedIsTrue(Post post);
 }

--- a/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.comment.repository;
 
 import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,6 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostAndIsActivatedIsTrue(Post post);
+
+    Comment findByPostAndCounselorAndIsActivatedIsTrue(Post post, Counselor counselor);
 }

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -61,6 +61,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/consults/counselors").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/payments/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/posts/counselors/**").hasRole(ROLE_COUNSELOR)
+                                .requestMatchers("/api/v1/comments/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers(("/api/v1/counselors/account")).hasRole(ROLE_COUNSELOR)
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/chatMessages/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/consults/counselors").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/payments/counselors/**").hasRole(ROLE_COUNSELOR)
+                                .requestMatchers("/api/v1/posts/counselors/**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers(("/api/v1/counselors/account")).hasRole(ROLE_COUNSELOR)
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -3,6 +3,7 @@ package com.example.sharemind.global.exception;
 import com.example.sharemind.auth.exception.AuthException;
 import com.example.sharemind.chat.exception.ChatException;
 import com.example.sharemind.chatMessage.exception.ChatMessageException;
+import com.example.sharemind.comment.exception.CommentException;
 import com.example.sharemind.consult.exception.ConsultException;
 import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.exception.CustomerException;
@@ -90,6 +91,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(ChatMessageException.class)
     public ResponseEntity<CustomExceptionResponse> catchChatMessageException(ChatMessageException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(CommentException.class)
+    public ResponseEntity<CustomExceptionResponse> catchCommentException(CommentException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -3,6 +3,7 @@ package com.example.sharemind.global.exception;
 import com.example.sharemind.auth.exception.AuthException;
 import com.example.sharemind.chat.exception.ChatException;
 import com.example.sharemind.chatMessage.exception.ChatMessageException;
+import com.example.sharemind.comment.exception.CommentException;
 import com.example.sharemind.consult.exception.ConsultException;
 import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.exception.CustomerException;
@@ -90,6 +91,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(ChatMessageException.class)
     public ResponseEntity<CustomExceptionResponse> catchChatMessageException(ChatMessageException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(CommentException.class)
+    public ResponseEntity<CustomExceptionResponse> catchCommentException(PostException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -27,9 +27,5 @@ public interface PostService {
 
     PostGetResponse getCounselorPostContent(Long postId, Long customerId);
 
-    Post getProceedingPost(Long postId);
-
     Post checkAndGetCounselorPost(Long postId, Long customerId);
-
-    Boolean checkCounselorReadAuthority(Long postId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -28,4 +28,6 @@ public interface PostService {
     PostGetResponse getCounselorPostContent(Long postId);
 
     Post getProceedingPost(Long postId);
+
+    Boolean checkCounselorReadAuthority(Long postId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -24,4 +24,6 @@ public interface PostService {
     List<PostGetResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
 
     List<Long> getRandomPosts();
+
+    PostGetResponse getCounselorPostContent(Long postId);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -3,6 +3,7 @@ package com.example.sharemind.post.application;
 import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
+
 import java.util.List;
 
 public interface PostService {
@@ -14,4 +15,6 @@ public interface PostService {
     Post getPostByPostId(Long postId);
 
     void updatePost(PostUpdateRequest postUpdateRequest, Long customerId);
+
+    List<Long> getRandomPosts();
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -26,4 +26,6 @@ public interface PostService {
     List<Long> getRandomPosts();
 
     PostGetResponse getCounselorPostContent(Long postId);
+
+    Post getProceedingPost(Long postId);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -25,9 +25,11 @@ public interface PostService {
 
     List<Long> getRandomPosts();
 
-    PostGetResponse getCounselorPostContent(Long postId);
+    PostGetResponse getCounselorPostContent(Long postId, Long customerId);
 
     Post getProceedingPost(Long postId);
+
+    Post checkAndGetCounselorPost(Long postId, Long customerId);
 
     Boolean checkCounselorReadAuthority(Long postId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -92,11 +92,17 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public PostGetResponse getCounselorPostContent(Long postId) {
+        Post post = getProceedingPost(postId);
+
+        return PostGetResponse.of(post);
+    }
+
+    @Override
+    public Post getProceedingPost(Long postId) {
         Post post = getPostByPostId(postId);
 
         checkPostProceeding(post);
-
-        return PostGetResponse.of(post);
+        return post;
     }
 
     private void checkPostProceeding(Post post) {

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -7,7 +7,6 @@ import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
-import com.example.sharemind.post.content.PostStatus;
 import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
@@ -111,11 +110,10 @@ public class PostServiceImpl implements PostService {
         return PostGetResponse.of(post);
     }
 
-    @Override
-    public Post getProceedingPost(Long postId) {
+    private Post getProceedingPost(Long postId) {
         Post post = getPostByPostId(postId);
 
-        checkPostProceeding(post);
+        post.checkPostProceeding();
         return post;
     }
 
@@ -126,8 +124,7 @@ public class PostServiceImpl implements PostService {
         return getProceedingPost(postId);
     }
 
-    @Override
-    public Boolean checkCounselorReadAuthority(Long postId, Long customerId){
+    private Boolean checkCounselorReadAuthority(Long postId, Long customerId){
         Post post = getPostByPostId(postId);
 
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
@@ -135,10 +132,5 @@ public class PostServiceImpl implements PostService {
         Comment comment = commentRepository.findByPostAndCounselorAndIsActivatedIsTrue(post, counselor);
 
         return comment != null;
-    }
-
-    private void checkPostProceeding(Post post) {
-        if (post.getPostStatus() != PostStatus.PROCEEDING)
-            throw new PostException(PostErrorCode.POST_NOT_PROCEEDING, post.getPostId().toString());
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -104,8 +104,9 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostGetResponse getCounselorPostContent(Long postId) {
-        Post post = getProceedingPost(postId);
+    public PostGetResponse getCounselorPostContent(Long postId, Long customerId) {
+
+        Post post = checkAndGetCounselorPost(postId, customerId);
 
         return PostGetResponse.of(post);
     }
@@ -116,6 +117,13 @@ public class PostServiceImpl implements PostService {
 
         checkPostProceeding(post);
         return post;
+    }
+
+    @Override
+    public Post checkAndGetCounselorPost(Long postId, Long customerId) {
+        if (checkCounselorReadAuthority(postId, customerId))
+            return getPostByPostId(postId);
+        return getProceedingPost(postId);
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.sharemind.post.application;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
+import com.example.sharemind.post.content.PostStatus;
 import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
@@ -87,5 +88,19 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<Long> getRandomPosts() {
         return postRepository.findRandomProceedingPostIds();
+    }
+
+    @Override
+    public PostGetResponse getCounselorPostContent(Long postId) {
+        Post post = getPostByPostId(postId);
+
+        checkPostProceeding(post);
+
+        return PostGetResponse.of(post);
+    }
+
+    private void checkPostProceeding(Post post) {
+        if (post.getPostStatus() != PostStatus.PROCEEDING)
+            throw new PostException(PostErrorCode.POST_NOT_PROCEEDING, post.getPostId().toString());
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -1,5 +1,9 @@
 package com.example.sharemind.post.application;
 
+import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.comment.repository.CommentRepository;
+import com.example.sharemind.counselor.application.CounselorService;
+import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
@@ -24,8 +28,10 @@ public class PostServiceImpl implements PostService {
 
     private static final int POST_CUSTOMER_PAGE_SIZE = 4;
 
-    private final PostRepository postRepository;
     private final CustomerService customerService;
+    private final CounselorService counselorService;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     @Override
@@ -110,6 +116,17 @@ public class PostServiceImpl implements PostService {
 
         checkPostProceeding(post);
         return post;
+    }
+
+    @Override
+    public Boolean checkCounselorReadAuthority(Long postId, Long customerId){
+        Post post = getPostByPostId(postId);
+
+        Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
+
+        Comment comment = commentRepository.findByPostAndCounselorAndIsActivatedIsTrue(post, counselor);
+
+        return comment != null;
     }
 
     private void checkPostProceeding(Post post) {

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -52,4 +52,9 @@ public class PostServiceImpl implements PostService {
         post.updatePost(consultCategory, postUpdateRequest.getTitle(),
                 postUpdateRequest.getContent(), postUpdateRequest.getIsCompleted(), customer);
     }
+
+    @Override
+    public List<Long> getRandomPosts() {
+        return postRepository.findRandomProceedingPostIds();
+    }
 }

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -87,6 +87,10 @@ public class Post extends BaseEntity {
         this.isPaid = true;
     }
 
+    public void updatePostStatus(PostStatus postStatus){
+        this.postStatus = postStatus;
+    }
+
     public void updatePost(ConsultCategory consultCategory, String title, String content,
             Boolean isCompleted, Customer customer) {
         checkUpdatability();

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -87,7 +87,7 @@ public class Post extends BaseEntity {
         this.isPaid = true;
     }
 
-    public void updatePostStatus(PostStatus postStatus){
+    public void updatePostStatus(PostStatus postStatus) {
         this.postStatus = postStatus;
     }
 
@@ -110,6 +110,11 @@ public class Post extends BaseEntity {
         if (!this.isPublic && !this.customer.getCustomerId().equals(customerId)) {
             throw new PostException(PostErrorCode.POST_ACCESS_DENIED);
         }
+    }
+
+    public void checkPostProceeding() {
+        if (this.getPostStatus() != PostStatus.PROCEEDING)
+            throw new PostException(PostErrorCode.POST_NOT_PROCEEDING, this.getPostId().toString());
     }
 
     private void setIsPaid(Boolean isPublic) {

--- a/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
+++ b/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
@@ -11,7 +11,8 @@ public enum PostErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "일대다 상담이 존재하지 않습니다."),
     POST_ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제 완료된 일대다 상담입니다."),
     POST_MODIFY_DENIED(HttpStatus.FORBIDDEN, "일대다 상담 질문 작성 권한이 없습니다."),
-    POST_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 일대다 상담 질문이 최종 제출되었습니다.");
+    POST_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 일대다 상담 질문이 최종 제출되었습니다."),
+    POST_NOT_PROCEEDING(HttpStatus.BAD_REQUEST, "진행중인 상담이 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -141,13 +141,35 @@ public class PostController {
                 customUserDetails.getCustomer().getCustomerId()));
     }
 
+    @Operation(summary = "상담사 랜덤 일대다 상담 ID 리스트 반환", description = """
+            - 상담사 일대다 상담 답변을 위한 진행중인 상담 ID 리스트를 랜덤으로 50개 반환하는 API
+            - 없을 경우 빈 리스트를 반환
+            - 주소 형식: /api/v1/posts/counselors/random""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
     @GetMapping("/counselors/random")
     public ResponseEntity<List<Long>> getRandomPosts() {
         return ResponseEntity.ok(postService.getRandomPosts());
     }
 
+    @Operation(summary = "상담사 사이드 일대다 상담 질문 단건 조회", description = """
+            - 상담사가 일대다 상담 질문에 대답하기 위한 상담 질문 단건 조회
+            - 주소 형식: /api/v1/posts/counselors/1""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담 2. 답변을 작성하지 않은 상담",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = """
+                    - 일대다 상담 ID""")
+    })
     @GetMapping("/counselors/{postId}")
-    public ResponseEntity<PostGetResponse> getPostInfo(@PathVariable Long postId) {
-        return ResponseEntity.ok(postService.getCounselorPostContent(postId));
+    public ResponseEntity<PostGetResponse> getPostInfo(@PathVariable Long postId,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(postService.getCounselorPostContent(postId, customUserDetails.getCustomer().getCustomerId()));
     }
 }

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -139,7 +139,7 @@ public class PostController {
         return ResponseEntity.ok(postService.getRandomPosts());
     }
 
-    @GetMapping("/counselors/contents/{postId}")
+    @GetMapping("/counselors/{postId}")
     public ResponseEntity<PostGetResponse> getPostInfo(@PathVariable Long postId) {
         return ResponseEntity.ok(postService.getCounselorPostContent(postId));
     }

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -16,11 +16,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Post Controller", description = "일대다 상담 질문 컨트롤러")
 @RestController
@@ -72,5 +70,10 @@ public class PostController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         postService.updatePost(postUpdateRequest, customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/counselors/random")
+    public ResponseEntity<List<Long>> getRandomPosts() {
+        return ResponseEntity.ok(postService.getRandomPosts());
     }
 }

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -138,4 +138,9 @@ public class PostController {
     public ResponseEntity<List<Long>> getRandomPosts() {
         return ResponseEntity.ok(postService.getRandomPosts());
     }
+
+    @GetMapping("/counselors/contents/{postId}")
+    public ResponseEntity<PostGetResponse> getPostInfo(@PathVariable Long postId) {
+        return ResponseEntity.ok(postService.getCounselorPostContent(postId));
+    }
 }

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -158,7 +158,7 @@ public class PostController {
             - 주소 형식: /api/v1/posts/counselors/1""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담 2. 답변을 작성하지 않은 상담",
+            @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담 2. 마감된 상담 중 상담사 본인이 답변을 작성하지 않은 상담",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
             )

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -4,6 +4,7 @@ import com.example.sharemind.post.domain.Post;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +13,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByPostIdAndIsActivatedIsTrue(Long postId);
 
     List<Post> findAllByIsPaidIsFalseAndIsActivatedIsTrue();
+
+    @Query(value = "SELECT post_id FROM post WHERE post_status = 'PROCEEDING' ORDER BY RAND() LIMIT 50", nativeQuery = true)
+    List<Long> findRandomProceedingPostIds();
 }


### PR DESCRIPTION
## 📄구현 내용
- 공개/비공개 일대다 상담 미답변 기능 질문 조회 기능 구현
- 공개/비공개 일대다 상담 미답변 답변 기능 구현

## 📝기타 알림사항
- comment 테이블 만들었습니다.
- 일대다 상담의 경우 상담을 넘기면 다시 돌아올 수 없다고 생각하여 임시저장 기능 구현하지 않았습니다.
- 24시간 이후 채팅을 앞으로 가져오는 로직에 대해 좀 더 생각해보고 해당 부분 리팩토링 진행하겠습니다ㅜㅜ~