### PR TITLE
feat: 편지/일대다 상담 임시저장 여부 조회 시 접근 권한 확인 로직 추가

### DIFF
--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageService.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageService.java
@@ -8,17 +8,23 @@ import com.example.sharemind.letterMessage.dto.response.LetterMessageGetRecentTy
 import com.example.sharemind.letterMessage.dto.response.LetterMessageGetResponse;
 
 public interface LetterMessageService {
-    LetterMessage createLetterMessage(LetterMessageCreateRequest letterMessageCreateRequest, Customer customer);
 
-    LetterMessage updateLetterMessage(LetterMessageUpdateRequest letterMessageUpdateRequest, Customer customer);
+    LetterMessage createLetterMessage(LetterMessageCreateRequest letterMessageCreateRequest,
+            Customer customer);
 
-    void createFirstQuestion(LetterMessageCreateFirstRequest letterMessageCreateFirstRequest, Customer customer);
+    LetterMessage updateLetterMessage(LetterMessageUpdateRequest letterMessageUpdateRequest,
+            Customer customer);
 
-    void updateFirstQuestion(LetterMessageUpdateFirstRequest letterMessageUpdateFirstRequest, Customer customer);
+    void createFirstQuestion(LetterMessageCreateFirstRequest letterMessageCreateFirstRequest,
+            Customer customer);
 
-    LetterMessageGetIsSavedResponse getIsSaved(Long letterId, String messageType);
+    void updateFirstQuestion(LetterMessageUpdateFirstRequest letterMessageUpdateFirstRequest,
+            Customer customer);
 
-    LetterMessageGetResponse getLetterMessage(Long letterId, String messageType, Boolean isCompleted, Customer customer);
+    LetterMessageGetIsSavedResponse getIsSaved(Long letterId, String messageType, Long customerId);
+
+    LetterMessageGetResponse getLetterMessage(Long letterId, String messageType,
+            Boolean isCompleted, Customer customer);
 
     LetterMessageGetRecentTypeResponse getRecentMessageType(Long letterId);
 }

