### PR TITLE
feat: 상담사 프로필 수정 이력 저장

### DIFF
--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -118,7 +118,7 @@ public class CounselorServiceImpl implements CounselorService {
     @Transactional
     @Override
     public void updateCounselorProfile(CounselorUpdateProfileRequest counselorUpdateProfileRequest,
-                                       Long customerId) {
+            Long customerId) {
         Counselor counselor = getCounselorByCustomerId(customerId);
         if ((counselor.getIsEducated() == null) || (!counselor.getIsEducated())) {
             throw new CounselorException(CounselorErrorCode.COUNSELOR_NOT_EDUCATED);
@@ -232,8 +232,8 @@ public class CounselorServiceImpl implements CounselorService {
 
     @Override
     public List<CounselorGetListResponse> getCounselorsByCategoryAndCustomer(Long customerId,
-                                                                             String sortType,
-                                                                             CounselorGetRequest counselorGetRequest) {
+            String sortType,
+            CounselorGetRequest counselorGetRequest) {
         List<Counselor> counselors = getCounselorByCategoryWithPagination(counselorGetRequest,
                 sortType);
         List<Long> counselorIds = redisTemplate.opsForValue().get(REALTIME_COUNSELOR);
@@ -255,7 +255,7 @@ public class CounselorServiceImpl implements CounselorService {
 
     @Override
     public List<CounselorGetListResponse> getAllCounselorsByCategory(String sortType,
-                                                                     CounselorGetRequest counselorGetRequest) {
+            CounselorGetRequest counselorGetRequest) {
         List<Counselor> counselors = getCounselorByCategoryWithPagination(counselorGetRequest,
                 sortType);
         List<Long> counselorIds = redisTemplate.opsForValue().get(REALTIME_COUNSELOR);
@@ -272,7 +272,7 @@ public class CounselorServiceImpl implements CounselorService {
 
     @Override
     public CounselorGetMinderProfileResponse getCounselorMinderProfileByCustomer(Long counselorId,
-                                                                                 Long customerId) {
+            Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
         Counselor counselor = getCounselorByCounselorId(counselorId);
 
@@ -290,7 +290,7 @@ public class CounselorServiceImpl implements CounselorService {
     @Transactional
     @Override
     public void updateAccount(CounselorUpdateAccountRequest counselorUpdateAccountRequest,
-                              Long customerId) {
+            Long customerId) {
         Counselor counselor = getCounselorByCustomerId(customerId);
         Bank.existsByDisplayName(counselorUpdateAccountRequest.getBank());
         counselor.updateAccountInfo(counselorUpdateAccountRequest.getAccount(),
@@ -318,7 +318,7 @@ public class CounselorServiceImpl implements CounselorService {
 
     @Override
     public CounselorGetForConsultResponse getCounselorForConsultCreation(Long counselorId,
-                                                                         String type) {
+            String type) {
         Counselor counselor = getCounselorByCounselorId(counselorId);
         ConsultType consultType = ConsultType.getConsultTypeByName(type);
         if (!counselor.getConsultTypes().contains(consultType)) {
@@ -365,7 +365,8 @@ public class CounselorServiceImpl implements CounselorService {
         int currentHour = LocalTime.now().getHour();
 
         List<Counselor> realtimeCounselors = counselors.stream()
-                .filter(counselor -> isAvailableAtRealTime(counselor.getConsultTimes(), currentDay, currentHour))
+                .filter(counselor -> isAvailableAtRealTime(counselor.getConsultTimes(), currentDay,
+                        currentHour))
                 .sorted((c1, c2) -> Long.compare(c2.getTotalConsult(), c1.getTotalConsult()))
                 .toList();
 
@@ -405,7 +406,8 @@ public class CounselorServiceImpl implements CounselorService {
         }
 
         List<Long> counselorsSubList = (counselorIds.size() >= start + COUNSELOR_PAGE) ?
-                counselorIds.subList(start, start + COUNSELOR_PAGE) : counselorIds.subList(start, counselorIds.size());
+                counselorIds.subList(start, start + COUNSELOR_PAGE)
+                : counselorIds.subList(start, counselorIds.size());
         return counselorRepository.findAllById(counselorsSubList);
     }
 

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -192,6 +192,7 @@ public class CounselorServiceImpl implements CounselorService {
                 .consultStyle(consultStyle)
                 .experience(counselorUpdateProfileRequest.getExperience())
                 .introduction(counselorUpdateProfileRequest.getIntroduction())
+                .profileStatus(counselor.getProfileStatus())
                 .build();
         profileRecordRepository.save(profileRecord);
 

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.sharemind.counselor.content.ProfileStatus;
 import com.example.sharemind.counselor.domain.ConsultCost;
 import com.example.sharemind.counselor.domain.ConsultTime;
 import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.counselor.domain.ProfileRecord;
 import com.example.sharemind.counselor.dto.request.CounselorGetRequest;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateAccountRequest;
 import com.example.sharemind.counselor.dto.request.CounselorUpdateProfileRequest;
@@ -17,6 +18,7 @@ import com.example.sharemind.counselor.dto.response.*;
 import com.example.sharemind.counselor.exception.CounselorErrorCode;
 import com.example.sharemind.counselor.exception.CounselorException;
 import com.example.sharemind.counselor.repository.CounselorRepository;
+import com.example.sharemind.counselor.repository.ProfileRecordRepository;
 import com.example.sharemind.customer.application.CustomerService;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.global.content.ConsultCategory;
@@ -49,6 +51,7 @@ public class CounselorServiceImpl implements CounselorService {
     private static final String SPLIT_HOURS = "~";
 
     private final CounselorRepository counselorRepository;
+    private final ProfileRecordRepository profileRecordRepository;
     private final CustomerService customerService;
     private final WishListCounselorService wishListCounselorService;
     private final RedisTemplate<String, List<Long>> redisTemplate;
@@ -178,6 +181,19 @@ public class CounselorServiceImpl implements CounselorService {
             List<String> times = rawTimes.get(day);
             consultTimes.add(ConsultTime.builder().day(day).times(times).build());
         }
+
+        ProfileRecord profileRecord = ProfileRecord.builder()
+                .counselor(counselor)
+                .nickname(counselorUpdateProfileRequest.getNickname())
+                .consultCosts(consultCosts)
+                .consultTimes(consultTimes)
+                .consultTypes(consultTypes)
+                .consultCategories(consultCategories)
+                .consultStyle(consultStyle)
+                .experience(counselorUpdateProfileRequest.getExperience())
+                .introduction(counselorUpdateProfileRequest.getIntroduction())
+                .build();
+        profileRecordRepository.save(profileRecord);
 
         counselor.updateProfile(counselorUpdateProfileRequest.getNickname(), consultCategories,
                 consultStyle, consultTypes, consultTimes, consultCosts,

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -43,23 +43,23 @@ public class Counselor extends BaseEntity {
     private ProfileStatus profileStatus;
 
     @ElementCollection(targetClass = ConsultCost.class, fetch = FetchType.LAZY)
-    @JoinTable(name = "costs", joinColumns = @JoinColumn(name = "counselor_id"))
+    @JoinTable(name = "consult_costs", joinColumns = @JoinColumn(name = "counselor_id"))
     @Column(name = "consult_costs")
     private Set<ConsultCost> consultCosts;
 
     @ElementCollection(targetClass = ConsultTime.class, fetch = FetchType.LAZY)
-    @JoinTable(name = "times", joinColumns = @JoinColumn(name = "counselor_id"))
+    @JoinTable(name = "consult_times", joinColumns = @JoinColumn(name = "counselor_id"))
     @Column(name = "consult_times")
     private Set<ConsultTime> consultTimes;
 
     @ElementCollection(targetClass = ConsultType.class, fetch = FetchType.LAZY)
-    @JoinTable(name = "types", joinColumns = @JoinColumn(name = "counselor_id"))
+    @JoinTable(name = "consult_types", joinColumns = @JoinColumn(name = "counselor_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "consult_types")
     private Set<ConsultType> consultTypes;
 
     @ElementCollection(targetClass = ConsultCategory.class, fetch = FetchType.LAZY)
-    @JoinTable(name = "categories", joinColumns = @JoinColumn(name = "counselor_id"))
+    @JoinTable(name = "consult_categories", joinColumns = @JoinColumn(name = "counselor_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "consult_categories")
     private Set<ConsultCategory> consultCategories;

--- a/src/main/java/com/example/sharemind/counselor/domain/ProfileRecord.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/ProfileRecord.java
@@ -1,6 +1,7 @@
 package com.example.sharemind.counselor.domain;
 
 import com.example.sharemind.counselor.content.ConsultStyle;
+import com.example.sharemind.counselor.content.ProfileStatus;
 import com.example.sharemind.global.content.ConsultCategory;
 import com.example.sharemind.global.content.ConsultType;
 import jakarta.persistence.Column;
@@ -68,11 +69,15 @@ public class ProfileRecord {
     @Column(columnDefinition = "TEXT")
     private String introduction;
 
+    @Column(name = "profile_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ProfileStatus profileStatus;
+
     @Builder
     public ProfileRecord(Counselor counselor, String nickname, Set<ConsultCost> consultCosts,
             Set<ConsultTime> consultTimes, Set<ConsultType> consultTypes,
             Set<ConsultCategory> consultCategories, ConsultStyle consultStyle, String experience,
-            String introduction) {
+            String introduction, ProfileStatus profileStatus) {
         this.counselor = counselor;
         this.nickname = nickname;
         this.consultCosts = consultCosts;
@@ -82,5 +87,6 @@ public class ProfileRecord {
         this.consultStyle = consultStyle;
         this.experience = experience;
         this.introduction = introduction;
+        this.profileStatus = profileStatus;
     }
 }

--- a/src/main/java/com/example/sharemind/counselor/domain/ProfileRecord.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/ProfileRecord.java
@@ -1,0 +1,86 @@
+package com.example.sharemind.counselor.domain;
+
+import com.example.sharemind.counselor.content.ConsultStyle;
+import com.example.sharemind.global.content.ConsultCategory;
+import com.example.sharemind.global.content.ConsultType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ProfileRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_record_id")
+    private Long profileRecordId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "counselor_id")
+    private Counselor counselor;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @ElementCollection(targetClass = ConsultCost.class, fetch = FetchType.LAZY)
+    @JoinTable(name = "consult_costs_record", joinColumns = @JoinColumn(name = "profile_record_id"))
+    @Column(name = "consult_costs")
+    private Set<ConsultCost> consultCosts;
+
+    @ElementCollection(targetClass = ConsultTime.class, fetch = FetchType.LAZY)
+    @JoinTable(name = "consult_times_record", joinColumns = @JoinColumn(name = "profile_record_id"))
+    @Column(name = "consult_times")
+    private Set<ConsultTime> consultTimes;
+
+    @ElementCollection(targetClass = ConsultType.class, fetch = FetchType.LAZY)
+    @JoinTable(name = "consult_types_record", joinColumns = @JoinColumn(name = "profile_record_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "consult_types")
+    private Set<ConsultType> consultTypes;
+
+    @ElementCollection(targetClass = ConsultCategory.class, fetch = FetchType.LAZY)
+    @JoinTable(name = "consult_categories_record", joinColumns = @JoinColumn(name = "profile_record_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "consult_categories")
+    private Set<ConsultCategory> consultCategories;
+
+    @Column(name = "consult_style")
+    @Enumerated(EnumType.STRING)
+    private ConsultStyle consultStyle;
+
+    @Column(columnDefinition = "TEXT")
+    private String experience;
+
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+
+    @Builder
+    public ProfileRecord(Counselor counselor, String nickname, Set<ConsultCost> consultCosts,
+            Set<ConsultTime> consultTimes, Set<ConsultType> consultTypes,
+            Set<ConsultCategory> consultCategories, ConsultStyle consultStyle, String experience,
+            String introduction) {
+        this.counselor = counselor;
+        this.nickname = nickname;
+        this.consultCosts = consultCosts;
+        this.consultTimes = consultTimes;
+        this.consultTypes = consultTypes;
+        this.consultCategories = consultCategories;
+        this.consultStyle = consultStyle;
+        this.experience = experience;
+        this.introduction = introduction;
+    }
+}

--- a/src/main/java/com/example/sharemind/counselor/repository/ProfileRecordRepository.java
+++ b/src/main/java/com/example/sharemind/counselor/repository/ProfileRecordRepository.java
@@ -1,0 +1,10 @@
+package com.example.sharemind.counselor.repository;
+
+import com.example.sharemind.counselor.domain.ProfileRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProfileRecordRepository extends JpaRepository<ProfileRecord, Long> {
+
+}


### PR DESCRIPTION
## 📄구현 내용
- Resolved #213 
  - 상담사가 직접 수정할 수 있는 필드들만 수정 신청 시 저장되도록 구현하였습니다.

## 📝기타 알림사항
- 기존에 상담사의 상담 가격, 상담 시간, 상담 유형, 상담 카테고리를 저장하던 테이블들이 어디의 가격, 시간, 유형, 카테고리인지 약간 헷갈리는 것 같아 consult prefix를 달아주었습니다.