### PR TITLE
feat: 공개상담 답변 대기/완료 로직 수정

### DIFF
--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.post.content.PostListSortType;
+import com.example.sharemind.post.content.PostStatus;
 import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -216,6 +218,17 @@ public class PostServiceImpl implements PostService {
         }
 
         return IS_NOT_POST_OWNER;
+    }
+
+    @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void checkPostStatus() {
+        postRepository.findAllProceedingPublicPostsAfter72Hours()
+                .forEach(post -> {
+                    if (post.getTotalComment() > 0) {
+                        post.updatePostStatus(PostStatus.COMPLETED);
+                    }
+                });
     }
 
     private Boolean checkCounselorReadAuthority(Long postId, Long customerId) {

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -16,6 +16,11 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     List<Post> findAllByIsPaidIsFalseAndIsActivatedIsTrue();
 
     @Query(value = "SELECT * FROM post " +
+            "WHERE is_public = true AND post_status = 'PROCEEDING' AND is_activated = true "
+            + "AND published_at <= CURRENT_TIMESTAMP - INTERVAL 3 DAY", nativeQuery = true)
+    List<Post> findAllProceedingPublicPostsAfter72Hours();
+
+    @Query(value = "SELECT * FROM post " +
             "WHERE is_public = true AND post_status = 'COMPLETED' AND is_activated = true " +
             "AND updated_at >= :weekAgo " +
             "ORDER BY total_like DESC LIMIT :size", nativeQuery = true)


### PR DESCRIPTION
## 📄구현 내용
- Resolved #179 
- '답변 완료의 기준: 답장 5개 달성 or 작성자 채택 완료 or (글 작성 72시간 경과 && 마인더 답변 1개 이상)'에서 구현되어있지 않은 '글 작성 72시간 경과 && 마인더 답변 1개 이상' 부분을 구현하였습니다.
스프링 스케줄러를 통해 1시간마다 '공개상담이면서 작성 72시간 경과'한 일대다 상담 목록을 조회하여 마인더 답변이 1개 이상이면 답변 완료로 postStatus를 수정합니다.

## 📝기타 알림사항
