### PR TITLE
feat: 어드민 페이지 상담사, 사용자 이메일 정보 추가

### DIFF
--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -197,8 +197,7 @@ public class AdminServiceImpl implements AdminService {
     public List<CounselorGetByNicknameOrEmailResponse> getCounselorsByNicknameOrEmail(
             String keyword) {
         return counselorService.getCounselorsByNicknameOrEmail(keyword).stream()
-                .map(counselor -> CounselorGetByNicknameOrEmailResponse.of(counselor,
-                        customerService.getCustomerByCounselor(counselor).getEmail()))
+                .map(CounselorGetByNicknameOrEmailResponse::of)
                 .toList();
     }
 

--- a/src/main/java/com/example/sharemind/admin/dto/response/ConsultGetUnpaidResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/ConsultGetUnpaidResponse.java
@@ -1,15 +1,15 @@
 package com.example.sharemind.admin.dto.response;
 
 import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConsultGetUnpaidResponse {
 
     @Schema(description = "상담 아이디")
@@ -18,8 +18,14 @@ public class ConsultGetUnpaidResponse {
     @Schema(description = "구매자 닉네임")
     private final String customerName;
 
+    @Schema(description = "구매자 이메일")
+    private final String customerEmail;
+
     @Schema(description = "판매자 닉네임")
     private final String counselorName;
+
+    @Schema(description = "판매자 이메일")
+    private final String counselorEmail;
 
     @Schema(description = "상담 유형", example = "편지")
     private final String consultType;
@@ -30,8 +36,34 @@ public class ConsultGetUnpaidResponse {
     @Schema(description = "상담 신청 일시")
     private final LocalDateTime createdAt;
 
+    @Builder
+    public ConsultGetUnpaidResponse(Long consultId, String customerName, String customerEmail,
+            String counselorName, String counselorEmail, String consultType, Long cost,
+            LocalDateTime createdAt) {
+        this.consultId = consultId;
+        this.customerName = customerName;
+        this.customerEmail = customerEmail;
+        this.counselorName = counselorName;
+        this.counselorEmail = counselorEmail;
+        this.consultType = consultType;
+        this.cost = cost;
+        this.createdAt = createdAt;
+    }
+
+
     public static ConsultGetUnpaidResponse of(Consult consult) {
-        return new ConsultGetUnpaidResponse(consult.getConsultId(), consult.getCustomer().getNickname(), consult.getCounselor().getNickname(),
-                consult.getConsultType().getDisplayName(), consult.getCost(), consult.getCreatedAt());
+        Customer customer = consult.getCustomer();
+        Counselor counselor = consult.getCounselor();
+
+        return ConsultGetUnpaidResponse.builder()
+                .consultId(consult.getConsultId())
+                .customerName(customer.getNickname())
+                .customerEmail(customer.getEmail())
+                .counselorName(counselor.getNickname())
+                .counselorEmail(counselor.getEmail())
+                .consultType(consult.getConsultType().getDisplayName())
+                .cost(consult.getCost())
+                .createdAt(consult.getCreatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/dto/response/CounselorGetByNicknameOrEmailResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/CounselorGetByNicknameOrEmailResponse.java
@@ -29,11 +29,11 @@ public class CounselorGetByNicknameOrEmailResponse {
         this.profileStatus = profileStatus;
     }
 
-    public static CounselorGetByNicknameOrEmailResponse of(Counselor counselor, String email) {
+    public static CounselorGetByNicknameOrEmailResponse of(Counselor counselor) {
         return CounselorGetByNicknameOrEmailResponse.builder()
                 .counselorId(counselor.getCounselorId())
                 .nickname(counselor.getNickname())
-                .email(email)
+                .email(counselor.getEmail())
                 .profileStatus(counselor.getProfileStatus().getDisplayName())
                 .build();
     }

--- a/src/main/java/com/example/sharemind/admin/dto/response/PaymentGetRefundWaitingResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/PaymentGetRefundWaitingResponse.java
@@ -1,17 +1,17 @@
 package com.example.sharemind.admin.dto.response;
 
 import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.domain.Payment;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentGetRefundWaitingResponse {
 
     @Schema(description = "결제 정보 아이디")
@@ -20,8 +20,14 @@ public class PaymentGetRefundWaitingResponse {
     @Schema(description = "구매자 닉네임")
     private final String customerNickname;
 
+    @Schema(description = "구매자 이메일")
+    private final String customerEmail;
+
     @Schema(description = "상담사 닉네임")
     private final String counselorNickname;
+
+    @Schema(description = "상담사 이메일")
+    private final String counselorEmail;
 
     @Schema(description = "상담 진행 상태", example = "상담 중")
     private final String status;
@@ -43,12 +49,41 @@ public class PaymentGetRefundWaitingResponse {
     @Schema(description = "결제 수단", example = "외부 결제")
     private final String method;
 
+    @Builder
+    public PaymentGetRefundWaitingResponse(Long paymentId, String customerNickname,
+            String customerEmail, String counselorNickname, String counselorEmail, String status,
+            String consultType, LocalDateTime consultedAt, Long cost, LocalDateTime paidAt,
+            String method) {
+        this.paymentId = paymentId;
+        this.customerNickname = customerNickname;
+        this.customerEmail = customerEmail;
+        this.counselorNickname = counselorNickname;
+        this.counselorEmail = counselorEmail;
+        this.status = status;
+        this.consultType = consultType;
+        this.consultedAt = consultedAt;
+        this.cost = cost;
+        this.paidAt = paidAt;
+        this.method = method;
+    }
+
     public static PaymentGetRefundWaitingResponse of(Payment payment) {
         Consult consult = payment.getConsult();
+        Customer customer = consult.getCustomer();
+        Counselor counselor = consult.getCounselor();
 
-        return new PaymentGetRefundWaitingResponse(payment.getPaymentId(), consult.getCustomer().getNickname(),
-                consult.getCounselor().getNickname(), consult.getConsultStatus().name(),
-                consult.getConsultType().getDisplayName(), consult.getConsultedAt(), consult.getCost(),
-                payment.getCreatedAt(), payment.getMethod());
+        return PaymentGetRefundWaitingResponse.builder()
+                .paymentId(payment.getPaymentId())
+                .customerNickname(customer.getNickname())
+                .customerEmail(customer.getEmail())
+                .counselorNickname(counselor.getNickname())
+                .counselorEmail(counselor.getEmail())
+                .status(consult.getConsultStatus().getDisplayName())
+                .consultType(consult.getConsultType().getDisplayName())
+                .consultedAt(consult.getConsultedAt())
+                .cost(consult.getCost())
+                .paidAt(payment.getCreatedAt())
+                .method(payment.getMethod())
+                .build();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/dto/response/PaymentGetSettlementOngoingResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/PaymentGetSettlementOngoingResponse.java
@@ -2,17 +2,16 @@ package com.example.sharemind.admin.dto.response;
 
 import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.counselor.domain.Counselor;
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.domain.Payment;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentGetSettlementOngoingResponse {
 
     @Schema(description = "결제 정보 아이디")
@@ -21,8 +20,14 @@ public class PaymentGetSettlementOngoingResponse {
     @Schema(description = "구매자 닉네임")
     private final String customerNickname;
 
+    @Schema(description = "구매자 이메일")
+    private final String customerEmail;
+
     @Schema(description = "상담사 닉네임")
     private final String counselorNickname;
+
+    @Schema(description = "상담사 이메일")
+    private final String counselorEmail;
 
     @Schema(description = "상담 유형", example = "편지")
     private final String consultType;
@@ -43,13 +48,41 @@ public class PaymentGetSettlementOngoingResponse {
     @Schema(description = "예금주명", example = "김뫄뫄")
     private final String accountHolder;
 
+    @Builder
+    public PaymentGetSettlementOngoingResponse(Long paymentId, String customerNickname,
+            String customerEmail, String counselorNickname, String counselorEmail,
+            String consultType, LocalDateTime consultedAt, Long cost, String bank, String account,
+            String accountHolder) {
+        this.paymentId = paymentId;
+        this.customerNickname = customerNickname;
+        this.customerEmail = customerEmail;
+        this.counselorNickname = counselorNickname;
+        this.counselorEmail = counselorEmail;
+        this.consultType = consultType;
+        this.consultedAt = consultedAt;
+        this.cost = cost;
+        this.bank = bank;
+        this.account = account;
+        this.accountHolder = accountHolder;
+    }
+
     public static PaymentGetSettlementOngoingResponse of(Payment payment) {
         Consult consult = payment.getConsult();
+        Customer customer = consult.getCustomer();
         Counselor counselor = consult.getCounselor();
 
-        return new PaymentGetSettlementOngoingResponse(payment.getPaymentId(), consult.getCustomer().getNickname(),
-                consult.getCounselor().getNickname(), consult.getConsultType().getDisplayName(),
-                consult.getConsultedAt(), consult.getCost(), counselor.getBank(), counselor.getAccount(),
-                counselor.getAccountHolder());
+        return PaymentGetSettlementOngoingResponse.builder()
+                .paymentId(payment.getPaymentId())
+                .customerNickname(customer.getNickname())
+                .customerEmail(customer.getEmail())
+                .counselorNickname(counselor.getNickname())
+                .counselorEmail(counselor.getEmail())
+                .consultType(consult.getConsultType().getDisplayName())
+                .consultedAt(consult.getConsultedAt())
+                .cost(consult.getCost())
+                .bank(counselor.getBank())
+                .account(counselor.getAccount())
+                .accountHolder(counselor.getAccountHolder())
+                .build();
     }
 }

--- a/src/main/java/com/example/sharemind/admin/dto/response/PostGetUnpaidPrivateResponse.java
+++ b/src/main/java/com/example/sharemind/admin/dto/response/PostGetUnpaidPrivateResponse.java
@@ -1,5 +1,6 @@
 package com.example.sharemind.admin.dto.response;
 
+import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -15,6 +16,9 @@ public class PostGetUnpaidPrivateResponse {
     @Schema(description = "구매자 닉네임")
     private final String customerName;
 
+    @Schema(description = "구매자 이메일")
+    private final String customerEmail;
+
     @Schema(description = "상담료")
     private final Long cost;
 
@@ -25,19 +29,23 @@ public class PostGetUnpaidPrivateResponse {
     private final LocalDateTime createdAt;
 
     @Builder
-    public PostGetUnpaidPrivateResponse(Long postId, String customerName, Long cost,
-            Boolean isPublic, LocalDateTime createdAt) {
+    public PostGetUnpaidPrivateResponse(Long postId, String customerName, String customerEmail,
+            Long cost, Boolean isPublic, LocalDateTime createdAt) {
         this.postId = postId;
         this.customerName = customerName;
+        this.customerEmail = customerEmail;
         this.cost = cost;
         this.isPublic = isPublic;
         this.createdAt = createdAt;
     }
 
     public static PostGetUnpaidPrivateResponse of(Post post) {
+        Customer customer = post.getCustomer();
+
         return PostGetUnpaidPrivateResponse.builder()
                 .postId(post.getPostId())
-                .customerName(post.getCustomer().getNickname())
+                .customerName(customer.getNickname())
+                .customerEmail(customer.getEmail())
                 .cost(post.getCost())
                 .isPublic(post.getIsPublic())
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -93,6 +93,7 @@ public class CounselorServiceImpl implements CounselorService {
             Counselor counselor = counselorRepository.save(
                     Counselor.builder()
                             .nickname(nickname)
+                            .email(customer.getEmail())
                             .build()
             );
             customer.setCounselor(counselor);

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -34,7 +34,7 @@ public class Counselor extends BaseEntity {
     private String nickname;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private String email;
 
     @Column(name = "is_educated")

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -9,6 +9,7 @@ import com.example.sharemind.counselor.content.ConsultStyle;
 import com.example.sharemind.global.content.ConsultType;
 import jakarta.persistence.*;
 
+import jakarta.validation.constraints.Email;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -31,6 +32,10 @@ public class Counselor extends BaseEntity {
     @Size(min = 1, max = 8, message = "닉네임은 최대 8자입니다.")
     @Column(unique = true, nullable = false)
     private String nickname;
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Column(nullable = false)
+    private String email;
 
     @Column(name = "is_educated")
     private Boolean isEducated;
@@ -106,8 +111,9 @@ public class Counselor extends BaseEntity {
     private Settlement settlement;
 
     @Builder
-    public Counselor(String nickname) {
+    public Counselor(String nickname, String email) {
         this.nickname = nickname;
+        this.email = email;
         this.level = 0;
         this.totalReview = 0L;
         this.ratingAverage = 0.0;

--- a/src/main/java/com/example/sharemind/customer/domain/Customer.java
+++ b/src/main/java/com/example/sharemind/customer/domain/Customer.java
@@ -28,7 +28,7 @@ public class Customer extends BaseEntity {
     private String nickname;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private String email;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 📄구현 내용
- Resolved #235 
  - 지난주 회의에서 나온 기획 파트 요청사항 반영하였습니다.

## 📝기타 알림사항
- 상담사의 이메일이 조회되는 니즈가 많은 것 같아 counselor 엔티티에 아예 email 필드를 추가해보았습니다. 이렇게 하면 counselor에 해당하는 customer를 찾지 않아도 돼서 쿼리가 한 번 덜 나갑니다...! 
괜찮으신 것 같으면 상담사 이메일 필드가 있는 다른 어드민 response dto에도 적용해보겠습니다.
- 수정한 dto 중 requriedArgsConstructor가 적용되어있는 dto에 대해 빌더 -> 정적 팩토리 메서드 플로우로 이루어지도록 수정하였습니다.
  - 이렇게 하나하나씩 수정하다보면... 언젠가는 다 수정할 수 있겠죠...😂