### PR TITLE
feat: 공개 상담 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -7,7 +7,7 @@ import com.example.sharemind.counselor.dto.request.CounselorUpdateAccountRequest
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
 import com.example.sharemind.counselor.dto.response.*;
 import com.example.sharemind.customer.domain.Customer;
-import com.example.sharemind.searchWord.dto.request.SearchWordFindRequest;
+import com.example.sharemind.searchWord.dto.request.SearchWordCounselorFindRequest;
 
 import com.example.sharemind.wishList.dto.request.WishListGetRequest;
 
@@ -31,7 +31,7 @@ public interface CounselorService {
 
     List<Counselor> getEvaluationPendingConsults();
 
-    List<Counselor> getCounselorByWordWithPagination(SearchWordFindRequest searchWordFindRequest,
+    List<Counselor> getCounselorByWordWithPagination(SearchWordCounselorFindRequest searchWordCounselorFindRequest,
                                                      String sortType);
 
     CounselorGetInfoResponse getCounselorMyInfo(Long customerId);

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -19,7 +19,7 @@ import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.global.content.ConsultType;
-import com.example.sharemind.searchWord.dto.request.SearchWordFindRequest;
+import com.example.sharemind.searchWord.dto.request.SearchWordCounselorFindRequest;
 import com.example.sharemind.wishList.application.WishListCounselorService;
 import com.example.sharemind.wishList.domain.WishList;
 import com.example.sharemind.wishList.dto.request.WishListGetRequest;
@@ -185,12 +185,13 @@ public class CounselorServiceImpl implements CounselorService {
     }
 
     @Override
-    public List<Counselor> getCounselorByWordWithPagination(SearchWordFindRequest searchWordFindRequest,
-                                                            String sortType) {
+    public List<Counselor> getCounselorByWordWithPagination(
+            SearchWordCounselorFindRequest searchWordCounselorFindRequest,
+            String sortType) {
         String sortColumn = getCounselorSortColumn(sortType);
-        Pageable pageable = PageRequest.of(searchWordFindRequest.getIndex(), COUNSELOR_PAGE,
+        Pageable pageable = PageRequest.of(searchWordCounselorFindRequest.getIndex(), COUNSELOR_PAGE,
                 Sort.by(sortColumn).descending());
-        Page<Counselor> page = counselorRepository.findByWordAndLevelAndStatus(searchWordFindRequest.getWord(),
+        Page<Counselor> page = counselorRepository.findByWordAndLevelAndStatus(searchWordCounselorFindRequest.getWord(),
                 pageable);
         return page.getContent();
     }

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                         requests -> requests.requestMatchers("/error", "/swagger-ui/**", "/api-docs/**",
                                         "/api/v1/auth/signUp", "/api/v1/auth/signIn", "/api/v1/auth/reissue",
                                         "/api/v1/auth/find-id", "/api/v1/auth/find-password", "/api/v1/auth/recovery-email/**", "/api/v1/emails/**").permitAll()
-                                .requestMatchers("/api/v1/counselors/all/**", "/api/v1/searchWords/results", "/api/v1/reviews/all/**").permitAll()
+                                .requestMatchers("/api/v1/counselors/all/**", "/api/v1/searchWords/results/**", "/api/v1/reviews/all/**").permitAll()
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html",
                                         "/counselor.html").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/posts/{postId}").permitAll()

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -5,6 +5,7 @@ import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
 import com.example.sharemind.post.dto.response.*;
 
+import com.example.sharemind.searchWord.dto.request.SearchWordPostFindRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -36,4 +37,7 @@ public interface PostService {
     PostGetResponse getCounselorPostContent(Long postId, Long customerId);
 
     Post checkAndGetCounselorPost(Long postId, Long customerId);
+
+    List<Post> getPostByWordWithPagination(SearchWordPostFindRequest searchWordPostFindRequest,
+                                           String sortType);
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
+import com.example.sharemind.post.content.PostListSortType;
 import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
@@ -16,6 +17,7 @@ import com.example.sharemind.post.exception.PostException;
 import com.example.sharemind.post.repository.PostRepository;
 import com.example.sharemind.postLike.repository.PostLikeRepository;
 import com.example.sharemind.postScrap.repository.PostScrapRepository;
+import com.example.sharemind.searchWord.dto.request.SearchWordPostFindRequest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -30,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PostServiceImpl implements PostService {
 
-    private static final int POST_PAGE_SIZE = 4;
+    private static final int POST_PAGE_SIZE = 5;
     private static final int POST_POPULARITY_SIZE = 3;
     private static final int TOTAL_POSTS = 50;
     private static final int POSTS_AFTER_24H_COUNT = TOTAL_POSTS / 3;
@@ -200,6 +202,18 @@ public class PostServiceImpl implements PostService {
         return getProceedingPost(postId);
     }
 
+    @Override
+    public List<Post> getPostByWordWithPagination(SearchWordPostFindRequest searchWordPostFindRequest,
+                                                  String sortType) {
+        String sortColumn = getPostSortColumn(sortType);
+        if (searchWordPostFindRequest.getPostId() == 0) {
+            return postRepository.getFirstPostByWordWithSortType(searchWordPostFindRequest, sortColumn, POST_PAGE_SIZE);
+        }
+        Post post = getPostByPostId(searchWordPostFindRequest.getPostId());
+        return postRepository.getPostByWordWithSortType(searchWordPostFindRequest, sortColumn, post,
+                POST_PAGE_SIZE);
+    }
+
     private Boolean checkCounselorReadAuthority(Long postId, Long customerId) {
         Post post = getPostByPostId(postId);
 
@@ -216,5 +230,10 @@ public class PostServiceImpl implements PostService {
 
         post.checkPostProceeding();
         return post;
+    }
+
+    private String getPostSortColumn(String sortType) {
+        PostListSortType postListSortType = PostListSortType.getSortTypeByName(sortType);
+        return postListSortType.getSortColumn();
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -32,7 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PostServiceImpl implements PostService {
 
-    private static final int POST_PAGE_SIZE = 5;
+    private static final int POST_PAGE_SIZE = 4;
+    private static final int POST_PAGE_SEARCH_SIZE = 5;
     private static final int POST_POPULARITY_SIZE = 3;
     private static final int TOTAL_POSTS = 50;
     private static final int POSTS_AFTER_24H_COUNT = TOTAL_POSTS / 3;
@@ -209,7 +210,8 @@ public class PostServiceImpl implements PostService {
                                                   String sortType) {
         String sortColumn = getPostSortColumn(sortType);
         if (searchWordPostFindRequest.getPostId() == 0) {
-            return postRepository.getFirstPostByWordWithSortType(searchWordPostFindRequest, sortColumn, POST_PAGE_SIZE);
+            return postRepository.getFirstPostByWordWithSortType(searchWordPostFindRequest, sortColumn,
+                    POST_PAGE_SEARCH_SIZE);
         }
         Post post = getPostByPostId(searchWordPostFindRequest.getPostId());
         return postRepository.getPostByWordWithSortType(searchWordPostFindRequest, sortColumn, post,

--- a/src/main/java/com/example/sharemind/post/content/PostListSortType.java
+++ b/src/main/java/com/example/sharemind/post/content/PostListSortType.java
@@ -1,0 +1,27 @@
+package com.example.sharemind.post.content;
+
+import com.example.sharemind.post.exception.PostErrorCode;
+import com.example.sharemind.post.exception.PostException;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum PostListSortType {
+
+    LATEST("publishedAt"),
+    DESC_TOTAL_COMMENT("totalComment"),
+    DESC_TOTAL_LIKE("totalLike");
+
+    private final String sortColumn;
+
+    PostListSortType(String sortColumn) {
+        this.sortColumn = sortColumn;
+    }
+
+    public static PostListSortType getSortTypeByName(String name) {
+        return Arrays.stream(PostListSortType.values())
+                .filter(sortType -> sortType.name().equalsIgnoreCase(name))
+                .findAny()
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_SORT_TYPE_NOT_FOUND, name));
+    }
+}

--- a/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
+++ b/src/main/java/com/example/sharemind/post/exception/PostErrorCode.java
@@ -13,8 +13,8 @@ public enum PostErrorCode {
     POST_MODIFY_DENIED(HttpStatus.FORBIDDEN, "일대다 상담 질문 작성 권한이 없습니다."),
     POST_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 일대다 상담 질문이 최종 제출되었습니다."),
     POST_NOT_PROCEEDING(HttpStatus.BAD_REQUEST, "진행중인 상담이 아닙니다."),
-    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "일대다 상담 질문 접근 권한이 없습니다.");
-
+    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "일대다 상담 질문 접근 권한이 없습니다."),
+    POST_SORT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정렬 방식이 존재하지 않습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/example/sharemind/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostCustomRepository.java
@@ -2,6 +2,7 @@ package com.example.sharemind.post.repository;
 
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.domain.Post;
+import com.example.sharemind.searchWord.dto.request.SearchWordPostFindRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,4 +13,10 @@ public interface PostCustomRepository {
 
     List<Post> findAllByIsPublicAndIsActivatedIsTrue(Long postId, LocalDateTime finishedAt,
             int size);
+
+    List<Post> getPostByWordWithSortType(SearchWordPostFindRequest searchWordPostFindRequest,
+                                           String sortColumn, Post lastPost, int size);
+
+    List<Post> getFirstPostByWordWithSortType(SearchWordPostFindRequest searchWordPostFindRequest,
+                                              String sortColumn, int size);
 }

--- a/src/main/java/com/example/sharemind/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostCustomRepositoryImpl.java
@@ -4,6 +4,10 @@ import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.content.PostStatus;
 import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.domain.QPost;
+import com.example.sharemind.post.exception.PostErrorCode;
+import com.example.sharemind.post.exception.PostException;
+import com.example.sharemind.searchWord.dto.request.SearchWordPostFindRequest;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
@@ -18,7 +22,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
     @Override
     public List<Post> findAllByCustomerAndIsActivatedIsTrue(Customer customer, Boolean filter,
-            Long postId, int size) {
+                                                            Long postId, int size) {
         return jpaQueryFactory
                 .selectFrom(post)
                 .where(
@@ -32,7 +36,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
     @Override
     public List<Post> findAllByIsPublicAndIsActivatedIsTrue(Long postId, LocalDateTime finishedAt,
-            int size) {
+                                                            int size) {
         return jpaQueryFactory
                 .selectFrom(post)
                 .where(
@@ -41,6 +45,41 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         post.isActivated.isTrue(),
                         lessThanFinishedAtAndPostId(postId, finishedAt)
                 ).orderBy(post.finishedAt.desc(), post.postId.desc()).limit(size).fetch();
+    }
+
+    @Override
+    public List<Post> getFirstPostByWordWithSortType(SearchWordPostFindRequest searchWordPostFindRequest,
+                                                     String sortColumn, int size) {
+        return jpaQueryFactory
+                .selectFrom(post)
+                .where(
+                        post.isPublic.isTrue(),
+                        post.isActivated.isTrue(),
+                        post.postStatus.in(PostStatus.PROCEEDING, PostStatus.COMPLETED),
+                        (post.title.contains(searchWordPostFindRequest.getWord())
+                                .or(post.content.contains(searchWordPostFindRequest.getWord())))
+                )
+                .orderBy(getOrderSpecifier(sortColumn, post), post.postId.asc())
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public List<Post> getPostByWordWithSortType(SearchWordPostFindRequest searchWordPostFindRequest,
+                                                String sortColumn, Post lastPost, int size) {
+        return jpaQueryFactory
+                .selectFrom(post)
+                .where(
+                        post.isPublic.isTrue(),
+                        post.isActivated.isTrue(),
+                        post.postStatus.in(PostStatus.PROCEEDING, PostStatus.COMPLETED),
+                        (post.title.contains(searchWordPostFindRequest.getWord())
+                                .or(post.content.contains(searchWordPostFindRequest.getWord()))),
+                        getSortColumnCondition(post, sortColumn, lastPost)
+                )
+                .orderBy(getOrderSpecifier(sortColumn, post), post.postId.asc())
+                .limit(size)
+                .fetch();
     }
 
     private BooleanExpression postStatusIn(Boolean filter) {
@@ -55,5 +94,27 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     private BooleanExpression lessThanFinishedAtAndPostId(Long postId, LocalDateTime finishedAt) {
         return postId != 0 ? post.finishedAt.lt(finishedAt)
                 .or(post.finishedAt.eq(finishedAt).and(post.postId.lt(postId))) : null;
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sortColumn, QPost post) {
+        return switch (sortColumn) {
+            case "publishedAt" -> post.publishedAt.desc();
+            case "totalComment" -> post.totalComment.desc();
+            case "totalLike" -> post.totalLike.desc();
+            default -> throw new PostException(PostErrorCode.POST_SORT_TYPE_NOT_FOUND, sortColumn);
+        };
+    }
+
+    private BooleanExpression getSortColumnCondition(QPost post, String sortColumn, Post lastPost) {
+        return switch (sortColumn) {
+            case "publishedAt" -> post.publishedAt.before(lastPost.getPublishedAt());
+            case "totalComment" -> post.totalComment.lt(lastPost.getTotalComment())
+                    .or(post.totalComment.eq(lastPost.getTotalComment())
+                            .and(post.postId.gt(lastPost.getPostId())));
+            case "totalLike" -> post.totalLike.lt(lastPost.getTotalLike())
+                    .or(post.totalLike.eq(lastPost.getTotalLike())
+                            .and(post.postId.gt(lastPost.getPostId())));
+            default -> throw new PostException(PostErrorCode.POST_SORT_TYPE_NOT_FOUND, sortColumn);
+        };
     }
 }

--- a/src/main/java/com/example/sharemind/searchWord/application/SearchWordService.java
+++ b/src/main/java/com/example/sharemind/searchWord/application/SearchWordService.java
@@ -1,22 +1,30 @@
 package com.example.sharemind.searchWord.application;
 
 import com.example.sharemind.counselor.dto.response.CounselorGetListResponse;
+import com.example.sharemind.post.dto.response.PostGetListResponse;
 import com.example.sharemind.searchWord.dto.request.SearchWordDeleteRequest;
-import com.example.sharemind.searchWord.dto.request.SearchWordFindRequest;
+import com.example.sharemind.searchWord.dto.request.SearchWordCounselorFindRequest;
 
+import com.example.sharemind.searchWord.dto.request.SearchWordPostFindRequest;
 import java.util.List;
 
 public interface SearchWordService {
 
     List<CounselorGetListResponse> storeSearchWordAndGetCounselorsByCustomer(Long customerId, String sortType,
-                                                                             SearchWordFindRequest searchWordFindRequest);
+                                                                             SearchWordCounselorFindRequest searchWordCounselorFindRequest);
 
     List<CounselorGetListResponse> storeAllSearchWordAndGetCounselors(String sortType,
-                                                                      SearchWordFindRequest searchWordFindRequest);
+                                                                      SearchWordCounselorFindRequest searchWordCounselorFindRequest);
 
     List<String> getRecentSearchWordsByCustomer(Long customerId);
 
     void removeSearchWordByCustomer(Long customerId, SearchWordDeleteRequest searchWordDeleteRequest);
 
     void storeSearchWordInDB(String word);
+
+    List<PostGetListResponse> storeAllSearchWordAndGetPosts(String sortType,
+                                                            SearchWordPostFindRequest searchWordPostFindRequest);
+
+    List<PostGetListResponse> storeSearchWordAndGetPosts(Long customerId, String sortType,
+                                                         SearchWordPostFindRequest searchWordPostFindRequest);
 }

--- a/src/main/java/com/example/sharemind/searchWord/dto/request/SearchWordCounselorFindRequest.java
+++ b/src/main/java/com/example/sharemind/searchWord/dto/request/SearchWordCounselorFindRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
-public class SearchWordFindRequest {
+public class SearchWordCounselorFindRequest {
 
     @Schema(description = "검색어")
     @Size(min = 2, max = 20, message = "검색어는 2-20글자 사이에서 입력 가능합니다.")

--- a/src/main/java/com/example/sharemind/searchWord/dto/request/SearchWordPostFindRequest.java
+++ b/src/main/java/com/example/sharemind/searchWord/dto/request/SearchWordPostFindRequest.java
@@ -1,0 +1,16 @@
+package com.example.sharemind.searchWord.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SearchWordPostFindRequest {
+
+    @Schema(description = "검색어")
+    @Size(min = 2, max = 20, message = "검색어는 2-20글자 사이에서 입력 가능합니다.")
+    private String word;
+
+    @Schema(description = "가장 마지막으로 받은 postId 반환, 처음 요청이라면 0을 반환", example = "0")
+    private Long postId;
+}

--- a/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
+++ b/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
@@ -91,7 +91,7 @@ public class SearchWordController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "1. 검색어가 2~20자 사이가 아님", content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = CustomExceptionResponse.class))),
-            @ApiResponse(responseCode = "404", description = "1. 해당 정렬 방식이 존재하지 않음", content = @Content(mediaType = "application/json",
+            @ApiResponse(responseCode = "404", description = "1. 해당 정렬 방식이 존재하지 않음 2. postId가 존재하지 않음", content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = CustomExceptionResponse.class)))
     })
     @Parameters({

--- a/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
+++ b/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
@@ -46,8 +46,8 @@ public class SearchWordController {
                 searchWordService.getRecentSearchWordsByCustomer(customUserDetails.getCustomer().getCustomerId()));
     }
 
-    @Operation(summary = "검색 결과 반환", description = """
-            - 주소 형식 예시 : /api/v1/searchWords/results?sortType=STAR_RATING
+    @Operation(summary = "상담사 검색 결과 반환", description = """
+            - 주소 형식 예시 : /api/v1/searchWords/results/counselors?sortType=STAR_RATING
             - 검색어 결과를 상담사 닉네임, 소개 제목, 소개 내용에서 찾아서 반환. 정확하게 일치하는 정보만 반환
             - 만약 이전에 검색했던 검색어의 경우(ex) 연애, 갈등)에서 갈등이 다시 검색된다면 (갈등, 연애)순서로 다시 서버에 저장합니다. (중복 저장x)
             - 검색 결과는 4개씩 반환하며, index는 페이지 번호 입니다(ex index 0 : id 0~3에 해당하는 값 반환 index 1: 4~7에 해당하는 값 반환)
@@ -55,6 +55,8 @@ public class SearchWordController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "1. 검색어가 2~20자 사이가 아님", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CustomExceptionResponse.class))),
+            @ApiResponse(responseCode = "404", description = "1. 해당 정렬 방식이 존재하지 않음", content = @Content(mediaType = "application/json",
                     schema = @Schema(implementation = CustomExceptionResponse.class)))
     })
     @Parameters({
@@ -78,6 +80,23 @@ public class SearchWordController {
                         sortType, searchWordCounselorFindRequest));
     }
 
+    @Operation(summary = "공개 상담 검색 결과 반환", description = """
+            - 주소 형식 예시 : /api/v1/searchWords/results/posts?sortType=LATEST
+            - 검색어 결과를 공개 상담 제목이나 내용 중 정확하게 일치하는 경우에 리턴
+            - 만약 이전에 검색했던 검색어의 경우(ex) 연애, 갈등)에서 갈등이 다시 검색된다면 (갈등, 연애)순서로 다시 서버에 저장합니다. (중복 저장x)
+            - 검색 결과는 5개씩 반환하며, 마지막에 리턴 받은 postId 이후 값을 5개 리턴합니다.
+            - 처음 조회 시 postId 0을 넘겨주세요~
+            - 해당하는 검색 결과가 없을 때는 빈배열을 리턴합니다.""")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 검색어가 2~20자 사이가 아님", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CustomExceptionResponse.class))),
+            @ApiResponse(responseCode = "404", description = "1. 해당 정렬 방식이 존재하지 않음", content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = CustomExceptionResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "sortType", description = "LATEST: 최근순, DESC_TOTAL_COMMENT: 코멘트 많은 순, DESC_TOTAL_LIKE: 공감 많은 순")
+    })
     @PatchMapping("/results/posts")
     public ResponseEntity<List<PostGetListResponse>> getSearchWordPostResults(
             @Valid @RequestBody SearchWordPostFindRequest searchWordPostFindRequest, @RequestParam String sortType,

--- a/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
+++ b/src/main/java/com/example/sharemind/searchWord/presentation/SearchWordController.java
@@ -3,9 +3,11 @@ package com.example.sharemind.searchWord.presentation;
 import com.example.sharemind.counselor.dto.response.CounselorGetListResponse;
 import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
+import com.example.sharemind.post.dto.response.PostGetListResponse;
 import com.example.sharemind.searchWord.application.SearchWordService;
 import com.example.sharemind.searchWord.dto.request.SearchWordDeleteRequest;
-import com.example.sharemind.searchWord.dto.request.SearchWordFindRequest;
+import com.example.sharemind.searchWord.dto.request.SearchWordCounselorFindRequest;
+import com.example.sharemind.searchWord.dto.request.SearchWordPostFindRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -58,18 +60,35 @@ public class SearchWordController {
     @Parameters({
             @Parameter(name = "sortType", description = "LATEST: 최근순, POPULARITY: 인기순, STAR_RATING: 별점 평균 순")
     })
-    @PatchMapping("/results")
-    public ResponseEntity<List<CounselorGetListResponse>> getSearchWordResults(
-            @Valid @RequestBody SearchWordFindRequest searchWordFindRequest, @RequestParam String sortType,
+    @PatchMapping("/results/counselors")
+    public ResponseEntity<List<CounselorGetListResponse>> getSearchWordCounselorResults(
+            @Valid @RequestBody SearchWordCounselorFindRequest searchWordCounselorFindRequest,
+            @RequestParam String sortType,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        if (searchWordFindRequest.getIndex() < 0) {
+        if (searchWordCounselorFindRequest.getIndex() < 0) {
             return ResponseEntity.ok(Collections.emptyList());
         }
-        if (customUserDetails == null)
-            return ResponseEntity.ok(searchWordService.storeAllSearchWordAndGetCounselors(sortType, searchWordFindRequest));
+        if (customUserDetails == null) {
+            return ResponseEntity.ok(searchWordService.storeAllSearchWordAndGetCounselors(sortType,
+                    searchWordCounselorFindRequest));
+        }
         return ResponseEntity.ok(
-                searchWordService.storeSearchWordAndGetCounselorsByCustomer(customUserDetails.getCustomer().getCustomerId(),
-                        sortType, searchWordFindRequest));
+                searchWordService.storeSearchWordAndGetCounselorsByCustomer(
+                        customUserDetails.getCustomer().getCustomerId(),
+                        sortType, searchWordCounselorFindRequest));
+    }
+
+    @PatchMapping("/results/posts")
+    public ResponseEntity<List<PostGetListResponse>> getSearchWordPostResults(
+            @Valid @RequestBody SearchWordPostFindRequest searchWordPostFindRequest, @RequestParam String sortType,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if (customUserDetails == null) {
+            return ResponseEntity.ok(
+                    searchWordService.storeAllSearchWordAndGetPosts(sortType, searchWordPostFindRequest));
+        }
+        return ResponseEntity.ok(
+                searchWordService.storeSearchWordAndGetPosts(customUserDetails.getCustomer().getCustomerId(),
+                        sortType, searchWordPostFindRequest));
     }
 
     @Operation(summary = "검색어 삭제", description = "검색어를 삭제하는 api\n"


### PR DESCRIPTION
## 📄구현 내용
- 공개 상담 검색 기능 구현
## 📝기타 알림사항
- 기획한테 아직 답이 안와서 일대다 검색 정렬 기준을 최신순, 코멘트 많은 순, 공감 많은 순으로 일단 작성해보았습니다.
- 만약 정렬 기준에 해당하는 요소가 같다면 postId 기준 오름차순으로 해서 반환하는 식으로 했습니다.
- 피그마상으로 검색 탭의 경우, 4개를 리턴하면 화면이 빌 것 같아서 하나 늘려서 5개 리턴했습니다~
- 상담사 검색 조회 다시 보니까 엉망이네요ㅜㅜ 리팩토링 하려고 합니다 이슈에 적어놓겠습니다