### PR TITLE
feat: 일대다 상담 상태 값 추가 및 관련 로직 수정

### DIFF
--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -99,7 +99,7 @@ public class CommentServiceImpl implements CommentService {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
         Post post = postService.getPostByPostId(postId);
         post.checkWriteAuthority(customer);
-        post.checkPostProceeding();
+        post.checkPostProceedingOrTimeOut();
 
         Comment comment = getCommentByCommentId(commentId);
         comment.checkCommentIsForPost(post);

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -128,8 +128,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<PostGetPublicListResponse> getPublicPostsByCustomer(Long postId,
-            LocalDateTime finishedAt,
-            Long customerId) {
+            LocalDateTime finishedAt, Long customerId) {
         if (customerId != 0) {
             Customer customer = customerService.getCustomerByCustomerId(customerId);
 
@@ -199,8 +198,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<Post> getPostByWordWithPagination(
-            SearchWordPostFindRequest searchWordPostFindRequest,
-            String sortType) {
+            SearchWordPostFindRequest searchWordPostFindRequest, String sortType) {
         String sortColumn = getPostSortColumn(sortType);
         if (searchWordPostFindRequest.getPostId() == 0) {
             return postRepository.getFirstPostByWordWithSortType(searchWordPostFindRequest,
@@ -230,7 +228,7 @@ public class PostServiceImpl implements PostService {
         postRepository.findAllProceedingPublicPostsAfter72Hours()
                 .forEach(post -> {
                     if (post.getTotalComment() > 0) {
-                        post.updatePostStatus(PostStatus.COMPLETED);
+                        post.updatePostStatus(PostStatus.TIME_OUT);
                     }
                 });
     }

--- a/src/main/java/com/example/sharemind/post/content/PostStatus.java
+++ b/src/main/java/com/example/sharemind/post/content/PostStatus.java
@@ -9,6 +9,7 @@ public enum PostStatus {
 
     WAITING("답변 대기"),
     PROCEEDING("답변 진행 중"),
+    TIME_OUT("시간 경과로 인한 답변 완료"),
     COMPLETED("답변 완료"),
     CANCELLED("상담 취소"),
     REPORTED("신고로 인한 게시 중단");

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -163,8 +163,15 @@ public class Post extends BaseEntity {
     }
 
     public void checkPostProceeding() {
-        if (this.getPostStatus() != PostStatus.PROCEEDING)
+        if (this.postStatus != PostStatus.PROCEEDING) {
             throw new PostException(PostErrorCode.POST_NOT_PROCEEDING, this.getPostId().toString());
+        }
+    }
+
+    public void checkPostProceedingOrTimeOut() {
+        if (this.postStatus != PostStatus.PROCEEDING && this.postStatus != PostStatus.TIME_OUT) {
+            throw new PostException(PostErrorCode.POST_NOT_PROCEEDING, this.getPostId().toString());
+        }
     }
 
     private void setIsPaid(Boolean isPublic) {

--- a/src/main/java/com/example/sharemind/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostCustomRepositoryImpl.java
@@ -41,7 +41,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .selectFrom(post)
                 .where(
                         post.isPublic.isTrue(),
-                        post.postStatus.eq(PostStatus.COMPLETED),
+                        post.postStatus.in(PostStatus.TIME_OUT, PostStatus.COMPLETED),
                         post.isActivated.isTrue(),
                         lessThanFinishedAtAndPostId(postId, finishedAt)
                 ).orderBy(post.finishedAt.desc(), post.postId.desc()).limit(size).fetch();
@@ -55,7 +55,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .where(
                         post.isPublic.isTrue(),
                         post.isActivated.isTrue(),
-                        post.postStatus.in(PostStatus.PROCEEDING, PostStatus.COMPLETED),
+                        post.postStatus.in(PostStatus.TIME_OUT, PostStatus.COMPLETED),
                         (post.title.contains(searchWordPostFindRequest.getWord())
                                 .or(post.content.contains(searchWordPostFindRequest.getWord())))
                 )
@@ -72,7 +72,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .where(
                         post.isPublic.isTrue(),
                         post.isActivated.isTrue(),
-                        post.postStatus.in(PostStatus.PROCEEDING, PostStatus.COMPLETED),
+                        post.postStatus.in(PostStatus.TIME_OUT, PostStatus.COMPLETED),
                         (post.title.contains(searchWordPostFindRequest.getWord())
                                 .or(post.content.contains(searchWordPostFindRequest.getWord()))),
                         getSortColumnCondition(post, sortColumn, lastPost)

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -21,8 +21,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     List<Post> findAllProceedingPublicPostsAfter72Hours();
 
     @Query(value = "SELECT * FROM post " +
-            "WHERE is_public = true AND post_status = 'COMPLETED' AND is_activated = true " +
-            "AND updated_at >= :weekAgo " +
+            "WHERE is_public = true AND (post_status = 'TIME_OUT' OR post_status = 'COMPLETED') " +
+            "AND is_activated = true AND updated_at >= :weekAgo " +
             "ORDER BY total_like DESC LIMIT :size", nativeQuery = true)
     List<Post> findPopularityPosts(LocalDate weekAgo, int size);
 


### PR DESCRIPTION
## 📄구현 내용
- Resolved #183 

## 📝기타 알림사항
- 디비의 PostStatus에 TIME_OUT 값 추가하였습니다. 그런데 checkPostStatus가 1시간마다 동작하는 로직이라 이미 COMPLETED 상태인 TIME_OUT 상담들은 지금 바꿔둬도 소용이 없어서 배포 후 수정하도록 하겠습니다!