### PR TITLE
feat: 답변 대기 중인 공개상담 24시간 경과 시 삭제

### DIFF
--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.sharemind.counselor.application.CounselorService;
 import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
+import com.example.sharemind.global.common.BaseEntity;
 import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.post.content.PostListSortType;
 import com.example.sharemind.post.content.PostStatus;
@@ -236,12 +237,11 @@ public class PostServiceImpl implements PostService {
     @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
     @Transactional
     public void checkPostStatus() {
-        postRepository.findAllProceedingPublicPostsAfter72Hours()
-                .forEach(post -> {
-                    if (post.getTotalComment() > 0) {
-                        post.updatePostStatus(PostStatus.TIME_OUT);
-                    }
-                });
+        postRepository.findAllWaitingPublicPostsAfter24Hours()
+                        .forEach(BaseEntity::updateIsActivatedFalse);
+
+        postRepository.findAllCommentedProceedingPublicPostsAfter72Hours()
+                .forEach(post -> post.updatePostStatus(PostStatus.TIME_OUT));
     }
 
     private Boolean checkCounselorReadAuthority(Long postId, Long customerId) {

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -15,6 +15,11 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     List<Post> findAllByIsPaidIsFalseAndIsActivatedIsTrue();
 
     @Query(value = "SELECT * FROM post " +
+            "WHERE is_public = true AND post_status = 'WAITING' AND is_activated = true "
+            + "AND created_at <= CURRENT_TIMESTAMP - INTERVAL 1 DAY ", nativeQuery = true)
+    List<Post> findAllWaitingPublicPostsAfter24Hours();
+
+    @Query(value = "SELECT * FROM post " +
             "WHERE is_public = true AND post_status = 'PROCEEDING' AND is_activated = true "
             + "AND published_at <= CURRENT_TIMESTAMP - INTERVAL 3 DAY "
             + "AND total_comment > 0", nativeQuery = true)

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -16,8 +16,9 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
 
     @Query(value = "SELECT * FROM post " +
             "WHERE is_public = true AND post_status = 'PROCEEDING' AND is_activated = true "
-            + "AND published_at <= CURRENT_TIMESTAMP - INTERVAL 3 DAY", nativeQuery = true)
-    List<Post> findAllProceedingPublicPostsAfter72Hours();
+            + "AND published_at <= CURRENT_TIMESTAMP - INTERVAL 3 DAY "
+            + "AND total_comment > 0", nativeQuery = true)
+    List<Post> findAllCommentedProceedingPublicPostsAfter72Hours();
 
     @Query(value = "SELECT post_id FROM post "
             + "WHERE post_status = 'PROCEEDING' AND is_activated = true "


### PR DESCRIPTION
## 📄구현 내용
- Resolved #212 
- 상담 내용 작성된 지 72시간 경과했을 때 답변이 1개 이상이면 답변 완료 상태로 postStatus 수정하도록 1시간마다 작동되는 로직이 있어 그 안에서 같이 해당하는 post 조회하여 삭제되도록 구현하였습니다.

## 📝기타 알림사항
- 상담 내용 작성된 지 72시간 경과했을 때 답변이 1개 이상인 post 조회해서 상태 수정하는 로직을 약간 수정하였습니다.
  - 이전에는 72시간 경과한 모든 post를 가져와서 서비스 단에서 답변 개수를 검사해주었는데, 답변 개수가 애초에 1개 이상인 것만 가져오도록 수정하였습니다.