### PR TITLE
fix: 아이디 그대로 넘겨줘서 사용자가 유추할 수 있는 부분 수정

### DIFF
--- a/src/main/java/com/example/sharemind/comment/application/CommentService.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentService.java
@@ -5,17 +5,18 @@ import com.example.sharemind.comment.dto.request.CommentCreateRequest;
 import com.example.sharemind.comment.dto.response.CommentGetResponse;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface CommentService {
-    List<CommentGetResponse> getCounselorComments(Long postId, Long customerId);
+    List<CommentGetResponse> getCounselorComments(UUID postUuid, Long customerId);
 
-    List<CommentGetResponse> getCustomerComments(Long postId, Long customerId);
+    List<CommentGetResponse> getCustomerComments(UUID postUuid, Long customerId);
 
     void createComment(CommentCreateRequest commentCreateRequest, Long customerId);
 
     Comment getCommentByCommentId(Long commentId);
 
-    void updateCustomerChosenComment(Long postId, Long commentId, Long customerId);
+    void updateCustomerChosenComment(UUID postUuid, Long commentId, Long customerId);
 
-    Boolean getIsCommentOwner(Long postId, Long customerId);
+    Boolean getIsCommentOwner(UUID postUuid, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/comment/application/CommentServiceImpl.java
@@ -14,6 +14,7 @@ import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.application.PostService;
 import com.example.sharemind.post.content.PostStatus;
 import com.example.sharemind.post.domain.Post;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +34,8 @@ public class CommentServiceImpl implements CommentService {
     private final CommentLikeRepository commentLikeRepository;
 
     @Override
-    public List<CommentGetResponse> getCounselorComments(Long postId, Long customerId) {
+    public List<CommentGetResponse> getCounselorComments(UUID postUuid, Long customerId) {
+        Long postId = postService.getPostByPostUuid(postUuid).getPostId();
         Post post = postService.checkAndGetCounselorPost(postId, customerId);
         Customer customer = customerService.getCustomerByCustomerId(customerId);
 
@@ -46,7 +48,8 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public List<CommentGetResponse> getCustomerComments(Long postId, Long customerId) {
+    public List<CommentGetResponse> getCustomerComments(UUID postUuid, Long customerId) {
+        Long postId = postService.getPostByPostUuid(postUuid).getPostId();
         Post post = postService.getPostByPostId(postId);
         post.checkReadAuthority(customerId);
 
@@ -70,7 +73,8 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     @Override
     public void createComment(CommentCreateRequest commentCreateRequest, Long customerId) {
-        Post post = postService.checkAndGetCounselorPost(commentCreateRequest.getPostId(),
+        Long postId = postService.getPostByPostUuid(commentCreateRequest.getPostUuid()).getPostId();
+        Post post = postService.checkAndGetCounselorPost(postId,
                 customerId);
         Customer customer = post.getCustomer();
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
@@ -95,9 +99,9 @@ public class CommentServiceImpl implements CommentService {
 
     @Transactional
     @Override
-    public void updateCustomerChosenComment(Long postId, Long commentId, Long customerId) {
+    public void updateCustomerChosenComment(UUID postUuid, Long commentId, Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
-        Post post = postService.getPostByPostId(postId);
+        Post post = postService.getPostByPostUuid(postUuid);
         post.checkWriteAuthority(customer);
         post.checkPostProceedingOrTimeOut();
 
@@ -110,8 +114,8 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public Boolean getIsCommentOwner(Long postId, Long customerId) {
-        Post post = postService.getPostByPostId(postId);
+    public Boolean getIsCommentOwner(UUID postUuid, Long customerId) {
+        Post post = postService.getPostByPostUuid(postUuid);
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
 
         return commentRepository.findByPostAndCounselorAndIsActivatedIsTrue(post, counselor) != null;

--- a/src/main/java/com/example/sharemind/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/example/sharemind/comment/dto/request/CommentCreateRequest.java
@@ -5,6 +5,7 @@ import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
 import lombok.Getter;
 
 @Getter
@@ -12,7 +13,7 @@ public class CommentCreateRequest {
 
     @Schema(description = "상담 id")
     @NotNull
-    private Long postId;
+    private UUID postUuid;
 
     @Schema(description = "content")
     private String content;

--- a/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/sharemind/comment/presentation/CommentController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +32,7 @@ public class CommentController {
 
     @Operation(summary = "상담사 사이드 일대다 상담 질문 단건의 댓글 조회", description = """
             - 상담사가 일대다 상담 질문에 대답하기 위한 상담 질문 단건의 댓글 조회
-            - 주소 형식: /api/v1/comments/counselors/1""")
+            - 주소 형식: /api/v1/comments/counselors/dd88d0d8-fc70-4394-b64a-726f31f48f9e""")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "1. 진행중이지 않은 상담\n 2. 마감된 상담 중 상담사 본인이 답변을 작성하지 않은 상담",
@@ -43,7 +44,7 @@ public class CommentController {
             @Parameter(name = "postId", description = "일대다 상담 ID")
     })
     @GetMapping("/counselors/{postId}")
-    public ResponseEntity<List<CommentGetResponse>> getCounselorComments(@PathVariable Long postId,
+    public ResponseEntity<List<CommentGetResponse>> getCounselorComments(@PathVariable UUID postId,
                                                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(commentService.getCounselorComments(postId,
                 customUserDetails.getCustomer().getCustomerId()));
@@ -83,7 +84,7 @@ public class CommentController {
             @Parameter(name = "postId", description = "일대다 상담 ID")
     })
     @GetMapping("/customers/{postId}")
-    public ResponseEntity<List<CommentGetResponse>> getCustomerComments(@PathVariable Long postId,
+    public ResponseEntity<List<CommentGetResponse>> getCustomerComments(@PathVariable UUID postId,
                                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(commentService.getCustomerComments(postId,
                 customUserDetails == null ? 0 : customUserDetails.getCustomer().getCustomerId()));
@@ -112,7 +113,7 @@ public class CommentController {
             @Parameter(name = "commentId", description = "답변 ID")
     })
     @PatchMapping("/customers/{postId}")
-    public ResponseEntity<Void> updateCustomerChosenComment(@PathVariable Long postId, @RequestParam Long commentId,
+    public ResponseEntity<Void> updateCustomerChosenComment(@PathVariable UUID postId, @RequestParam Long commentId,
                                                             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         commentService.updateCustomerChosenComment(postId, commentId, customUserDetails.getCustomer().getCustomerId());
         return ResponseEntity.ok().build();
@@ -131,7 +132,7 @@ public class CommentController {
             @Parameter(name = "postId", description = "일대다 상담 ID"),
     })
     @GetMapping("/counselors/authentication/{postId}")
-    public Boolean getIsCommentOwner(@PathVariable Long postId,
+    public Boolean getIsCommentOwner(@PathVariable UUID postId,
                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return commentService.getIsCommentOwner(postId, customUserDetails.getCustomer().getCustomerId());
     }

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -29,7 +29,7 @@ public class Consult extends BaseEntity {
     @Column(name = "consult_id")
     private Long consultId;
 
-    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    @Column(columnDefinition = "BINARY(16)", updatable = false)
     private UUID consultUuid;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -13,6 +13,7 @@ import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.review.domain.Review;
 import com.example.sharemind.customer.domain.Customer;
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -27,6 +28,9 @@ public class Consult extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "consult_id")
     private Long consultId;
+
+    @Column(columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+    private UUID consultUuid;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "customer_id")
@@ -65,6 +69,11 @@ public class Consult extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "payment_id", unique = true)
     private Payment payment;
+
+    @PrePersist
+    public void prePersist() {
+        this.consultUuid = UUID.randomUUID();
+    }
 
     @Builder
     public Consult(Customer customer, Counselor counselor, Long cost, ConsultType consultType) {

--- a/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/global/dto/response/ChatLetterGetResponse.java
@@ -9,6 +9,7 @@ import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.global.utils.*;
 import com.example.sharemind.letter.dto.response.LetterGetResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -47,8 +48,8 @@ public class ChatLetterGetResponse {
     @Schema(description = "리뷰 작성 여부")
     private final Boolean reviewCompleted;
 
-    @Schema(description = "상담 아이디")
-    private final Long consultId;
+    @Schema(description = "상담 uuid")
+    private final UUID consultUuid;
 
     @Schema(description = "채팅/편지 여부")
     private final Boolean isChat;
@@ -57,7 +58,8 @@ public class ChatLetterGetResponse {
         return new ChatLetterGetResponse(letterGetResponse.getLetterId(), letterGetResponse.getConsultStyle(),
                 letterGetResponse.getLetterStatus(), letterGetResponse.getOpponentName(),
                 letterGetResponse.getUpdatedAt(), letterGetResponse.getRecentContent(), null,
-                null, letterGetResponse.getReviewCompleted(), letterGetResponse.getConsultId(),
+                null, letterGetResponse.getReviewCompleted(),
+                letterGetResponse.getConsultUuid(),
                 IS_LETTER);
     }
 
@@ -70,7 +72,7 @@ public class ChatLetterGetResponse {
                     chat.changeChatStatusForChatList().getDisplayName(), nickname,
                     TimeUtil.getUpdatedAt(chat.getConsult().getUpdatedAt()),
                     counselor.getNickname() + "님께 고민내용을 남겨주세요. " + counselor.getNickname() + "님이 24시간 내에 채팅 요청을 드립니다.",
-                    null, 0, reviewCompleted, chat.getConsult().getConsultId(),
+                    null, 0, reviewCompleted, chat.getConsult().getConsultUuid(),
                     IS_CHAT);
         }
         String chatMessageContent = chatMessage.getContent();
@@ -87,6 +89,6 @@ public class ChatLetterGetResponse {
                 chat.changeChatStatusForChatList().getDisplayName(), nickname,
                 TimeUtil.getUpdatedAt(chatMessage.getUpdatedAt()),
                 chatMessageContent, chatMessage.getIsCustomer(), unreadMessageCount, reviewCompleted,
-                chat.getConsult().getConsultId(), IS_CHAT);
+                chat.getConsult().getConsultUuid(), IS_CHAT);
     }
 }

--- a/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
+++ b/src/main/java/com/example/sharemind/letter/dto/response/LetterGetResponse.java
@@ -6,6 +6,7 @@ import com.example.sharemind.letter.content.LetterStatus;
 import com.example.sharemind.letter.domain.Letter;
 import com.example.sharemind.letterMessage.domain.LetterMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -35,8 +36,8 @@ public class LetterGetResponse {
     @Schema(description = "리뷰 작성 여부")
     private final Boolean reviewCompleted;
 
-    @Schema(description = "상담 아이디")
-    private final Long consultId;
+    @Schema(description = "상담 uuid")
+    private final UUID consultUuid;
 
     public static ChatLetterGetResponse of(Letter letter, LetterMessage recentMessage, Boolean isCustomer) {
         String letterStatus;
@@ -58,12 +59,13 @@ public class LetterGetResponse {
         if (recentMessage == null) {
             return ChatLetterGetResponse.of(new LetterGetResponse(letter.getLetterId(), letterStatus,
                     letter.getConsult().getCounselor().getConsultStyle().getDisplayName(), opponentName,
-                    TimeUtil.getUpdatedAt(letter.getConsult().getUpdatedAt()), null, reviewCompleted, letter.getConsult().getConsultId()));
+                    TimeUtil.getUpdatedAt(letter.getConsult().getUpdatedAt()), null, reviewCompleted,
+                    letter.getConsult().getConsultUuid()));
         }
 
         return ChatLetterGetResponse.of(new LetterGetResponse(letter.getLetterId(), letterStatus,
                 letter.getConsult().getCounselor().getConsultStyle().getDisplayName(), opponentName,
                 TimeUtil.getUpdatedAt((recentMessage.getUpdatedAt())), recentMessage.getContent(), reviewCompleted,
-                letter.getConsult().getConsultId()));
+                letter.getConsult().getConsultUuid()));
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -8,6 +8,7 @@ import com.example.sharemind.post.dto.response.*;
 import com.example.sharemind.searchWord.dto.request.SearchWordPostFindRequest;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 public interface PostService {
 
@@ -19,30 +20,32 @@ public interface PostService {
 
     Post getPostByPostId(Long postId);
 
+    Post getPostByPostUuid(UUID postUuid);
+
     void updatePost(PostUpdateRequest postUpdateRequest, Long customerId);
 
-    PostGetResponse getPost(Long postId, Long customerId);
+    PostGetResponse getPost(UUID postId, Long customerId);
 
-    List<PostGetCustomerListResponse> getPostsByCustomer(Boolean filter, Long postId,
+    List<PostGetCustomerListResponse> getPostsByCustomer(Boolean filter, UUID postId,
             Long customerId);
 
-    List<PostGetCounselorListResponse> getPostsByCounselor(Boolean filter, Long postId,
+    List<PostGetCounselorListResponse> getPostsByCounselor(Boolean filter, UUID postUuid,
             Long customerId);
 
-    List<PostGetPublicListResponse> getPublicPostsByCustomer(Long postId, LocalDateTime finishedAt,
+    List<PostGetPublicListResponse> getPublicPostsByCustomer(UUID postUuid, LocalDateTime finishedAt,
             Long customerId);
 
-    List<PostGetPublicListResponse> getPopularityPosts(Long postId, LocalDateTime finishedAt,
+    List<PostGetPublicListResponse> getPopularityPosts(UUID postUuid, LocalDateTime finishedAt,
             Long customerId);
 
-    List<Long> getRandomPosts();
+    List<UUID> getRandomPosts();
 
-    PostGetResponse getCounselorPostContent(Long postId, Long customerId);
+    PostGetResponse getCounselorPostContent(UUID postId, Long customerId);
 
     Post checkAndGetCounselorPost(Long postId, Long customerId);
 
     List<Post> getPostByWordWithPagination(SearchWordPostFindRequest searchWordPostFindRequest,
             String sortType);
 
-    Boolean getIsPostOwner(Long postId, Long customerId);
+    Boolean getIsPostOwner(UUID postUuid, Long customerId);
 }

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -16,8 +16,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +36,9 @@ public class Post extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
     private Long postId;
+
+    @Column(columnDefinition = "BINARY(16)", updatable = false)
+    private UUID postUuid;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "customer_id")
@@ -79,6 +84,11 @@ public class Post extends BaseEntity {
 
     @Column(name = "finished_at")
     private LocalDateTime finishedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.postUuid = UUID.randomUUID();
+    }
 
     @Builder
     public Post(Customer customer, Long cost, Boolean isPublic) {

--- a/src/main/java/com/example/sharemind/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/example/sharemind/post/dto/request/PostUpdateRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 import lombok.Getter;
 
 @Getter
@@ -11,7 +12,7 @@ public class PostUpdateRequest {
 
     @Schema(description = "일대다 상담 아이디")
     @NotNull(message = "일대다 상담 아이디는 공백일 수 없습니다.")
-    private Long postId;
+    private UUID postUuid;
 
     @Schema(description = "선택한 상담 카테고리", example = "BOREDOM")
     @NotBlank(message = "상담 카테고리는 공백일 수 없습니다.")

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetCounselorListResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetCounselorListResponse.java
@@ -5,6 +5,7 @@ import com.example.sharemind.global.utils.TimeUtil;
 import com.example.sharemind.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ import lombok.Getter;
 public class PostGetCounselorListResponse {
 
     @Schema(description = "일대다 질문 아이디")
-    private final Long postId;
+    private final UUID postUuid;
 
     @Schema(description = "제목")
     private final String title;
@@ -42,10 +43,10 @@ public class PostGetCounselorListResponse {
     private final Boolean isChosen;
 
     @Builder
-    public PostGetCounselorListResponse(Long postId, String title, String content, String consultCategory,
+    public PostGetCounselorListResponse(UUID postUuid, String title, String content, String consultCategory,
                                         Boolean isPublic, Long totalLike, Long totalScrap, Long totalComment,
                                         String publishedAt, Boolean isChosen) {
-        this.postId = postId;
+        this.postUuid = postUuid;
         this.title = title;
         this.content = content;
         this.consultCategory = consultCategory;
@@ -59,7 +60,7 @@ public class PostGetCounselorListResponse {
 
     public static PostGetCounselorListResponse of(Post post, Comment comment) {
         return PostGetCounselorListResponse.builder()
-                .postId(post.getPostId())
+                .postUuid(post.getPostUuid())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .consultCategory(post.getConsultCategory().getDisplayName())

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetCustomerListResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetCustomerListResponse.java
@@ -5,6 +5,7 @@ import com.example.sharemind.post.domain.Post;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ import lombok.Getter;
 public class PostGetCustomerListResponse {
 
     @Schema(description = "일대다 질문 아이디")
-    private final Long postId;
+    private final UUID postUuid;
 
     @Schema(description = "임시저장 여부")
     private final Boolean isCompleted;
@@ -49,10 +50,10 @@ public class PostGetCustomerListResponse {
     private final LocalDateTime finishedAt;
 
     @Builder
-    public PostGetCustomerListResponse(Long postId, Boolean isCompleted, String title,
+    public PostGetCustomerListResponse(UUID postUuid, Boolean isCompleted, String title,
             String content, Boolean isPublic, Boolean isLiked, Long totalLike, Boolean isScrapped,
             Long totalScrap, Long totalComment, String updatedAt, LocalDateTime finishedAt) {
-        this.postId = postId;
+        this.postUuid = postUuid;
         this.isCompleted = isCompleted;
         this.title = title;
         this.content = content;
@@ -68,7 +69,7 @@ public class PostGetCustomerListResponse {
 
     public static PostGetCustomerListResponse of(Post post, Boolean isLiked, Boolean isScrapped) {
         return PostGetCustomerListResponse.builder()
-                .postId(post.getPostId())
+                .postUuid(post.getPostUuid())
                 .isCompleted(post.getIsCompleted())
                 .title(post.getTitle())
                 .content(post.getContent())
@@ -85,7 +86,7 @@ public class PostGetCustomerListResponse {
 
     public static PostGetCustomerListResponse ofIsNotCompleted(Post post) {
         return PostGetCustomerListResponse.builder()
-                .postId(post.getPostId())
+                .postUuid(post.getPostUuid())
                 .isCompleted(post.getIsCompleted())
                 .title(null)
                 .content(null)

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetPublicListResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetPublicListResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +14,7 @@ import lombok.Getter;
 public class PostGetPublicListResponse {
 
     @Schema(description = "일대다 질문 아이디")
-    private final Long postId;
+    private final UUID postUuid;
 
     @Schema(description = "제목")
     private final String title;
@@ -44,10 +45,10 @@ public class PostGetPublicListResponse {
     private final LocalDateTime finishedAt;
 
     @Builder
-    public PostGetPublicListResponse(Long postId, String title, String content, Boolean isLiked,
+    public PostGetPublicListResponse(UUID postUuid, String title, String content, Boolean isLiked,
             Long totalLike, Boolean isScrapped, Long totalScrap, Long totalComment,
             String updatedAt, LocalDateTime finishedAt) {
-        this.postId = postId;
+        this.postUuid = postUuid;
         this.title = title;
         this.content = content;
         this.isLiked = isLiked;
@@ -61,7 +62,7 @@ public class PostGetPublicListResponse {
 
     public static PostGetPublicListResponse of(Post post, Boolean isLiked, Boolean isScrapped) {
         return PostGetPublicListResponse.builder()
-                .postId(post.getPostId())
+                .postUuid(post.getPostUuid())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .isLiked(isLiked)

--- a/src/main/java/com/example/sharemind/post/dto/response/PostGetResponse.java
+++ b/src/main/java/com/example/sharemind/post/dto/response/PostGetResponse.java
@@ -3,6 +3,7 @@ package com.example.sharemind.post.dto.response;
 import com.example.sharemind.global.utils.TimeUtil;
 import com.example.sharemind.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,7 +11,7 @@ import lombok.Getter;
 public class PostGetResponse {
 
     @Schema(description = "일대다 질문 아이디")
-    private final Long postId;
+    private final UUID postUuid;
 
     @Schema(description = "상담 카테고리", example = "권태기")
     private final String consultCategory;
@@ -40,10 +41,10 @@ public class PostGetResponse {
     private final String updatedAt;
 
     @Builder
-    public PostGetResponse(Long postId, String consultCategory, String title, String content,
+    public PostGetResponse(UUID postUuid, String consultCategory, String title, String content,
             Boolean isPublic, Boolean isLiked, Long totalLike, Boolean isScrapped, Long totalScrap,
             String updatedAt) {
-        this.postId = postId;
+        this.postUuid = postUuid;
         this.consultCategory = consultCategory;
         this.title = title;
         this.content = content;
@@ -57,7 +58,7 @@ public class PostGetResponse {
 
     public static PostGetResponse of(Post post, Boolean isLiked, Boolean isScrapped) {
         return PostGetResponse.builder()
-                .postId(post.getPostId())
+                .postUuid(post.getPostUuid())
                 .consultCategory(post.getConsultCategory().getDisplayName())
                 .title(post.getTitle())
                 .content(post.getContent())

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -95,7 +96,7 @@ public class PostController {
             @Parameter(name = "postId", description = "일대다 질문 아이디")
     })
     @GetMapping("/{postId}")
-    public ResponseEntity<PostGetResponse> getPost(@PathVariable Long postId,
+    public ResponseEntity<PostGetResponse> getPost(@PathVariable UUID postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(postService.getPost(postId,
                 customUserDetails == null ? 0 : customUserDetails.getCustomer().getCustomerId()));
@@ -115,13 +116,13 @@ public class PostController {
             @Parameter(name = "filter", description = "완료/취소된 상담 제외: true, 포함: false"),
             @Parameter(name = "postId", description = """
                     - 조회 결과는 4개씩 반환하며, postId로 구분
-                    1. 최초 조회 요청이면 postId는 0
+                    1. 최초 조회 요청이면 postId는 00000000-0000-0000-0000-000000000000
                     2. 2번째 요청부터 postId는 직전 요청의 조회 결과 4개 중 마지막 postId""")
     })
     @GetMapping("/customers")
     public ResponseEntity<List<PostGetCustomerListResponse>> getPostsByCustomer(
             @RequestParam Boolean filter,
-            @RequestParam Long postId,
+            @RequestParam UUID postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(postService.getPostsByCustomer(filter, postId,
                 customUserDetails.getCustomer().getCustomerId()));
@@ -137,13 +138,13 @@ public class PostController {
             @Parameter(name = "filter", description = "완료/취소된 상담 제외: true, 포함: false"),
             @Parameter(name = "postId", description = """
                     - 조회 결과는 4개씩 반환하며, postId로 구분
-                    1. 최초 조회 요청이면 postId는 0
+                    1. 최초 조회 요청이면 postId는 00000000-0000-0000-0000-000000000000
                     2. 2번째 요청부터 postId는 직전 요청의 조회 결과 4개 중 마지막 postId""")
     })
     @GetMapping("/counselors")
     public ResponseEntity<List<PostGetCounselorListResponse>> getPostsByCounselor(
             @RequestParam Boolean filter,
-            @RequestParam Long postId,
+            @RequestParam UUID postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(postService.getPostsByCounselor(filter, postId,
                 customUserDetails.getCustomer().getCustomerId()));
@@ -159,7 +160,7 @@ public class PostController {
     @Parameters({
             @Parameter(name = "postId", description = """
                     - 조회 결과는 4개씩 반환하며, postId와 finishedAt으로 구분
-                    1. 최초 조회 요청이면 postId는 0
+                    1. 최초 조회 요청이면 postId는 00000000-0000-0000-0000-000000000000
                     2. 2번째 요청부터 postId는 직전 요청의 조회 결과 4개 중 마지막 postId"""),
             @Parameter(name = "finishedAt", description = """
                     1. 최초 조회 요청이면 지금 시간
@@ -168,7 +169,7 @@ public class PostController {
     })
     @GetMapping("/customers/public")
     public ResponseEntity<List<PostGetPublicListResponse>> getPublicPostsByCustomer(
-            @RequestParam Long postId,
+            @RequestParam UUID postId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime finishedAt,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(postService.getPublicPostsByCustomer(postId, finishedAt,
@@ -185,7 +186,7 @@ public class PostController {
     @Parameters({
             @Parameter(name = "postId", description = """
                     - 조회 결과는 4개씩 반환하며, postId와 finishedAt으로 구분
-                    1. 최초 조회 요청이면 postId는 0
+                    1. 최초 조회 요청이면 postId는 00000000-0000-0000-0000-000000000000
                     2. 2번째 요청부터 postId는 직전 요청의 조회 결과 4개 중 마지막 postId"""),
             @Parameter(name = "finishedAt", description = """
                     1. 최초 조회 요청이면 지금 시간
@@ -194,7 +195,7 @@ public class PostController {
     })
     @GetMapping("/customers/public/likes")
     public ResponseEntity<List<PostGetPublicListResponse>> getPopularityPosts(
-            @RequestParam Long postId,
+            @RequestParam UUID postId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime finishedAt,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(postService.getPopularityPosts(postId, finishedAt,
@@ -209,7 +210,7 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
     })
     @GetMapping("/counselors/random")
-    public ResponseEntity<List<Long>> getRandomPosts() {
+    public ResponseEntity<List<UUID>> getRandomPosts() {
         return ResponseEntity.ok(postService.getRandomPosts());
     }
 
@@ -228,7 +229,7 @@ public class PostController {
                     - 일대다 상담 ID""")
     })
     @GetMapping("/counselors/{postId}")
-    public ResponseEntity<PostGetResponse> getPostInfo(@PathVariable Long postId,
+    public ResponseEntity<PostGetResponse> getPostInfo(@PathVariable UUID postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(postService.getCounselorPostContent(postId,
                 customUserDetails.getCustomer().getCustomerId()));
@@ -247,7 +248,7 @@ public class PostController {
             @Parameter(name = "postId", description = "일대다 질문 아이디")
     })
     @GetMapping("/customers/public/{postId}")
-    public Boolean getIsPostOwner(@PathVariable Long postId,
+    public Boolean getIsPostOwner(@PathVariable UUID postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return postService.getIsPostOwner(postId,
                 customUserDetails == null ? 0 : customUserDetails.getCustomer().getCustomerId());

--- a/src/main/java/com/example/sharemind/post/repository/PostRepository.java
+++ b/src/main/java/com/example/sharemind/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.example.sharemind.post.repository;
 import com.example.sharemind.post.domain.Post;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,8 @@ import org.springframework.stereotype.Repository;
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 
     Optional<Post> findByPostIdAndIsActivatedIsTrue(Long postId);
+
+    Optional<Post> findByPostUuidAndIsActivatedIsTrue(UUID postUuid);
 
     List<Post> findAllByIsActivatedIsTrue();
 
@@ -27,13 +30,13 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
             + "AND total_comment > 0", nativeQuery = true)
     List<Post> findAllCommentedProceedingPublicPostsAfter72Hours();
 
-    @Query(value = "SELECT post_id FROM post "
+    @Query(value = "SELECT post_uuid FROM post "
             + "WHERE post_status = 'PROCEEDING' AND is_activated = true "
             + "AND published_at <= CURRENT_TIMESTAMP - INTERVAL 1 DAY ORDER BY RAND() LIMIT 50", nativeQuery = true)
-    List<Long> findRandomProceedingPostIdsAfter24Hours();
+    List<UUID> findRandomProceedingPostIdsAfter24Hours();
 
-    @Query(value = "SELECT post_id FROM post "
+    @Query(value = "SELECT post_uuid FROM post "
             + "WHERE post_status = 'PROCEEDING' AND is_activated = true "
             + "AND published_at > CURRENT_TIMESTAMP - INTERVAL 1 DAY ORDER BY RAND() LIMIT 50", nativeQuery = true)
-    List<Long> findRandomProceedingPostIdsWithin24Hours();
+    List<UUID> findRandomProceedingPostIdsWithin24Hours();
 }


### PR DESCRIPTION
## 📄구현 내용
- 전에 했던 consult와 post관련하여 일차적으로 수정하였습니다. 프론트쪽에서 문제가 없다고 하면 이어서 작업할 예정입니다!

## 📝기타 알림사항
- UUID 관련해서 generateValue 어노테이션을 썼는데 해당 어노테이션은 PK일 때만 된다고 합니다ㅜ.ㅜ 그래서 @PrePersist 이용하여 null 일때 생성해주는 방식을 사용했습니다.
- 문제가 없다면 db에 UUID 필드 업데이트 해서 반영하겠습니다.
- 프론트쪽에서 id를 받을 일이 없으니, 해당하는 부분에서 requestParam으로 넘길 때는 그냥 id로 받았습니다. 다만 request dto같은 경우 getter를 사용할 때 백엔드 로직에서 명확하게 보기 위해서 uuid로 넘겨 받았습니다.