### PR TITLE
feat: 테스트 서버 분리 위한 github actions workflow 설정 추가

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,9 +1,9 @@
-name: sharemind-deploy
+name: sharemind-prod-deploy
 
 on:
   push:
     branches:
-      - 'develop'
+      - 'main'
 
 jobs:
   build:

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -1,0 +1,62 @@
+name: sharemind-test-deploy
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Make application.yml
+        run: |
+          cd ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.PROPERTIES_TEST }}" > ./application.yml
+        shell: bash
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        shell: bash
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test
+        shell: bash
+
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DDTHH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Generate deployment package
+        run: |
+          mkdir -p deploy
+          cp build/libs/*.jar deploy/application.jar
+          cp Procfile deploy/Procfile
+          cp -r .ebextensions deploy/.ebextensions
+          cp -r .platform deploy/.platform
+          cd deploy && zip -r deploy.zip .
+
+      - name: Deploy to EB
+        uses: einaregilsson/beanstalk-deploy@v21
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
+          application_name: Sharemind-test
+          environment_name: Sharemind-test-env
+          version_label: github-actions-${{steps.current-time.outputs.formattedTime}}
+          region: ap-northeast-2
+          deployment_package: deploy/deploy.zip

--- a/src/main/java/com/example/sharemind/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SwaggerConfig.java
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
 
     @Bean
-    public OpenAPI openAPI(@Value("${springdoc.version}") String springdocVersion) {
+    public OpenAPI openAPI(@Value("${springdoc.version}") String springdocVersion,
+            @Value("${swagger.url}") String swaggerUrl) {
         Info info = new Info()
                 .title("Sharemind API Document")
                 .version(springdocVersion)
@@ -31,7 +32,7 @@ public class SwaggerConfig {
                         .bearerFormat("JWT"));
 
         return new OpenAPI()
-                .addServersItem(new Server().url("https://server.sharemindapp.com"))
+                .addServersItem(new Server().url(swaggerUrl))
                 .components(new Components())
                 .info(info)
                 .addSecurityItem(securityRequirement)


### PR DESCRIPTION
## 📄구현 내용
- Resolved #238 
  - main 브랜치에 push 되면 메인 서버에, develop 브랜치에 push 되면 이번에 새로 만든 테스트 서버에 배포되도록 설정했습니다.
  - 테스트용 aws 계정에 셋팅 완료했습니다.
  - deploy_test.yml에 필요한 키 값들도 깃헙에 설정해두었습니다. yml 파일은 노션에 업로드해두었습니다.

## 📝기타 알림사항
- 테스트용 서버를 만들면서 디비와 레디스도 테스트용으로 따로 만들었습니다.
- 서버별로 올바른 스웨거 url을 사용할 수 있도록 스웨거 url을 환경변수로 처리했습니다. yml 업데이트된 부분은 노션에서 확인하실 수 있습니다.