### PR TITLE
feat: 구매자 공개상담 탭 api 구현

### DIFF
--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/posts/{postId}").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/posts/customers/public/**").permitAll()
                                 .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/chats/counselors/**").hasRole(ROLE_COUNSELOR)

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -6,6 +6,7 @@ import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.PostGetIsSavedResponse;
 import com.example.sharemind.post.dto.response.PostGetListResponse;
 import com.example.sharemind.post.dto.response.PostGetResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostService {
@@ -23,6 +24,8 @@ public interface PostService {
     PostGetResponse getPost(Long postId, Long customerId);
 
     List<PostGetListResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
+
+    List<PostGetListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime updatedAt);
 
     List<Long> getRandomPosts();
 

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -4,6 +4,7 @@ import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.PostGetIsSavedResponse;
+import com.example.sharemind.post.dto.response.PostGetListResponse;
 import com.example.sharemind.post.dto.response.PostGetResponse;
 import java.util.List;
 
@@ -21,7 +22,7 @@ public interface PostService {
 
     PostGetResponse getPost(Long postId, Long customerId);
 
-    List<PostGetResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
+    List<PostGetListResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
 
     List<Long> getRandomPosts();
 

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -5,6 +5,7 @@ import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.PostGetIsSavedResponse;
 import com.example.sharemind.post.dto.response.PostGetListResponse;
+import com.example.sharemind.post.dto.response.PostGetPopularityResponse;
 import com.example.sharemind.post.dto.response.PostGetResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,6 +27,8 @@ public interface PostService {
     List<PostGetListResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
 
     List<PostGetListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime updatedAt);
+
+    List<PostGetPopularityResponse> getPopularityPosts();
 
     List<Long> getRandomPosts();
 

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -26,7 +26,7 @@ public interface PostService {
 
     List<PostGetListResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
 
-    List<PostGetListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime updatedAt);
+    List<PostGetListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime finishedAt);
 
     List<PostGetPopularityResponse> getPopularityPosts();
 

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.PostGetIsSavedResponse;
+import com.example.sharemind.post.dto.response.PostGetListResponse;
 import com.example.sharemind.post.dto.response.PostGetResponse;
 import com.example.sharemind.post.exception.PostErrorCode;
 import com.example.sharemind.post.exception.PostException;
@@ -87,13 +88,13 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostGetResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId) {
+    public List<PostGetListResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
 
         return postRepository.findAllByCustomerAndIsActivatedIsTrue(customer, filter, postId,
                         POST_CUSTOMER_PAGE_SIZE).stream()
                 .map(post -> (post.getIsCompleted() != null && !post.getIsCompleted())
-                        ? PostGetResponse.ofIsNotCompleted(post) : PostGetResponse.of(post))
+                        ? PostGetListResponse.ofIsNotCompleted(post) : PostGetListResponse.of(post))
                 .toList();
     }
 

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -12,10 +12,12 @@ import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.PostGetIsSavedResponse;
 import com.example.sharemind.post.dto.response.PostGetListResponse;
+import com.example.sharemind.post.dto.response.PostGetPopularityResponse;
 import com.example.sharemind.post.dto.response.PostGetResponse;
 import com.example.sharemind.post.exception.PostErrorCode;
 import com.example.sharemind.post.exception.PostException;
 import com.example.sharemind.post.repository.PostRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostServiceImpl implements PostService {
 
     private static final int POST_CUSTOMER_PAGE_SIZE = 4;
+    private static final int POST_POPULARITY_SIZE = 3;
 
     private final CustomerService customerService;
     private final CounselorService counselorService;
@@ -104,8 +107,16 @@ public class PostServiceImpl implements PostService {
     public List<PostGetListResponse> getPublicPostsByCustomer(Long postId,
             LocalDateTime updatedAt) {
         return postRepository.findAllByIsPublicAndIsActivatedIsTrue(postId, updatedAt,
-                POST_CUSTOMER_PAGE_SIZE).stream()
+                        POST_CUSTOMER_PAGE_SIZE).stream()
                 .map(PostGetListResponse::of)
+                .toList();
+    }
+
+    @Override
+    public List<PostGetPopularityResponse> getPopularityPosts() {
+        return postRepository.findPopularityPosts(LocalDate.now().minusWeeks(1),
+                        POST_POPULARITY_SIZE).stream()
+                .map(PostGetPopularityResponse::of)
                 .toList();
     }
 

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -81,7 +81,7 @@ public class PostServiceImpl implements PostService {
         if (customerId != 0) {
             customerService.getCustomerByCustomerId(customerId);
         }
-        post.checkReadAuthority(customerId); // TODO: 비공개 상담에 답변 단 판매자도 볼 수 있게 해야함
+        post.checkReadAuthority(customerId);
 
         return PostGetResponse.of(post);
     }
@@ -104,17 +104,9 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public PostGetResponse getCounselorPostContent(Long postId, Long customerId) {
-
         Post post = checkAndGetCounselorPost(postId, customerId);
 
         return PostGetResponse.of(post);
-    }
-
-    private Post getProceedingPost(Long postId) {
-        Post post = getPostByPostId(postId);
-
-        post.checkPostProceeding();
-        return post;
     }
 
     @Override
@@ -132,5 +124,12 @@ public class PostServiceImpl implements PostService {
         Comment comment = commentRepository.findByPostAndCounselorAndIsActivatedIsTrue(post, counselor);
 
         return comment != null;
+    }
+
+    private Post getProceedingPost(Long postId) {
+        Post post = getPostByPostId(postId);
+
+        post.checkPostProceeding();
+        return post;
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -105,8 +105,8 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<PostGetListResponse> getPublicPostsByCustomer(Long postId,
-            LocalDateTime updatedAt) {
-        return postRepository.findAllByIsPublicAndIsActivatedIsTrue(postId, updatedAt,
+            LocalDateTime finishedAt) {
+        return postRepository.findAllByIsPublicAndIsActivatedIsTrue(postId, finishedAt,
                         POST_CUSTOMER_PAGE_SIZE).stream()
                 .map(PostGetListResponse::of)
                 .toList();

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -71,6 +72,9 @@ public class Post extends BaseEntity {
     @Column(name = "is_completed")
     private Boolean isCompleted;
 
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+
     @Builder
     public Post(Customer customer, Long cost, Boolean isPublic) {
         this.customer = customer;
@@ -89,6 +93,10 @@ public class Post extends BaseEntity {
 
     public void updatePostStatus(PostStatus postStatus) {
         this.postStatus = postStatus;
+
+        if (this.postStatus == PostStatus.COMPLETED) {
+            this.finishedAt = LocalDateTime.now();
+        }
     }
 
     public void updatePost(ConsultCategory consultCategory, String title, String content,

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
@@ -7,13 +7,10 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class PostGetResponse {
+public class PostGetListResponse {
 
     @Schema(description = "일대다 질문 아이디")
     private final Long postId;
-
-    @Schema(description = "상담 카테고리", example = "권태기")
-    private final String consultCategory;
 
     @Schema(description = "제목")
     private final String title;
@@ -30,31 +27,47 @@ public class PostGetResponse {
     @Schema(description = "스크랩 수")
     private final Long totalScrap;
 
+    @Schema(description = "답변 수")
+    private final Long totalComment;
+
     @Schema(description = "마지막 업데이트 일시", example = "8분 전")
     private final String updatedAt;
 
     @Builder
-    public PostGetResponse(Long postId, String consultCategory, String title, String content,
-            Boolean isPublic, Long totalLike, Long totalScrap, String updatedAt) {
+    public PostGetListResponse(Long postId, String title, String content, Boolean isPublic,
+            Long totalLike, Long totalScrap, Long totalComment, String updatedAt) {
         this.postId = postId;
-        this.consultCategory = consultCategory;
         this.title = title;
         this.content = content;
         this.isPublic = isPublic;
         this.totalLike = totalLike;
         this.totalScrap = totalScrap;
+        this.totalComment = totalComment;
         this.updatedAt = updatedAt;
     }
 
-    public static PostGetResponse of(Post post) {
-        return PostGetResponse.builder()
+    public static PostGetListResponse of(Post post) {
+        return PostGetListResponse.builder()
                 .postId(post.getPostId())
-                .consultCategory(post.getConsultCategory().getDisplayName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .isPublic(post.getIsPublic())
                 .totalLike(post.getTotalLike())
                 .totalScrap(post.getTotalScrap())
+                .totalComment(post.getTotalComment())
+                .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
+                .build();
+    }
+
+    public static PostGetListResponse ofIsNotCompleted(Post post) {
+        return PostGetListResponse.builder()
+                .postId(post.getPostId())
+                .title(null)
+                .content(null)
+                .isPublic(post.getIsPublic())
+                .totalLike(post.getTotalLike())
+                .totalScrap(post.getTotalScrap())
+                .totalComment(post.getTotalComment())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
                 .build();
     }

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
@@ -2,7 +2,9 @@ package com.example.sharemind.post.dto.response;
 
 import com.example.sharemind.global.utils.TimeUtil;
 import com.example.sharemind.post.domain.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -33,9 +35,14 @@ public class PostGetListResponse {
     @Schema(description = "마지막 업데이트 일시", example = "8분 전")
     private final String updatedAt;
 
+    @Schema(description = "페이지네이션 위한 업데이트 일시")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private final LocalDateTime updatedAtForPaging;
+
     @Builder
     public PostGetListResponse(Long postId, String title, String content, Boolean isPublic,
-            Long totalLike, Long totalScrap, Long totalComment, String updatedAt) {
+            Long totalLike, Long totalScrap, Long totalComment, String updatedAt,
+            LocalDateTime updatedAtForPaging) {
         this.postId = postId;
         this.title = title;
         this.content = content;
@@ -44,6 +51,7 @@ public class PostGetListResponse {
         this.totalScrap = totalScrap;
         this.totalComment = totalComment;
         this.updatedAt = updatedAt;
+        this.updatedAtForPaging = updatedAtForPaging;
     }
 
     public static PostGetListResponse of(Post post) {
@@ -56,6 +64,7 @@ public class PostGetListResponse {
                 .totalScrap(post.getTotalScrap())
                 .totalComment(post.getTotalComment())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
+                .updatedAtForPaging(post.getUpdatedAt())
                 .build();
     }
 
@@ -69,6 +78,7 @@ public class PostGetListResponse {
                 .totalScrap(post.getTotalScrap())
                 .totalComment(post.getTotalComment())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
+                .updatedAtForPaging(post.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
@@ -35,14 +35,14 @@ public class PostGetListResponse {
     @Schema(description = "마지막 업데이트 일시", example = "8분 전")
     private final String updatedAt;
 
-    @Schema(description = "페이지네이션 위한 업데이트 일시")
+    @Schema(description = "답변 완료 일시")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    private final LocalDateTime updatedAtForPaging;
+    private final LocalDateTime finishedAt;
 
     @Builder
     public PostGetListResponse(Long postId, String title, String content, Boolean isPublic,
             Long totalLike, Long totalScrap, Long totalComment, String updatedAt,
-            LocalDateTime updatedAtForPaging) {
+            LocalDateTime finishedAt) {
         this.postId = postId;
         this.title = title;
         this.content = content;
@@ -51,7 +51,7 @@ public class PostGetListResponse {
         this.totalScrap = totalScrap;
         this.totalComment = totalComment;
         this.updatedAt = updatedAt;
-        this.updatedAtForPaging = updatedAtForPaging;
+        this.finishedAt = finishedAt;
     }
 
     public static PostGetListResponse of(Post post) {
@@ -64,7 +64,7 @@ public class PostGetListResponse {
                 .totalScrap(post.getTotalScrap())
                 .totalComment(post.getTotalComment())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
-                .updatedAtForPaging(post.getUpdatedAt())
+                .finishedAt(post.getFinishedAt())
                 .build();
     }
 
@@ -78,7 +78,7 @@ public class PostGetListResponse {
                 .totalScrap(post.getTotalScrap())
                 .totalComment(post.getTotalComment())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))
-                .updatedAtForPaging(post.getUpdatedAt())
+                .finishedAt(post.getFinishedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetPopularityResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetPopularityResponse.java
@@ -1,0 +1,29 @@
+package com.example.sharemind.post.dto.response;
+
+import com.example.sharemind.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostGetPopularityResponse {
+
+    @Schema(description = "일대다 질문 아이디")
+    private final Long postId;
+
+    @Schema(description = "제목")
+    private final String title;
+
+    @Builder
+    public PostGetPopularityResponse(Long postId, String title) {
+        this.postId = postId;
+        this.title = title;
+    }
+
+    public static PostGetPopularityResponse of(Post post) {
+        return PostGetPopularityResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -6,6 +6,7 @@ import com.example.sharemind.post.application.PostService;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.PostGetIsSavedResponse;
+import com.example.sharemind.post.dto.response.PostGetListResponse;
 import com.example.sharemind.post.dto.response.PostGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -135,7 +136,7 @@ public class PostController {
                     2. 2번째 요청부터 postId는 직전 요청의 조회 결과 4개 중 마지막 postId""")
     })
     @GetMapping("/customers")
-    public ResponseEntity<List<PostGetResponse>> getPostsByCustomer(@RequestParam Boolean filter,
+    public ResponseEntity<List<PostGetListResponse>> getPostsByCustomer(@RequestParam Boolean filter,
             @RequestParam Long postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(postService.getPostsByCustomer(filter, postId,

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -7,6 +7,7 @@ import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.PostGetIsSavedResponse;
 import com.example.sharemind.post.dto.response.PostGetListResponse;
+import com.example.sharemind.post.dto.response.PostGetPopularityResponse;
 import com.example.sharemind.post.dto.response.PostGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -167,6 +168,16 @@ public class PostController {
             @RequestParam Long postId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime updatedAt) {
         return ResponseEntity.ok(postService.getPublicPostsByCustomer(postId, updatedAt));
+    }
+
+    @Operation(summary = "구매자 사이드 공개상담 탭 일대다 상담 리스트 인기순 조회", description = """
+            - 구매자 사이드의 공개상담 탭에서 답변 완료된 일대다 상담 질문 리스트 인기순 조회""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/customers/public/likes")
+    public ResponseEntity<List<PostGetPopularityResponse>> getPopularityPosts() {
+        return ResponseEntity.ok(postService.getPopularityPosts());
     }
 
     @Operation(summary = "상담사 랜덤 일대다 상담 ID 리스트 반환", description = """

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -149,25 +149,25 @@ public class PostController {
 
     @Operation(summary = "구매자 사이드 공개상담 탭 일대다 상담 리스트 기본순 조회", description = """
             - 구매자 사이드의 공개상담 탭에서 답변 완료된 일대다 상담 질문 리스트 기본순 조회
-            - 주소 형식: /api/v1/posts/customers/public?postId=0&updatedAt=2024-03-22T00:47:59""")
+            - 주소 형식: /api/v1/posts/customers/public?postId=0&finishedAt=2024-03-22T00:47:59""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     @Parameters({
             @Parameter(name = "postId", description = """
-                    - 조회 결과는 4개씩 반환하며, postId와 updatedAt으로 구분
+                    - 조회 결과는 4개씩 반환하며, postId와 finishedAt으로 구분
                     1. 최초 조회 요청이면 postId는 0
                     2. 2번째 요청부터 postId는 직전 요청의 조회 결과 4개 중 마지막 postId"""),
-            @Parameter(name = "updatedAt", description = """
+            @Parameter(name = "finishedAt", description = """
                     1. 최초 조회 요청이면 지금 시간
-                    2. 2번째 요청부터 updatedAt 직전 요청의 조회 결과 4개 중 마지막 updatedAtForPaging
+                    2. 2번째 요청부터 finishedAt 직전 요청의 조회 결과 4개 중 마지막 finishedAt
                     3. 형식 예시에 적어둔 것과 꼭 맞춰주셔야 합니다"""),
     })
     @GetMapping("/customers/public")
     public ResponseEntity<List<PostGetListResponse>> getPublicPostsByCustomer(
             @RequestParam Long postId,
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime updatedAt) {
-        return ResponseEntity.ok(postService.getPublicPostsByCustomer(postId, updatedAt));
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime finishedAt) {
+        return ResponseEntity.ok(postService.getPublicPostsByCustomer(postId, finishedAt));
     }
 
     @Operation(summary = "구매자 사이드 공개상담 탭 일대다 상담 리스트 인기순 조회", description = """

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -93,8 +93,9 @@ public class PostController {
         return ResponseEntity.ok(postService.getIsSaved(postId));
     }
 
-    @Operation(summary = "일대다 상담 질문 단건 조회",
-            description = "- 일대다 상담 질문 단건 조회\n - 로그인한 사용자일 경우 헤더에 accessToken을 넣어주세요")
+    @Operation(summary = "구매자&비로그인 사용자 일대다 상담 질문 단건 조회", description = """
+            - 구매자&비로그인 사용자 일대다 상담 질문 단건 조회
+            - 로그인한 사용자일 경우 헤더에 accessToken을 넣어주세요""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "접근 권한이 없는 상담(다른 회원의 비공개 상담 접근 시도)",

--- a/src/main/java/com/example/sharemind/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostCustomRepository.java
@@ -2,10 +2,14 @@ package com.example.sharemind.post.repository;
 
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.domain.Post;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostCustomRepository {
 
     List<Post> findAllByCustomerAndIsActivatedIsTrue(Customer customer, Boolean filter,
             Long postId, int size);
+
+    List<Post> findAllByIsPublicAndIsActivatedIsTrue(Long postId, LocalDateTime updatedAt,
+            int size);
 }

--- a/src/main/java/com/example/sharemind/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostCustomRepository.java
@@ -10,6 +10,6 @@ public interface PostCustomRepository {
     List<Post> findAllByCustomerAndIsActivatedIsTrue(Customer customer, Boolean filter,
             Long postId, int size);
 
-    List<Post> findAllByIsPublicAndIsActivatedIsTrue(Long postId, LocalDateTime updatedAt,
+    List<Post> findAllByIsPublicAndIsActivatedIsTrue(Long postId, LocalDateTime finishedAt,
             int size);
 }

--- a/src/main/java/com/example/sharemind/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostCustomRepositoryImpl.java
@@ -31,7 +31,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public List<Post> findAllByIsPublicAndIsActivatedIsTrue(Long postId, LocalDateTime updatedAt,
+    public List<Post> findAllByIsPublicAndIsActivatedIsTrue(Long postId, LocalDateTime finishedAt,
             int size) {
         return jpaQueryFactory
                 .selectFrom(post)
@@ -39,8 +39,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.isPublic.isTrue(),
                         post.postStatus.eq(PostStatus.COMPLETED),
                         post.isActivated.isTrue(),
-                        lessThanUpdatedAtAndPostId(postId, updatedAt)
-                ).orderBy(post.updatedAt.desc(), post.postId.desc()).limit(size).fetch();
+                        lessThanFinishedAtAndPostId(postId, finishedAt)
+                ).orderBy(post.finishedAt.desc(), post.postId.desc()).limit(size).fetch();
     }
 
     private BooleanExpression postStatusIn(Boolean filter) {
@@ -52,8 +52,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return postId != 0 ? post.postId.lt(postId) : null;
     }
 
-    private BooleanExpression lessThanUpdatedAtAndPostId(Long postId, LocalDateTime updatedAt) {
-        return postId != 0 ? post.updatedAt.lt(updatedAt)
-                .or(post.updatedAt.eq(updatedAt).and(post.postId.lt(postId))) : null;
+    private BooleanExpression lessThanFinishedAtAndPostId(Long postId, LocalDateTime finishedAt) {
+        return postId != 0 ? post.finishedAt.lt(finishedAt)
+                .or(post.finishedAt.eq(finishedAt).and(post.postId.lt(postId))) : null;
     }
 }

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.post.repository;
 
 import com.example.sharemind.post.domain.Post;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,14 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
 
     List<Post> findAllByIsPaidIsFalseAndIsActivatedIsTrue();
 
-    @Query(value = "SELECT post_id FROM post WHERE post_status = 'PROCEEDING' ORDER BY RAND() LIMIT 50", nativeQuery = true)
+    @Query(value = "SELECT * FROM post " +
+            "WHERE is_public = true AND post_status = 'COMPLETED' AND is_activated = true " +
+            "AND updated_at >= :weekAgo " +
+            "ORDER BY total_like DESC LIMIT :size", nativeQuery = true)
+    List<Post> findPopularityPosts(LocalDate weekAgo, int size);
+
+    @Query(value = "SELECT post_id FROM post "
+            + "WHERE post_status = 'PROCEEDING' "
+            + "ORDER BY RAND() LIMIT 50", nativeQuery = true)
     List<Long> findRandomProceedingPostIds();
 }


### PR DESCRIPTION
## 📄구현 내용
- 기본순 목록 조회
- 인기순 목록 조회

## 📝기타 알림사항
- 일대다 질문 단건 조회 response dto와 목록 조회 response dto를 분리하였습니다. 
필요한 값이 비슷해서 하나로 두었었는데, 기획 수정되다보니 조금씩 차이가 생기기도 했고 용도별로 분리하는 것이 더 적합한 구현이라고 생각했습니다.