### PR TITLE
feat: 일대다 상담 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/example/sharemind/comment/application/CommentService.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentService.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.comment.application;
 
+import com.example.sharemind.comment.domain.Comment;
 import com.example.sharemind.comment.dto.request.CommentCreateRequest;
 import com.example.sharemind.comment.dto.response.CommentGetResponse;
 
@@ -9,4 +10,6 @@ public interface CommentService {
     List<CommentGetResponse> getCommentsByPost(Long postId, Long customerId);
 
     void createComment(CommentCreateRequest commentCreateRequest, Long customerId);
+
+    Comment getCommentByCommentId(Long commentId);
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -6,8 +6,11 @@ import com.example.sharemind.comment.dto.response.CommentGetResponse;
 import com.example.sharemind.comment.exception.CommentErrorCode;
 import com.example.sharemind.comment.exception.CommentException;
 import com.example.sharemind.comment.repository.CommentRepository;
+import com.example.sharemind.commentLike.repository.CommentLikeRepository;
 import com.example.sharemind.counselor.application.CounselorService;
 import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.application.CustomerService;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.application.PostService;
 import com.example.sharemind.post.content.PostStatus;
 import com.example.sharemind.post.domain.Post;
@@ -26,15 +29,20 @@ public class CommentServiceImpl implements CommentService {
 
     private final PostService postService;
     private final CounselorService counselorService;
+    private final CustomerService customerService;
     private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
     @Override
     public List<CommentGetResponse> getCommentsByPost(Long postId, Long customerId) {
         Post post = postService.checkAndGetCounselorPost(postId, customerId);
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
 
         List<Comment> comments = commentRepository.findByPostAndIsActivatedIsTrue(post);
         return comments.stream()
-                .map(CommentGetResponse::of)
+                .map(comment -> CommentGetResponse.of(comment,
+                        commentLikeRepository.existsByCommentAndCustomerAndIsActivatedIsTrue(
+                                comment, customer)))
                 .toList();
     }
 

--- a/src/main/java/com/example/sharemind/comment/domain/Comment.java
+++ b/src/main/java/com/example/sharemind/comment/domain/Comment.java
@@ -45,4 +45,12 @@ public class Comment extends BaseEntity {
         isChosen = false;
         totalLike = 0L;
     }
+
+    public void increaseTotalLike() {
+        this.totalLike++;
+    }
+
+    public void decreaseTotalLike() {
+        this.totalLike--;
+    }
 }

--- a/src/main/java/com/example/sharemind/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/example/sharemind/comment/dto/response/CommentGetResponse.java
@@ -15,28 +15,34 @@ public class CommentGetResponse {
     @Schema(description = "답변 내용")
     private final String content;
 
+    @Schema(description = "조회한 회원의 좋아요 여부")
+    private final Boolean isLiked;
+
     @Schema(description = "좋아요 수")
     private final Long totalLike;
 
     @Schema(description = "마지막 업데이트 일시", example = "오전 11:10")
     private final String updatedAt;
 
-    @Schema(description =  "채택 여부", example="true")
+    @Schema(description = "채택 여부", example = "true")
     private final Boolean isChosen;
 
     @Builder
-    public CommentGetResponse(String nickName, String content, Long totalLike, String updatedAt, Boolean isChosen) {
+    public CommentGetResponse(String nickName, String content, Boolean isLiked, Long totalLike,
+            String updatedAt, Boolean isChosen) {
         this.nickName = nickName;
         this.content = content;
+        this.isLiked = isLiked;
         this.totalLike = totalLike;
         this.updatedAt = updatedAt;
         this.isChosen = isChosen;
     }
 
-    public static CommentGetResponse of(Comment comment) {
+    public static CommentGetResponse of(Comment comment, Boolean isLiked) {
         return CommentGetResponse.builder()
                 .nickName(comment.getCounselor().getNickname())
                 .content(comment.getContent())
+                .isLiked(isLiked)
                 .totalLike(comment.getTotalLike())
                 .updatedAt(TimeUtil.getUpdatedAt(comment.getUpdatedAt()))
                 .isChosen(comment.getIsChosen())

--- a/src/main/java/com/example/sharemind/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/example/sharemind/comment/exception/CommentErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CommentErrorCode {
 
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "일대다 상담 댓글이 존재하지 않습니다."),
     COMMENT_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "상담사 당 댓글은 한 번만 작성할 수 있습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/sharemind/comment/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package com.example.sharemind.comment.repository;
 import com.example.sharemind.comment.domain.Comment;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.post.domain.Post;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +11,10 @@ import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
     List<Comment> findByPostAndIsActivatedIsTrue(Post post);
 
     Comment findByPostAndCounselorAndIsActivatedIsTrue(Post post, Counselor counselor);
+
+    Optional<Comment> findByCommentIdAndIsActivatedIsTrue(Long commentId);
 }

--- a/src/main/java/com/example/sharemind/commentLike/application/CommentLikeService.java
+++ b/src/main/java/com/example/sharemind/commentLike/application/CommentLikeService.java
@@ -1,0 +1,6 @@
+package com.example.sharemind.commentLike.application;
+
+public interface CommentLikeService {
+
+    void createCommentLike(Long commentId, Long customerId);
+}

--- a/src/main/java/com/example/sharemind/commentLike/application/CommentLikeService.java
+++ b/src/main/java/com/example/sharemind/commentLike/application/CommentLikeService.java
@@ -3,4 +3,6 @@ package com.example.sharemind.commentLike.application;
 public interface CommentLikeService {
 
     void createCommentLike(Long commentId, Long customerId);
+
+    void deleteCommentLike(Long commentId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/commentLike/application/CommentLikeServiceImpl.java
+++ b/src/main/java/com/example/sharemind/commentLike/application/CommentLikeServiceImpl.java
@@ -1,0 +1,45 @@
+package com.example.sharemind.commentLike.application;
+
+import com.example.sharemind.comment.application.CommentService;
+import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.commentLike.domain.CommentLike;
+import com.example.sharemind.commentLike.exception.CommentLikeErrorCode;
+import com.example.sharemind.commentLike.exception.CommentLikeException;
+import com.example.sharemind.commentLike.repository.CommentLikeRepository;
+import com.example.sharemind.customer.application.CustomerService;
+import com.example.sharemind.customer.domain.Customer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentLikeServiceImpl implements CommentLikeService {
+
+    private final CustomerService customerService;
+    private final CommentService commentService;
+    private final CommentLikeRepository commentLikeRepository;
+
+    @Transactional
+    @Override
+    public void createCommentLike(Long commentId, Long customerId) {
+        Comment comment = commentService.getCommentByCommentId(commentId);
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+
+        if (commentLikeRepository.existsByCommentAndCustomer(comment, customer)) {
+            CommentLike commentLike = commentLikeRepository.findByCommentAndCustomer(comment,
+                    customer).orElseThrow(
+                    () -> new CommentLikeException(CommentLikeErrorCode.COMMENT_LIKE_NOT_FOUND));
+
+            commentLike.updateIsActivatedTrue();
+        } else {
+            CommentLike commentLike = CommentLike.builder()
+                    .comment(comment)
+                    .customer(customer)
+                    .build();
+
+            commentLikeRepository.save(commentLike);
+        }
+    }
+}

--- a/src/main/java/com/example/sharemind/commentLike/application/CommentLikeServiceImpl.java
+++ b/src/main/java/com/example/sharemind/commentLike/application/CommentLikeServiceImpl.java
@@ -42,4 +42,17 @@ public class CommentLikeServiceImpl implements CommentLikeService {
             commentLikeRepository.save(commentLike);
         }
     }
+
+    @Transactional
+    @Override
+    public void deleteCommentLike(Long commentId, Long customerId) {
+        Comment comment = commentService.getCommentByCommentId(commentId);
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+
+        CommentLike commentLike = commentLikeRepository.findByCommentAndCustomerAndIsActivatedIsTrue(
+                comment, customer).orElseThrow(
+                () -> new CommentLikeException(CommentLikeErrorCode.COMMENT_LIKE_NOT_FOUND));
+
+        commentLike.updateIsActivatedFalse();
+    }
 }

--- a/src/main/java/com/example/sharemind/commentLike/domain/CommentLike.java
+++ b/src/main/java/com/example/sharemind/commentLike/domain/CommentLike.java
@@ -1,0 +1,65 @@
+package com.example.sharemind.commentLike.domain;
+
+import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.commentLike.exception.CommentLikeErrorCode;
+import com.example.sharemind.commentLike.exception.CommentLikeException;
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class CommentLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_like_id")
+    private Long commentLikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Builder
+    public CommentLike(Customer customer, Comment comment) {
+        this.customer = customer;
+        this.comment = comment;
+
+        this.comment.increaseTotalLike();
+    }
+
+    public void updateIsActivatedTrue() {
+        checkIsActivatedFalse();
+
+        super.updateIsActivatedTrue();
+        this.comment.increaseTotalLike();
+    }
+
+    public void updateIsActivatedFalse() {
+        super.updateIsActivatedFalse();
+
+        this.comment.decreaseTotalLike();
+    }
+
+    private void checkIsActivatedFalse() {
+        if (this.isActivated()) {
+            throw new CommentLikeException(CommentLikeErrorCode.COMMENT_ALREADY_LIKED);
+        }
+    }
+}

--- a/src/main/java/com/example/sharemind/commentLike/exception/CommentLikeErrorCode.java
+++ b/src/main/java/com/example/sharemind/commentLike/exception/CommentLikeErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.commentLike.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentLikeErrorCode {
+
+    COMMENT_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "일대다 상담 댓글 좋아요 정보가 존재하지 않습니다."),
+    COMMENT_ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 일대다 상담 댓글입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/sharemind/commentLike/exception/CommentLikeException.java
+++ b/src/main/java/com/example/sharemind/commentLike/exception/CommentLikeException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.commentLike.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CommentLikeException extends RuntimeException {
+
+    private final CommentLikeErrorCode errorCode;
+
+    public CommentLikeException(CommentLikeErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/commentLike/presentation/CommentLikeController.java
+++ b/src/main/java/com/example/sharemind/commentLike/presentation/CommentLikeController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,5 +51,27 @@ public class CommentLikeController {
         commentLikeService.createCommentLike(commentId,
                 customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "일대다 상담 댓글 좋아요 취소", description = "일대다 상담 댓글 좋아요 취소")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "취소 성공"),
+            @ApiResponse(responseCode = "404", description = """
+                    1. 존재하지 않는 댓글
+                    2. 존재하지 않는 회원
+                    3. 존재하지 않는 좋아요""",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "commentId", description = "일대다 상담 댓글 아이디")
+    })
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteCommentLike(@PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        commentLikeService.deleteCommentLike(commentId,
+                customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/commentLike/presentation/CommentLikeController.java
+++ b/src/main/java/com/example/sharemind/commentLike/presentation/CommentLikeController.java
@@ -1,0 +1,54 @@
+package com.example.sharemind.commentLike.presentation;
+
+import com.example.sharemind.commentLike.application.CommentLikeService;
+import com.example.sharemind.global.exception.CustomExceptionResponse;
+import com.example.sharemind.global.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "CommentLike Controller", description = "일대다 상담 댓글 좋아요 컨트롤러")
+@RestController
+@RequestMapping("/api/v1/commentLikes")
+@RequiredArgsConstructor
+public class CommentLikeController {
+
+    private final CommentLikeService commentLikeService;
+
+    @Operation(summary = "일대다 상담 댓글 좋아요 생성", description = "일대다 상담 댓글 좋아요 생성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400",
+                    description = "이미 좋아요를 누른 댓글",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 댓글\n 2. 존재하지 않는 회원",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "commentId", description = "일대다 상담 댓글 아이디")
+    })
+    @PostMapping("/{commentId}")
+    public ResponseEntity<Void> createCommentLike(@PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        commentLikeService.createCommentLike(commentId,
+                customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/example/sharemind/commentLike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/example/sharemind/commentLike/repository/CommentLikeRepository.java
@@ -12,6 +12,8 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
 
     Boolean existsByCommentAndCustomer(Comment comment, Customer customer);
 
+    Boolean existsByCommentAndCustomerAndIsActivatedIsTrue(Comment comment, Customer customer);
+
     Optional<CommentLike> findByCommentAndCustomer(Comment comment, Customer customer);
 
     Optional<CommentLike> findByCommentAndCustomerAndIsActivatedIsTrue(Comment comment,

--- a/src/main/java/com/example/sharemind/commentLike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/example/sharemind/commentLike/repository/CommentLikeRepository.java
@@ -13,4 +13,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     Boolean existsByCommentAndCustomer(Comment comment, Customer customer);
 
     Optional<CommentLike> findByCommentAndCustomer(Comment comment, Customer customer);
+
+    Optional<CommentLike> findByCommentAndCustomerAndIsActivatedIsTrue(Comment comment,
+            Customer customer);
 }

--- a/src/main/java/com/example/sharemind/commentLike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/example/sharemind/commentLike/repository/CommentLikeRepository.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.commentLike.repository;
+
+import com.example.sharemind.comment.domain.Comment;
+import com.example.sharemind.commentLike.domain.CommentLike;
+import com.example.sharemind.customer.domain.Customer;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    Boolean existsByCommentAndCustomer(Comment comment, Customer customer);
+
+    Optional<CommentLike> findByCommentAndCustomer(Comment comment, Customer customer);
+}

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -12,6 +12,7 @@ import com.example.sharemind.letter.exception.LetterException;
 import com.example.sharemind.letterMessage.exception.LetterMessageException;
 import com.example.sharemind.payment.exception.PaymentException;
 import com.example.sharemind.post.exception.PostException;
+import com.example.sharemind.postLike.exception.PostLikeException;
 import com.example.sharemind.review.exception.ReviewException;
 import com.example.sharemind.wishList.exception.WishListException;
 import jakarta.validation.ConstraintViolationException;
@@ -119,6 +120,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(PostException.class)
     public ResponseEntity<CustomExceptionResponse> catchPostException(PostException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(PostLikeException.class)
+    public ResponseEntity<CustomExceptionResponse> catchPostLikeException(PostLikeException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -4,6 +4,7 @@ import com.example.sharemind.auth.exception.AuthException;
 import com.example.sharemind.chat.exception.ChatException;
 import com.example.sharemind.chatMessage.exception.ChatMessageException;
 import com.example.sharemind.comment.exception.CommentException;
+import com.example.sharemind.commentLike.exception.CommentLikeException;
 import com.example.sharemind.consult.exception.ConsultException;
 import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.customer.exception.CustomerException;
@@ -99,6 +100,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(CommentException.class)
     public ResponseEntity<CustomExceptionResponse> catchCommentException(CommentException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(CommentLikeException.class)
+    public ResponseEntity<CustomExceptionResponse> catchCommentLikeException(CommentLikeException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -26,7 +26,8 @@ public interface PostService {
 
     List<PostGetListResponse> getPostsByCustomer(Boolean filter, Long postId, Long customerId);
 
-    List<PostGetListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime finishedAt);
+    List<PostGetListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime finishedAt,
+            Long customerId);
 
     List<PostGetPopularityResponse> getPopularityPosts();
 

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -17,6 +17,7 @@ import com.example.sharemind.post.dto.response.PostGetResponse;
 import com.example.sharemind.post.exception.PostErrorCode;
 import com.example.sharemind.post.exception.PostException;
 import com.example.sharemind.post.repository.PostRepository;
+import com.example.sharemind.postLike.repository.PostLikeRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,11 +32,13 @@ public class PostServiceImpl implements PostService {
 
     private static final int POST_CUSTOMER_PAGE_SIZE = 4;
     private static final int POST_POPULARITY_SIZE = 3;
+    private static final Boolean POST_IS_NOT_LIKED = false;
 
     private final CustomerService customerService;
     private final CounselorService counselorService;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @Transactional
     @Override
@@ -84,11 +87,15 @@ public class PostServiceImpl implements PostService {
         Post post = getPostByPostId(postId);
 
         if (customerId != 0) {
-            customerService.getCustomerByCustomerId(customerId);
-        }
-        post.checkReadAuthority(customerId);
+            Customer customer = customerService.getCustomerByCustomerId(customerId);
 
-        return PostGetResponse.of(post);
+            post.checkReadAuthority(customerId);
+            return PostGetResponse.of(post,
+                    postLikeRepository.existsByPostAndCustomerAndIsActivatedIsTrue(post, customer));
+        }
+
+        post.checkReadAuthority(customerId);
+        return PostGetResponse.of(post, POST_IS_NOT_LIKED);
     }
 
     @Override
@@ -99,16 +106,29 @@ public class PostServiceImpl implements PostService {
         return postRepository.findAllByCustomerAndIsActivatedIsTrue(customer, filter, postId,
                         POST_CUSTOMER_PAGE_SIZE).stream()
                 .map(post -> (post.getIsCompleted() != null && !post.getIsCompleted())
-                        ? PostGetListResponse.ofIsNotCompleted(post) : PostGetListResponse.of(post))
+                        ? PostGetListResponse.ofIsNotCompleted(post) : PostGetListResponse.of(post,
+                        postLikeRepository.existsByPostAndCustomerAndIsActivatedIsTrue(post,
+                                customer)))
                 .toList();
     }
 
     @Override
-    public List<PostGetListResponse> getPublicPostsByCustomer(Long postId,
-            LocalDateTime finishedAt) {
+    public List<PostGetListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime finishedAt,
+            Long customerId) {
+        if (customerId != 0) {
+            Customer customer = customerService.getCustomerByCustomerId(customerId);
+
+            return postRepository.findAllByIsPublicAndIsActivatedIsTrue(postId, finishedAt,
+                            POST_CUSTOMER_PAGE_SIZE).stream()
+                    .map(post -> PostGetListResponse.of(post,
+                            postLikeRepository.existsByPostAndCustomerAndIsActivatedIsTrue(post,
+                                    customer)))
+                    .toList();
+        }
+
         return postRepository.findAllByIsPublicAndIsActivatedIsTrue(postId, finishedAt,
                         POST_CUSTOMER_PAGE_SIZE).stream()
-                .map(PostGetListResponse::of)
+                .map(post -> PostGetListResponse.of(post, POST_IS_NOT_LIKED))
                 .toList();
     }
 
@@ -129,7 +149,7 @@ public class PostServiceImpl implements PostService {
     public PostGetResponse getCounselorPostContent(Long postId, Long customerId) {
         Post post = checkAndGetCounselorPost(postId, customerId);
 
-        return PostGetResponse.of(post);
+        return PostGetResponse.of(post, POST_IS_NOT_LIKED);
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -99,6 +99,14 @@ public class Post extends BaseEntity {
         }
     }
 
+    public void increaseTotalLike() {
+        this.totalLike++;
+    }
+
+    public void decreaseTotalLike() {
+        this.totalLike--;
+    }
+
     public void updatePost(ConsultCategory consultCategory, String title, String content,
             Boolean isCompleted, Customer customer) {
         checkUpdatability();

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetListResponse.java
@@ -5,6 +5,7 @@ import com.example.sharemind.post.domain.Post;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,6 +23,9 @@ public class PostGetListResponse {
 
     @Schema(description = "공개/비공개 여부")
     private final Boolean isPublic;
+
+    @Schema(description = "조회한 회원의 좋아요 여부")
+    private final Boolean isLiked;
 
     @Schema(description = "좋아요 수")
     private final Long totalLike;
@@ -41,12 +45,13 @@ public class PostGetListResponse {
 
     @Builder
     public PostGetListResponse(Long postId, String title, String content, Boolean isPublic,
-            Long totalLike, Long totalScrap, Long totalComment, String updatedAt,
+            Boolean isLiked, Long totalLike, Long totalScrap, Long totalComment, String updatedAt,
             LocalDateTime finishedAt) {
         this.postId = postId;
         this.title = title;
         this.content = content;
         this.isPublic = isPublic;
+        this.isLiked = isLiked;
         this.totalLike = totalLike;
         this.totalScrap = totalScrap;
         this.totalComment = totalComment;
@@ -54,12 +59,13 @@ public class PostGetListResponse {
         this.finishedAt = finishedAt;
     }
 
-    public static PostGetListResponse of(Post post) {
+    public static PostGetListResponse of(Post post, Boolean isLiked) {
         return PostGetListResponse.builder()
                 .postId(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .isPublic(post.getIsPublic())
+                .isLiked(isLiked)
                 .totalLike(post.getTotalLike())
                 .totalScrap(post.getTotalScrap())
                 .totalComment(post.getTotalComment())
@@ -74,6 +80,7 @@ public class PostGetListResponse {
                 .title(null)
                 .content(null)
                 .isPublic(post.getIsPublic())
+                .isLiked(false)
                 .totalLike(post.getTotalLike())
                 .totalScrap(post.getTotalScrap())
                 .totalComment(post.getTotalComment())

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetResponse.java
@@ -24,6 +24,9 @@ public class PostGetResponse {
     @Schema(description = "공개/비공개 여부")
     private final Boolean isPublic;
 
+    @Schema(description = "조회한 회원의 좋아요 여부")
+    private final Boolean isLiked;
+
     @Schema(description = "좋아요 수")
     private final Long totalLike;
 
@@ -35,24 +38,26 @@ public class PostGetResponse {
 
     @Builder
     public PostGetResponse(Long postId, String consultCategory, String title, String content,
-            Boolean isPublic, Long totalLike, Long totalScrap, String updatedAt) {
+            Boolean isPublic, Boolean isLiked, Long totalLike, Long totalScrap, String updatedAt) {
         this.postId = postId;
         this.consultCategory = consultCategory;
         this.title = title;
         this.content = content;
         this.isPublic = isPublic;
+        this.isLiked = isLiked;
         this.totalLike = totalLike;
         this.totalScrap = totalScrap;
         this.updatedAt = updatedAt;
     }
 
-    public static PostGetResponse of(Post post) {
+    public static PostGetResponse of(Post post, Boolean isLiked) {
         return PostGetResponse.builder()
                 .postId(post.getPostId())
                 .consultCategory(post.getConsultCategory().getDisplayName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .isPublic(post.getIsPublic())
+                .isLiked(isLiked)
                 .totalLike(post.getTotalLike())
                 .totalScrap(post.getTotalScrap())
                 .updatedAt(TimeUtil.getUpdatedAt(post.getUpdatedAt()))

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -149,6 +149,7 @@ public class PostController {
 
     @Operation(summary = "구매자 사이드 공개상담 탭 일대다 상담 리스트 기본순 조회", description = """
             - 구매자 사이드의 공개상담 탭에서 답변 완료된 일대다 상담 질문 리스트 기본순 조회
+            - 로그인한 사용자일 경우 헤더에 accessToken을 넣어주세요
             - 주소 형식: /api/v1/posts/customers/public?postId=0&finishedAt=2024-03-22T00:47:59""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
@@ -166,8 +167,10 @@ public class PostController {
     @GetMapping("/customers/public")
     public ResponseEntity<List<PostGetListResponse>> getPublicPostsByCustomer(
             @RequestParam Long postId,
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime finishedAt) {
-        return ResponseEntity.ok(postService.getPublicPostsByCustomer(postId, finishedAt));
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime finishedAt,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(postService.getPublicPostsByCustomer(postId, finishedAt,
+                customUserDetails == null ? 0 : customUserDetails.getCustomer().getCustomerId()));
     }
 
     @Operation(summary = "구매자 사이드 공개상담 탭 일대다 상담 리스트 인기순 조회", description = """

--- a/src/main/java/com/example/sharemind/postLike/application/PostLikeService.java
+++ b/src/main/java/com/example/sharemind/postLike/application/PostLikeService.java
@@ -3,4 +3,6 @@ package com.example.sharemind.postLike.application;
 public interface PostLikeService {
 
     void createPostLike(Long postId, Long customerId);
+
+    void deletePostLike(Long postId, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/postLike/application/PostLikeService.java
+++ b/src/main/java/com/example/sharemind/postLike/application/PostLikeService.java
@@ -1,0 +1,6 @@
+package com.example.sharemind.postLike.application;
+
+public interface PostLikeService {
+
+    void createPostLike(Long postId, Long customerId);
+}

--- a/src/main/java/com/example/sharemind/postLike/application/PostLikeServiceImpl.java
+++ b/src/main/java/com/example/sharemind/postLike/application/PostLikeServiceImpl.java
@@ -21,6 +21,7 @@ public class PostLikeServiceImpl implements PostLikeService {
     private final PostService postService;
     private final PostLikeRepository postLikeRepository;
 
+    @Transactional
     @Override
     public void createPostLike(Long postId, Long customerId) {
         Post post = postService.getPostByPostId(postId);
@@ -40,5 +41,18 @@ public class PostLikeServiceImpl implements PostLikeService {
 
             postLikeRepository.save(postLike);
         }
+    }
+
+    @Transactional
+    @Override
+    public void deletePostLike(Long postId, Long customerId) {
+        Post post = postService.getPostByPostId(postId);
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+
+        PostLike postLike = postLikeRepository.findByPostAndCustomerAndIsActivatedIsTrue(post,
+                        customer)
+                .orElseThrow(() -> new PostLikeException(PostLikeErrorCode.POST_LIKE_NOT_FOUND));
+
+        postLike.updateIsActivatedFalse();
     }
 }

--- a/src/main/java/com/example/sharemind/postLike/application/PostLikeServiceImpl.java
+++ b/src/main/java/com/example/sharemind/postLike/application/PostLikeServiceImpl.java
@@ -1,0 +1,44 @@
+package com.example.sharemind.postLike.application;
+
+import com.example.sharemind.customer.application.CustomerService;
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.post.application.PostService;
+import com.example.sharemind.post.domain.Post;
+import com.example.sharemind.postLike.domain.PostLike;
+import com.example.sharemind.postLike.exception.PostLikeErrorCode;
+import com.example.sharemind.postLike.exception.PostLikeException;
+import com.example.sharemind.postLike.repository.PostLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostLikeServiceImpl implements PostLikeService {
+
+    private final CustomerService customerService;
+    private final PostService postService;
+    private final PostLikeRepository postLikeRepository;
+
+    @Override
+    public void createPostLike(Long postId, Long customerId) {
+        Post post = postService.getPostByPostId(postId);
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+
+        if (postLikeRepository.existsByPostAndCustomer(post, customer)) {
+            PostLike postLike = postLikeRepository.findByPostAndCustomer(post, customer)
+                    .orElseThrow(
+                            () -> new PostLikeException(PostLikeErrorCode.POST_LIKE_NOT_FOUND));
+
+            postLike.updateIsActivatedTrue();
+        } else {
+            PostLike postLike = PostLike.builder()
+                    .post(post)
+                    .customer(customer)
+                    .build();
+
+            postLikeRepository.save(postLike);
+        }
+    }
+}

--- a/src/main/java/com/example/sharemind/postLike/domain/PostLike.java
+++ b/src/main/java/com/example/sharemind/postLike/domain/PostLike.java
@@ -40,12 +40,15 @@ public class PostLike extends BaseEntity {
     public PostLike(Customer customer, Post post) {
         this.customer = customer;
         this.post = post;
+
+        this.post.increaseTotalLike();
     }
 
     public void updateIsActivatedTrue() {
         checkIsActivatedFalse();
 
         super.updateIsActivatedTrue();
+        this.post.increaseTotalLike();
     }
 
     private void checkIsActivatedFalse() {

--- a/src/main/java/com/example/sharemind/postLike/domain/PostLike.java
+++ b/src/main/java/com/example/sharemind/postLike/domain/PostLike.java
@@ -51,6 +51,12 @@ public class PostLike extends BaseEntity {
         this.post.increaseTotalLike();
     }
 
+    public void updateIsActivatedFalse() {
+        super.updateIsActivatedFalse();
+
+        this.post.decreaseTotalLike();
+    }
+
     private void checkIsActivatedFalse() {
         if (this.isActivated()) {
             throw new PostLikeException(PostLikeErrorCode.POST_ALREADY_LIKED);

--- a/src/main/java/com/example/sharemind/postLike/domain/PostLike.java
+++ b/src/main/java/com/example/sharemind/postLike/domain/PostLike.java
@@ -1,0 +1,56 @@
+package com.example.sharemind.postLike.domain;
+
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.global.common.BaseEntity;
+import com.example.sharemind.post.domain.Post;
+import com.example.sharemind.postLike.exception.PostLikeErrorCode;
+import com.example.sharemind.postLike.exception.PostLikeException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class PostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_like_id")
+    private Long postLikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Builder
+    public PostLike(Customer customer, Post post) {
+        this.customer = customer;
+        this.post = post;
+    }
+
+    public void updateIsActivatedTrue() {
+        checkIsActivatedFalse();
+
+        super.updateIsActivatedTrue();
+    }
+
+    private void checkIsActivatedFalse() {
+        if (this.isActivated()) {
+            throw new PostLikeException(PostLikeErrorCode.POST_ALREADY_LIKED);
+        }
+    }
+}

--- a/src/main/java/com/example/sharemind/postLike/exception/PostLikeErrorCode.java
+++ b/src/main/java/com/example/sharemind/postLike/exception/PostLikeErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.postLike.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostLikeErrorCode {
+
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "일대다 상담 질문 좋아요 정보가 존재하지 않습니다."),
+    POST_ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 일대다 상담 질문입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/sharemind/postLike/exception/PostLikeException.java
+++ b/src/main/java/com/example/sharemind/postLike/exception/PostLikeException.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.postLike.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PostLikeException extends RuntimeException {
+
+    private final PostLikeErrorCode errorCode;
+
+    public PostLikeException(PostLikeErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/postLike/presentation/PostLikeController.java
+++ b/src/main/java/com/example/sharemind/postLike/presentation/PostLikeController.java
@@ -1,0 +1,53 @@
+package com.example.sharemind.postLike.presentation;
+
+import com.example.sharemind.global.exception.CustomExceptionResponse;
+import com.example.sharemind.global.jwt.CustomUserDetails;
+import com.example.sharemind.postLike.application.PostLikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "PostLike Controller", description = "일대다 상담 질문 좋아요 컨트롤러")
+@RestController
+@RequestMapping("/api/v1/postLikes")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @Operation(summary = "일대다 상담 질문 좋아요 생성", description = "일대다 상담 질문 좋아요 생성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400",
+                    description = "이미 좋아요를 누른 질문",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 질문\n 2. 존재하지 않는 회원",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "일대다 질문 아이디")
+    })
+    @PostMapping("/{postId}")
+    public ResponseEntity<Void> createPostLike(@PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        postLikeService.createPostLike(postId, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/example/sharemind/postLike/presentation/PostLikeController.java
+++ b/src/main/java/com/example/sharemind/postLike/presentation/PostLikeController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,5 +50,26 @@ public class PostLikeController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         postLikeService.createPostLike(postId, customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "일대다 상담 질문 좋아요 취소", description = "일대다 상담 질문 좋아요 취소")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "취소 성공"),
+            @ApiResponse(responseCode = "404", description = """
+                    1. 존재하지 않는 질문
+                    2. 존재하지 않는 회원
+                    3. 존재하지 않는 좋아요""",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            )
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "일대다 질문 아이디")
+    })
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePostLike(@PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        postLikeService.deletePostLike(postId, customUserDetails.getCustomer().getCustomerId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/sharemind/postLike/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/sharemind/postLike/repository/PostLikeRepository.java
@@ -12,6 +12,8 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     Boolean existsByPostAndCustomer(Post post, Customer customer);
 
+    Boolean existsByPostAndCustomerAndIsActivatedIsTrue(Post post, Customer customer);
+
     Optional<PostLike> findByPostAndCustomer(Post post, Customer customer);
 
     Optional<PostLike> findByPostAndCustomerAndIsActivatedIsTrue(Post post, Customer customer);

--- a/src/main/java/com/example/sharemind/postLike/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/sharemind/postLike/repository/PostLikeRepository.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.postLike.repository;
+
+import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.post.domain.Post;
+import com.example.sharemind.postLike.domain.PostLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    Boolean existsByPostAndCustomer(Post post, Customer customer);
+
+    Optional<PostLike> findByPostAndCustomer(Post post, Customer customer);
+}

--- a/src/main/java/com/example/sharemind/postLike/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/sharemind/postLike/repository/PostLikeRepository.java
@@ -13,4 +13,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Boolean existsByPostAndCustomer(Post post, Customer customer);
 
     Optional<PostLike> findByPostAndCustomer(Post post, Customer customer);
+
+    Optional<PostLike> findByPostAndCustomerAndIsActivatedIsTrue(Post post, Customer customer);
 }


### PR DESCRIPTION
## 📄구현 내용
- 일대다 상담 질문 좋아요 api 구현
- 일대다 상담 질문 좋아요 취소 api 구현
- 일대다 상담 질문 좋아요 수 수정 로직 구현
- 일대다 상담 질문 좋아요 여부 dto에 추가
- 일대다 상담 답변 좋아요 api 구현
- 일대다 상담 답변 좋아요 취소 api 구현
- 일대다 상담 답변 좋아요 수 수정 로직 구현
- 일대다 상담 답변 좋아요 여부 dto에 추가

## 📝기타 알림사항
- Post, Comment의 response dto에서 좋아요 여부 필드 추가하는 과정에서 기존 방식대로 의존관계를 구성하면 서비스 레이어 간의 순환 참조 문제가 생깁니다. 
이전에 이런 경우에는 따로 서비스 클래스를 만들어주었는데, 좋아요의 경우 각각 질문/답변에 종속되는 도메인이라는 생각에 리포지토리로 의존관계를 설정해도 괜찮을 것 같아 그렇게 구현해보았습니다. 
+) 간단한 리포지토리 코드 한 줄만 필요하다는 점도 크게 작용했습니다.