--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LetterMessageServiceImpl implements LetterMessageService {
     private static final Boolean IS_NOT_COMPLETED = false;
 
+    private final CustomerService customerService;
     private final LetterService letterService;
     private final LetterMessageRepository letterMessageRepository;
 
@@ -85,6 +86,9 @@ public class LetterMessageServiceImpl implements LetterMessageService {
     @Override
     public LetterMessageGetIsSavedResponse getIsSaved(Long letterId, String type) {
         Letter letter = letterService.getLetterByLetterId(letterId);
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+        letter.checkReadAuthority(customer);
+
         LetterMessageType messageType = LetterMessageType.getLetterMessageTypeByName(type);
 
         if (letterMessageRepository.existsByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(

--- a/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
+++ b/src/main/java/com/example/sharemind/letterMessage/application/LetterMessageServiceImpl.java
@@ -101,10 +101,9 @@ public class LetterMessageServiceImpl implements LetterMessageService {
     @Override
     public LetterMessageGetIsSavedResponse getIsSaved(Long letterId, String type, Long customerId) {
         Letter letter = letterService.getLetterByLetterId(letterId);
-        Customer customer = customerService.getCustomerByCustomerId(customerId);
-        letter.checkReadAuthority(customer);
-
         LetterMessageType messageType = LetterMessageType.getLetterMessageTypeByName(type);
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
+        letter.checkWriteAuthority(messageType, customer);
 
         if (letterMessageRepository.existsByLetterAndMessageTypeAndIsCompletedAndIsActivatedIsTrue(
                 letter, messageType, IS_NOT_COMPLETED)) {

--- a/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
+++ b/src/main/java/com/example/sharemind/letterMessage/presentation/LetterMessageController.java
@@ -49,9 +49,11 @@ public class LetterMessageController {
             )
     })
     @PostMapping
-    public ResponseEntity<Void> createLetterMessage(@Valid @RequestBody LetterMessageCreateRequest letterMessageCreateRequest,
-                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        letterMessageService.createLetterMessage(letterMessageCreateRequest, customUserDetails.getCustomer());
+    public ResponseEntity<Void> createLetterMessage(
+            @Valid @RequestBody LetterMessageCreateRequest letterMessageCreateRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        letterMessageService.createLetterMessage(letterMessageCreateRequest,
+                customUserDetails.getCustomer());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -74,9 +76,11 @@ public class LetterMessageController {
             )
     })
     @PatchMapping
-    public ResponseEntity<Void> updateLetterMessage(@Valid @RequestBody LetterMessageUpdateRequest letterMessageUpdateRequest,
-                                                    @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        letterMessageService.updateLetterMessage(letterMessageUpdateRequest, customUserDetails.getCustomer());
+    public ResponseEntity<Void> updateLetterMessage(
+            @Valid @RequestBody LetterMessageUpdateRequest letterMessageUpdateRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        letterMessageService.updateLetterMessage(letterMessageUpdateRequest,
+                customUserDetails.getCustomer());
         return ResponseEntity.ok().build();
     }
 
@@ -99,9 +103,11 @@ public class LetterMessageController {
             )
     })
     @PostMapping("/first-question")
-    public ResponseEntity<Void> createFirstQuestion(@Valid @RequestBody LetterMessageCreateFirstRequest letterMessageCreateFirstRequest,
-                                                    @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        letterMessageService.createFirstQuestion(letterMessageCreateFirstRequest, customUserDetails.getCustomer());
+    public ResponseEntity<Void> createFirstQuestion(
+            @Valid @RequestBody LetterMessageCreateFirstRequest letterMessageCreateFirstRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        letterMessageService.createFirstQuestion(letterMessageCreateFirstRequest,
+                customUserDetails.getCustomer());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -124,9 +130,11 @@ public class LetterMessageController {
             )
     })
     @PatchMapping("/first-question")
-    public ResponseEntity<Void> updateFirstQuestion(@Valid @RequestBody LetterMessageUpdateFirstRequest letterMessageUpdateFirstRequest,
-                                                    @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        letterMessageService.updateFirstQuestion(letterMessageUpdateFirstRequest, customUserDetails.getCustomer());
+    public ResponseEntity<Void> updateFirstQuestion(
+            @Valid @RequestBody LetterMessageUpdateFirstRequest letterMessageUpdateFirstRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        letterMessageService.updateFirstQuestion(letterMessageUpdateFirstRequest,
+                customUserDetails.getCustomer());
         return ResponseEntity.ok().build();
     }
 
@@ -149,8 +157,11 @@ public class LetterMessageController {
             @Parameter(name = "messageType", description = "메시지 유형")
     })
     @GetMapping("/drafts/{letterId}")
-    public ResponseEntity<LetterMessageGetIsSavedResponse> getIsSaved(@PathVariable Long letterId, @RequestParam String messageType) {
-        return ResponseEntity.ok(letterMessageService.getIsSaved(letterId, messageType));
+    public ResponseEntity<LetterMessageGetIsSavedResponse> getIsSaved(@PathVariable Long letterId,
+            @RequestParam String messageType,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(letterMessageService.getIsSaved(letterId, messageType,
+                customUserDetails.getCustomer().getCustomerId()));
     }
 
     @Operation(summary = "메시지 조회",
@@ -170,9 +181,11 @@ public class LetterMessageController {
     })
     @GetMapping("/{letterId}")
     public ResponseEntity<LetterMessageGetResponse> getLetterMessage(@PathVariable Long letterId,
-                                                                     @RequestParam String messageType, @RequestParam Boolean isCompleted,
-                                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.ok(letterMessageService.getLetterMessage(letterId, messageType, isCompleted, customUserDetails.getCustomer()));
+            @RequestParam String messageType, @RequestParam Boolean isCompleted,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(
+                letterMessageService.getLetterMessage(letterId, messageType, isCompleted,
+                        customUserDetails.getCustomer()));
     }
 
     @Operation(summary = "편지 진행 상태 조회",
@@ -188,7 +201,8 @@ public class LetterMessageController {
             @Parameter(name = "letterId", description = "편지 아이디")
     })
     @GetMapping("/recent-type/{letterId}")
-    public ResponseEntity<LetterMessageGetRecentTypeResponse> getRecentMessageType(@PathVariable Long letterId) {
+    public ResponseEntity<LetterMessageGetRecentTypeResponse> getRecentMessageType(
+            @PathVariable Long letterId) {
         return ResponseEntity.ok(letterMessageService.getRecentMessageType(letterId));
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -18,7 +18,7 @@ public interface PostService {
 
     void updatePost(PostUpdateRequest postUpdateRequest, Long customerId);
 
-    PostGetIsSavedResponse getIsSaved(Long postId);
+    PostGetIsSavedResponse getIsSaved(Long postId, Long customerId);
 
     PostGetResponse getPost(Long postId, Long customerId);
 

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -76,8 +76,10 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public PostGetIsSavedResponse getIsSaved(Long postId) {
+    public PostGetIsSavedResponse getIsSaved(Long postId, Long customerId) {
+        Customer customer = customerService.getCustomerByCustomerId(customerId);
         Post post = getPostByPostId(postId);
+        post.checkWriteAuthority(customer);
 
         if ((post.getIsCompleted() != null) && !post.getIsCompleted()) {
             return PostGetIsSavedResponse.of(post);

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -152,6 +152,12 @@ public class Post extends BaseEntity {
         }
     }
 
+    public void checkWriteAuthority(Customer customer) {
+        if (!customer.getCustomerId().equals(this.customer.getCustomerId())) {
+            throw new PostException(PostErrorCode.POST_MODIFY_DENIED);
+        }
+    }
+
     public void checkPostProceeding() {
         if (this.getPostStatus() != PostStatus.PROCEEDING)
             throw new PostException(PostErrorCode.POST_NOT_PROCEEDING, this.getPostId().toString());
@@ -162,12 +168,6 @@ public class Post extends BaseEntity {
             this.isPaid = true;
         } else {
             this.isPaid = false;
-        }
-    }
-
-    private void checkWriteAuthority(Customer customer) {
-        if (!customer.getCustomerId().equals(this.customer.getCustomerId())) {
-            throw new PostException(PostErrorCode.POST_MODIFY_DENIED);
         }
     }
 

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -80,7 +80,13 @@ public class PostController {
     @Operation(summary = "일대다 상담 질문 임시저장 내용 존재 여부 조회",
             description = "임시저장 내용 존재 여부 조회")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공(임시저장 내용 존재하지 않으면 수정일시는 null로 반환됨)"),
+            @ApiResponse(responseCode = "200",
+                    description = "조회 성공(임시저장 내용 존재하지 않으면 수정일시는 null로 반환됨)"),
+            @ApiResponse(responseCode = "403",
+                    description = "접근 권한이 없는 질문에 대한 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionResponse.class))
+            ),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 일대다 질문 아이디로 요청됨",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = CustomExceptionResponse.class))
@@ -90,8 +96,10 @@ public class PostController {
             @Parameter(name = "postId", description = "일대다 질문 아이디")
     })
     @GetMapping("/drafts/{postId}")
-    public ResponseEntity<PostGetIsSavedResponse> getIsSaved(@PathVariable Long postId) {
-        return ResponseEntity.ok(postService.getIsSaved(postId));
+    public ResponseEntity<PostGetIsSavedResponse> getIsSaved(@PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(
+                postService.getIsSaved(postId, customUserDetails.getCustomer().getCustomerId()));
     }
 
     @Operation(summary = "구매자&비로그인 사용자 일대다 상담 질문 단건 조회", description = """


### PR DESCRIPTION
## 📄구현 내용
- Resolved #162 
- 편지 메시지 임시저장 여부 조회 시 접근 권한 확인 로직 추가
- 일대다 상담 질문 임시저장 여부 조회 시 접근 권한 확인 로직 추가

## 📝기타 알림사항
- 처음엔 checkReadAuthority로 권한 확인하려고 하였는데, 수정 권한이 있는 사용자만이 임시저장 여부를 확인할 수 있어야겠다는 생각이 들어 checkWriteAuthority로 확인하도록 로직 구성하였습니다
- 오랜만에 letterMessageService쪽 들어가니 거슬리는 코드가 너무 많네요...ㅠㅠㅠ(일단 전부 authenticationPrinicipal로 customer를 받아오고 있다는 점이...) 빠른 시일 내에 리팩토링이 필요하겠습니다...
