### PR TITLE
feat: 구매자 사이드 일대다 상담 댓글 조회 구현

### DIFF
--- a/src/main/java/com/example/sharemind/comment/application/CommentService.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentService.java
@@ -7,7 +7,9 @@ import com.example.sharemind.comment.dto.response.CommentGetResponse;
 import java.util.List;
 
 public interface CommentService {
-    List<CommentGetResponse> getCommentsByPost(Long postId, Long customerId);
+    List<CommentGetResponse> getCounselorComments(Long postId, Long customerId);
+
+    List<CommentGetResponse> getCustomerComments(Long postId, Long customerId);
 
     void createComment(CommentCreateRequest commentCreateRequest, Long customerId);
 

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                                         "/counselor.html").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/posts/{postId}").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/posts/customers/public/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/comments/customers/{postId}").permitAll()
                                 .requestMatchers("/api/v1/admins/**").hasRole(ROLE_ADMIN)
                                 .requestMatchers("/api/v1/letters/counselors/**", "/api/v1/reviews/counselors**").hasRole(ROLE_COUNSELOR)
                                 .requestMatchers("/api/v1/chats/counselors/**").hasRole(ROLE_COUNSELOR)

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -85,16 +85,15 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostGetResponse getPost(Long postId, Long customerId) {
         Post post = getPostByPostId(postId);
+        post.checkReadAuthority(customerId);
 
         if (customerId != 0) {
             Customer customer = customerService.getCustomerByCustomerId(customerId);
 
-            post.checkReadAuthority(customerId);
             return PostGetResponse.of(post,
                     postLikeRepository.existsByPostAndCustomerAndIsActivatedIsTrue(post, customer));
         }
 
-        post.checkReadAuthority(customerId);
         return PostGetResponse.of(post, POST_IS_NOT_LIKED);
     }
 


### PR DESCRIPTION
## 📄구현 내용
- 구매자 사이드 일대다 상담 댓글 조회 구현

## 📝기타 알림사항
- 판매자 사이드 일대다 상담 댓글 조회 api 네이밍을 getCounselorComments로 해주셔서 구매자 사이드도 비슷한 느낌으로 가면 좋을 것 같아 구현하는 과정에서 이전에 작성해주신 서비스 레이어 메서드 네이밍 수정이 있었습니다.
혹시 이전의 네이밍이 더 마음에 드신다면 다시 바꿔두겠습니다!