### PR TITLE
feat: 프론트 셧다운 상태 저장 및 확인 위한 api 구현

### DIFF
--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -48,4 +48,6 @@ public interface AdminService {
     InformationGetResponse getInformation();
 
     Boolean updateShutdown(Boolean shutdown);
+
+    Boolean getShutdown();
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -46,4 +46,6 @@ public interface AdminService {
     void deletePostByPostId(Long postId);
 
     InformationGetResponse getInformation();
+
+    Boolean updateShutdown(Boolean shutdown);
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -41,6 +41,8 @@ import com.example.sharemind.post.domain.Post;
 import com.example.sharemind.post.exception.PostErrorCode;
 import com.example.sharemind.post.exception.PostException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +52,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AdminServiceImpl implements AdminService {
+    private static final String SHUT_DOWN_KEY = "SHUT_DOWN";
 
     private final ConsultService consultService;
     private final LetterService letterService;
@@ -59,6 +62,7 @@ public class AdminServiceImpl implements AdminService {
     private final CustomerService customerService;
     private final PostService postService;
     private final EmailService emailService;
+    private final RedisTemplate<String, Boolean> redisTemplate;
 
     @Override
     public List<ConsultGetUnpaidResponse> getUnpaidConsults() {
@@ -294,5 +298,13 @@ public class AdminServiceImpl implements AdminService {
                 completedLetters, completedLetterCosts, canceledLetters, canceledLetterCosts,
                 publicPosts, completedPublicPosts, secretPosts, secretPostCosts,
                 completedSecretPosts, completedSecretPostCosts);
+    }
+
+    @Override
+    public Boolean updateShutdown(Boolean shutdown) {
+        ValueOperations<String, Boolean> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(SHUT_DOWN_KEY, shutdown);
+
+        return valueOperations.get(SHUT_DOWN_KEY);
     }
 }

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -307,4 +307,10 @@ public class AdminServiceImpl implements AdminService {
 
         return valueOperations.get(SHUT_DOWN_KEY);
     }
+
+    @Override
+    public Boolean getShutdown() {
+        ValueOperations<String, Boolean> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(SHUT_DOWN_KEY);
+    }
 }

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -304,4 +304,13 @@ public class AdminController {
     public ResponseEntity<Boolean> updateShutdown(@RequestParam Boolean shutdown) {
         return ResponseEntity.ok(adminService.updateShutdown(shutdown));
     }
+
+    @Operation(summary = "서비스 셧다운 여부 조회", description = "서비스 셧다운 여부 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공")
+    })
+    @GetMapping("/managements")
+    public ResponseEntity<Boolean> getShutdown() {
+        return ResponseEntity.ok(adminService.getShutdown());
+    }
 }

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -292,4 +292,16 @@ public class AdminController {
     public ResponseEntity<InformationGetResponse> getInformation() {
         return ResponseEntity.ok(adminService.getInformation());
     }
+
+    @Operation(summary = "서비스 셧다운 여부 수정", description = "서비스 셧다운 여부 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공")
+    })
+    @Parameters({
+            @Parameter(name = "shutdown", description = "true: 서비스 셧다운, false: 서비스 정상 동작")
+    })
+    @PatchMapping("/managements")
+    public ResponseEntity<Boolean> updateShutdown(@RequestParam Boolean shutdown) {
+        return ResponseEntity.ok(adminService.updateShutdown(shutdown));
+    }
 }


### PR DESCRIPTION
## 📄구현 내용
- Resolved #215 
- 지난주 회의에서 프론트 요청 사항이었던 '서비스 점검 화면 띄울지 여부 수정/확인'(?) 하는 api 구현하였습니다
  - 멍청하게 잠시 레디스를 까먹고 이걸 위해 테이블을 만들어야 되는건가 고민하다 생각난 레디스...

## 📝기타 알림사항
