### PR TITLE
feat: 결제 외부 api 연결 및 플로우 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.4'
-    id 'io.spring.dependency-management' version '1.1.3'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.example'

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -84,7 +84,11 @@ public class AdminServiceImpl implements AdminService {
 
                 consult.updateIsPaidAndLetter(letter);
             }
-            case CHAT -> chatService.createChat(consult);
+            case CHAT -> {
+                Chat chat = chatService.createChat(consult);
+
+                consult.updateIsPaidAndChat(chat);
+            }
         }
     }
 

--- a/src/main/java/com/example/sharemind/chat/application/ChatService.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatService.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface ChatService {
-    void createChat(Consult consult);
+    Chat createChat(Consult consult);
 
     Chat getChatByChatId(Long chatId);
     List<Chat> getAllChats();

--- a/src/main/java/com/example/sharemind/chat/application/ChatServiceImpl.java
+++ b/src/main/java/com/example/sharemind/chat/application/ChatServiceImpl.java
@@ -60,7 +60,7 @@ public class ChatServiceImpl implements ChatService {
     private final ChatNoticeService chatNoticeService;
 
     @Override
-    public void createChat(Consult consult) {
+    public Chat createChat(Consult consult) {
         Chat chat = Chat.newInstance();
         chatRepository.save(chat);
 
@@ -71,6 +71,8 @@ public class ChatServiceImpl implements ChatService {
         notifyNewChat(chat, consult);
 
         chatTaskScheduler.checkAutoRefund(chat);
+
+        return chat;
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/consult/application/ConsultService.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultService.java
@@ -11,7 +11,7 @@ import com.example.sharemind.global.content.ConsultType;
 import java.util.List;
 
 public interface ConsultService {
-    void createConsult(ConsultCreateRequest consultCreateRequest, Long customerId);
+    Long createConsult(ConsultCreateRequest consultCreateRequest, Long customerId);
 
     Consult getConsultByConsultId(Long consultId);
 

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -64,6 +64,7 @@ public class ConsultServiceImpl implements ConsultService {
                 .counselor(counselor)
                 .consultType(consultType)
                 .cost(cost)
+                .customerPhoneNumber(consultCreateRequest.getPhoneNumber())
                 .build();
         consultRepository.save(consult);
     }

--- a/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
+++ b/src/main/java/com/example/sharemind/consult/application/ConsultServiceImpl.java
@@ -43,7 +43,7 @@ public class ConsultServiceImpl implements ConsultService {
 
     @Transactional
     @Override
-    public void createConsult(ConsultCreateRequest consultCreateRequest, Long customerId) {
+    public Long createConsult(ConsultCreateRequest consultCreateRequest, Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
         Counselor counselor = counselorService.getCounselorByCounselorId(consultCreateRequest.getCounselorId());
         if (!counselor.getProfileStatus().equals(ProfileStatus.EVALUATION_COMPLETE)) {
@@ -67,6 +67,8 @@ public class ConsultServiceImpl implements ConsultService {
                 .customerPhoneNumber(consultCreateRequest.getPhoneNumber())
                 .build();
         consultRepository.save(consult);
+
+        return consult.getPayment().getPaymentId();
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -120,12 +120,28 @@ public class Consult extends BaseEntity {
         this.payment.updateIsPaidTrue();
     }
 
+    public void updateIsPaidAndLetter(Letter letter, String method, String approvedAt) {
+        validateConsultType(ConsultType.LETTER);
+        setLetter(letter);
+        updateConsultedAt();
+
+        this.payment.updateMethodAndIsPaidAndApprovedAt(method, approvedAt);
+    }
+
     public void updateIsPaidAndChat(Chat chat) {
         validateConsultType(ConsultType.CHAT);
         setChat(chat);
         updateConsultedAt();
 
         this.payment.updateIsPaidTrue();
+    }
+
+    public void updateIsPaidAndChat(Chat chat, String method, String approvedAt) {
+        validateConsultType(ConsultType.CHAT);
+        setChat(chat);
+        updateConsultedAt();
+
+        this.payment.updateMethodAndIsPaidAndApprovedAt(method, approvedAt);
     }
 
     public void setReview() {

--- a/src/main/java/com/example/sharemind/consult/domain/Consult.java
+++ b/src/main/java/com/example/sharemind/consult/domain/Consult.java
@@ -67,13 +67,17 @@ public class Consult extends BaseEntity {
     private Payment payment;
 
     @Builder
-    public Consult(Customer customer, Counselor counselor, Long cost, ConsultType consultType) {
+    public Consult(Customer customer, Counselor counselor, Long cost, ConsultType consultType,
+            String customerPhoneNumber) {
         this.customer = customer;
         this.counselor = counselor;
         this.cost = cost;
         this.consultType = consultType;
         this.consultStatus = ConsultStatus.WAITING;
-        this.payment = Payment.builder().consult(this).build();
+        this.payment = Payment.builder()
+                .customerPhoneNumber(customerPhoneNumber)
+                .consult(this)
+                .build();
     }
 
     public void updateConsultStatusOnGoing() {

--- a/src/main/java/com/example/sharemind/consult/dto/request/ConsultCreateRequest.java
+++ b/src/main/java/com/example/sharemind/consult/dto/request/ConsultCreateRequest.java
@@ -15,4 +15,8 @@ public class ConsultCreateRequest {
     @Schema(description = "신청할 상담 종류", example = "Letter")
     @NotBlank(message = "상담 유형은 공백일 수 없습니다.")
     private String consultTypeName;
+
+    @Schema(description = "전화번호(하이픈 필수)", example = "010-1234-5678")
+    @NotBlank(message = "전화번호는 공백일 수 없습니다.")
+    private String phoneNumber;
 }

--- a/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sharemind/global/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/counselors/all/**", "/api/v1/searchWords/results/**", "/api/v1/reviews/all/**").permitAll()
                                 .requestMatchers("/index.html", "/favicon.ico", "/chat/**", "/customer.html", "/customer2.html",
                                         "/counselor.html").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/v1/payApp/consults", "/api/v1/payApp/posts").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/admins/managements").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/posts/{postId}").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/posts/customers/public/**").permitAll()

--- a/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/sharemind/global/exception/CustomExceptionHandler.java
@@ -11,6 +11,7 @@ import com.example.sharemind.customer.exception.CustomerException;
 import com.example.sharemind.email.exception.EmailException;
 import com.example.sharemind.letter.exception.LetterException;
 import com.example.sharemind.letterMessage.exception.LetterMessageException;
+import com.example.sharemind.payApp.exception.PayAppException;
 import com.example.sharemind.payment.exception.PaymentException;
 import com.example.sharemind.post.exception.PostException;
 import com.example.sharemind.postLike.exception.PostLikeException;
@@ -143,6 +144,13 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(PostScrapException.class)
     public ResponseEntity<CustomExceptionResponse> catchPostScrapException(PostScrapException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(PayAppException.class)
+    public ResponseEntity<CustomExceptionResponse> catchPayAppException(PayAppException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(CustomExceptionResponse.of(e.getErrorCode().name(), e.getMessage()));

--- a/src/main/java/com/example/sharemind/payApp/application/PayAppService.java
+++ b/src/main/java/com/example/sharemind/payApp/application/PayAppService.java
@@ -1,0 +1,14 @@
+package com.example.sharemind.payApp.application;
+
+public interface PayAppService {
+
+    String payConsult(Long paymentId);
+
+    String payPost(Long postId);
+
+    String confirmConsult(String userId, String key, String value, Long cost,
+            String approvedAt, Integer method, Integer state, Long val1, String payAppId);
+
+    String confirmPost(String userId, String key, String value, Long cost,
+            String approvedAt, Integer method, Integer state, Long val1, String payAppId);
+}

--- a/src/main/java/com/example/sharemind/payApp/application/PayAppServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payApp/application/PayAppServiceImpl.java
@@ -1,0 +1,232 @@
+package com.example.sharemind.payApp.application;
+
+import com.example.sharemind.chat.application.ChatService;
+import com.example.sharemind.chat.domain.Chat;
+import com.example.sharemind.consult.domain.Consult;
+import com.example.sharemind.letter.application.LetterService;
+import com.example.sharemind.letter.domain.Letter;
+import com.example.sharemind.payApp.content.PayMethod;
+import com.example.sharemind.payApp.exception.PayAppErrorCode;
+import com.example.sharemind.payApp.exception.PayAppException;
+import com.example.sharemind.payment.application.PaymentService;
+import com.example.sharemind.payment.domain.Payment;
+import com.example.sharemind.post.application.PostService;
+import com.example.sharemind.post.domain.Post;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PayAppServiceImpl implements PayAppService {
+
+    private static final String PAY_REQUEST_CMD = "payrequest";
+    private static final String CHECK_RETRY_Y = "y";
+    private static final String SECRET_POST = "공개상담 - 비공개";
+
+    private final PaymentService paymentService;
+    private final PostService postService;
+    private final ChatService chatService;
+    private final LetterService letterService;
+
+    @Value("${payapp.url}")
+    private String payAppUrl;
+
+    private final RestClient restClient = RestClient.builder()
+            .baseUrl(payAppUrl)
+            .build();
+
+    @Value("${payapp.user-id}")
+    private String payAppUserId;
+
+    @Value("${payapp.key}")
+    private String payAppKey;
+
+    @Value("${payapp.value}")
+    private String payAppValue;
+
+    @Value("${payapp.feedback.consult}")
+    private String feedBackConsult;
+
+    @Value("${payapp.feedback.post}")
+    private String feedBackPost;
+
+    @Value("${payapp.return}")
+    private String returnUrl;
+
+    @Override
+    @Transactional
+    public String payConsult(Long paymentId) {
+        Payment payment = paymentService.getPaymentByPaymentId(paymentId);
+        if (payment.checkAlreadyPaid()) {
+            throw new PayAppException(PayAppErrorCode.ALREADY_REQUESTED_PAYMENT);
+        }
+
+        Consult consult = payment.getConsult();
+
+        String result = restClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("cmd", PAY_REQUEST_CMD)
+                        .queryParam("userid", payAppUserId)
+                        .queryParam("goodname", consult.getConsultType().getDisplayName())
+                        .queryParam("price", consult.getCost())
+                        .queryParam("recvphone", payment.getCustomerPhoneNumber())
+                        .queryParam("feedbackurl", feedBackConsult)
+                        .queryParam("val1", payment.getPaymentId())
+                        .queryParam("returnurl", returnUrl)
+                        .queryParam("checkretry", CHECK_RETRY_Y)
+                        .build())
+                .retrieve()
+                .body(String.class);
+
+        if (result == null) {
+            throw new PayAppException(PayAppErrorCode.PAY_RESPONSE_NOT_FOUND);
+        }
+
+        Map<String, String> response = parseQueryString(result);
+
+        String state = response.get("state");
+        if (state.equals("1")) {
+            String payAppId = response.get("mul_no");
+            payment.updatePayAppId(payAppId);
+
+            return response.get("payurl");
+        } else if (state.equals("0")) {
+            String errorNumber = response.get("errno");
+            String errorMessage = response.get("errorMessage");
+
+            throw new PayAppException(PayAppErrorCode.PAY_REQUEST_FAIL,
+                    errorNumber + " " + errorMessage);
+        } else {
+            throw new PayAppException(PayAppErrorCode.PAY_REQUEST_FAIL);
+        }
+    }
+
+    @Override
+    @Transactional
+    public String payPost(Long postId) {
+        Post post = postService.getPostByPostId(postId);
+        if (post.checkAlreadyPaid()) {
+            throw new PayAppException(PayAppErrorCode.ALREADY_REQUESTED_PAYMENT);
+        }
+
+        String result = restClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("cmd", PAY_REQUEST_CMD)
+                        .queryParam("userid", payAppUserId)
+                        .queryParam("goodname", SECRET_POST)
+                        .queryParam("price", post.getCost())
+                        .queryParam("recvphone", post.getCustomerPhoneNumber())
+                        .queryParam("feedbackurl", feedBackPost)
+                        .queryParam("val1", post.getPostId())
+                        .queryParam("returnurl", returnUrl)
+                        .queryParam("checkretry", CHECK_RETRY_Y)
+                        .build())
+                .retrieve()
+                .body(String.class);
+
+        if (result == null) {
+            throw new PayAppException(PayAppErrorCode.PAY_RESPONSE_NOT_FOUND);
+        }
+
+        Map<String, String> response = parseQueryString(result);
+
+        String state = response.get("state");
+        if (state.equals("1")) {
+            String payAppId = response.get("mul_no");
+            post.updatePayAppId(payAppId);
+
+            return response.get("payurl");
+        } else if (state.equals("0")) {
+            String errorNumber = response.get("errno");
+            String errorMessage = response.get("errorMessage");
+
+            throw new PayAppException(PayAppErrorCode.PAY_REQUEST_FAIL,
+                    errorNumber + " " + errorMessage);
+        } else {
+            throw new PayAppException(PayAppErrorCode.PAY_REQUEST_FAIL);
+        }
+    }
+
+    @Override
+    @Transactional
+    public String confirmConsult(String userId, String key, String value, Long cost,
+            String approvedAt, Integer method, Integer state, Long val1, String payAppId) {
+        if (!payAppUserId.equals(userId) || !payAppKey.equals(key) || !payAppValue.equals(value)) {
+            throw new PayAppException(PayAppErrorCode.CONFIRM_BASIC_INFO_FAIL);
+        }
+
+        Payment payment = paymentService.getPaymentByPaymentId(val1);
+        if (!payment.getPayAppId().equals(payAppId) || !payment.getConsult().getCost()
+                .equals(cost)) {
+            throw new PayAppException(PayAppErrorCode.CONFIRM_PAYMENT_INFO_FAIL);
+        }
+
+        if (state == 4 && !payment.getIsPaid()) {
+            PayMethod payMethod = PayMethod.getPayMethod(method);
+
+            Consult consult = payment.getConsult();
+            switch (consult.getConsultType()) {
+                case LETTER -> {
+                    Letter letter = letterService.createLetter();
+
+                    consult.updateIsPaidAndLetter(letter, payMethod.getMethod(), approvedAt);
+                }
+                case CHAT -> {
+                    Chat chat = chatService.createChat(consult);
+
+                    consult.updateIsPaidAndChat(chat, payMethod.getMethod(), approvedAt);
+                }
+            }
+        }
+
+        return "SUCCESS";
+    }
+
+    @Override
+    @Transactional
+    public String confirmPost(String userId, String key, String value, Long cost,
+            String approvedAt, Integer method, Integer state, Long val1, String payAppId) {
+        if (!payAppUserId.equals(userId) || !payAppKey.equals(key) || !payAppValue.equals(value)) {
+            throw new PayAppException(PayAppErrorCode.CONFIRM_BASIC_INFO_FAIL);
+        }
+
+        Post post = postService.getPostByPostId(val1);
+        if (!post.getPayAppId().equals(payAppId) || !post.getCost().equals(cost)) {
+            throw new PayAppException(PayAppErrorCode.CONFIRM_PAYMENT_INFO_FAIL);
+        }
+
+        if (state == 4 && !post.getIsPaid()) {
+            PayMethod payMethod = PayMethod.getPayMethod(method);
+
+            post.updateMethodAndIsPaidAndApprovedAt(payMethod.getMethod(), approvedAt);
+        }
+
+        return "SUCCESS";
+    }
+
+    private Map<String, String> parseQueryString(String queryString) {
+        Map<String, String> map = new HashMap<>();
+
+        String[] pairs = queryString.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            String key = idx > 0 ? pair.substring(0, idx) : pair;
+            String value = idx > 0 && pair.length() > idx + 1 ? pair.substring(idx + 1) : "";
+
+            String decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8);
+            String decodedValue = URLDecoder.decode(value, StandardCharsets.UTF_8);
+
+            map.put(decodedKey, decodedValue);
+        }
+
+        return map;
+    }
+}

--- a/src/main/java/com/example/sharemind/payApp/content/PayMethod.java
+++ b/src/main/java/com/example/sharemind/payApp/content/PayMethod.java
@@ -1,0 +1,35 @@
+package com.example.sharemind.payApp.content;
+
+import com.example.sharemind.payApp.exception.PayAppErrorCode;
+import com.example.sharemind.payApp.exception.PayAppException;
+import java.util.Arrays;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum PayMethod {
+
+    CREDIT_CARD(1, "신용카드"),
+    MOBILE_PHONE(2, "휴대전화"),
+    OVERSEAS_PAYMENT(3, "해외결제"),
+    IN_PERSON_PAYMENT(4, "대면결제"),
+    BANK_TRANSFER(6, "계좌이체"),
+    VIRTUAL_ACCOUNT(7, "가상계좌"),
+    KAKAO_PAY(15, "카카오페이"),
+    NAVER_PAY(16, "네이버페이"),
+    REGISTERED_PAYMENT(17, "등록결제"),
+    SMILE_PAY(21, "스마일페이"),
+    APPLE_PAY(23, "애플페이");
+
+    private final Integer number;
+    private final String method;
+
+    public static PayMethod getPayMethod(Integer number) {
+        return Arrays.stream(PayMethod.values())
+                .filter(method -> method.getNumber().equals(number))
+                .findAny().orElseThrow(() -> new PayAppException(PayAppErrorCode.METHOD_NOT_FOUND,
+                        number.toString()));
+    }
+}

--- a/src/main/java/com/example/sharemind/payApp/exception/PayAppErrorCode.java
+++ b/src/main/java/com/example/sharemind/payApp/exception/PayAppErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.sharemind.payApp.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum PayAppErrorCode {
+
+    ALREADY_REQUESTED_PAYMENT(HttpStatus.BAD_REQUEST, "결제 요청 정보가 이미 존재합니다."),
+    PAY_RESPONSE_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 요청에 대한 응답이 존재하지 않습니다."),
+    PAY_REQUEST_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "결제 요청이 실패하였습니다."),
+    CONFIRM_BASIC_INFO_FAIL(HttpStatus.BAD_REQUEST, "판매자 아이디, key, value 값이 일치하지 않습니다."),
+    CONFIRM_PAYMENT_INFO_FAIL(HttpStatus.BAD_REQUEST, "상담료, payAppId 값이 일치하지 않습니다."),
+    METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 수단을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    PayAppErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/sharemind/payApp/exception/PayAppException.java
+++ b/src/main/java/com/example/sharemind/payApp/exception/PayAppException.java
@@ -1,0 +1,19 @@
+package com.example.sharemind.payApp.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PayAppException extends RuntimeException {
+
+    private final PayAppErrorCode errorCode;
+
+    public PayAppException(PayAppErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public PayAppException(PayAppErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " : " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/sharemind/payApp/presentation/PayAppController.java
+++ b/src/main/java/com/example/sharemind/payApp/presentation/PayAppController.java
@@ -1,0 +1,36 @@
+package com.example.sharemind.payApp.presentation;
+
+import com.example.sharemind.payApp.application.PayAppService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/payApp")
+@RequiredArgsConstructor
+public class PayAppController {
+
+    private final PayAppService payAppService;
+
+    @PostMapping("/consults")
+    public String confirmPay(@RequestParam("userid") String userId,
+            @RequestParam("linkkey") String key, @RequestParam("linkval") String value,
+            @RequestParam("price") Long cost, @RequestParam("pay_date") String approvedAt,
+            @RequestParam("pay_type") Integer method, @RequestParam("pay_state") Integer state,
+            @RequestParam("val1") Long val1, @RequestParam("mul_no") String payAppId) {
+        return payAppService.confirmConsult(userId, key, value, cost, approvedAt, method, state,
+                val1, payAppId);
+    }
+
+    @PostMapping("/posts")
+    public String confirmPost(@RequestParam("userid") String userId,
+            @RequestParam("linkkey") String key, @RequestParam("linkval") String value,
+            @RequestParam("price") Long cost, @RequestParam("pay_date") String approvedAt,
+            @RequestParam("pay_type") Integer method, @RequestParam("pay_state") Integer state,
+            @RequestParam("val1") Long val1, @RequestParam("mul_no") String payAppId) {
+        return payAppService.confirmPost(userId, key, value, cost, approvedAt, method, state,
+                val1, payAppId);
+    }
+}

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -9,6 +9,7 @@ import com.example.sharemind.payment.content.PaymentCustomerStatus;
 import com.example.sharemind.payment.exception.PaymentErrorCode;
 import com.example.sharemind.payment.exception.PaymentException;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,8 +29,18 @@ public class Payment extends BaseEntity {
     @Column(name = "payment_id")
     private Long paymentId;
 
-    @Column(nullable = false)
+    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 하이픈(-)을 포함한 10~11자리이어야 합니다.")
+    @Column(name = "customer_phone_number")
+    private String customerPhoneNumber;
+
+    @Column(name = "pay_app_id")
+    private String payAppId;
+
+    @Column
     private String method;
+
+    @Column
+    private String approved;
 
     @Column(name = "is_paid", nullable = false)
     private Boolean isPaid;
@@ -49,11 +60,22 @@ public class Payment extends BaseEntity {
     private Consult consult;
 
     @Builder
-    public Payment(Consult consult) {
+    public Payment(String customerPhoneNumber, Consult consult) {
+        this.customerPhoneNumber = customerPhoneNumber;
         this.consult = consult;
-        this.method = "외부 결제";
         this.isPaid = false;
         updateBothStatusNone();
+    }
+
+    public void updatePayAppId(String payAppId) {
+        this.payAppId = payAppId;
+    }
+
+    public void updateMethodAndIsPaidAndApprovedAt(String method, String approvedAt) {
+        this.method = method;
+        this.isPaid = true;
+        this.approved = approvedAt;
+        updateCustomerStatusPaymentComplete();
     }
 
     public void updateIsPaidTrue() {
@@ -133,5 +155,9 @@ public class Payment extends BaseEntity {
         if (!this.consult.getCounselor().getCounselorId().equals(counselorId)) {
             throw new PaymentException(PaymentErrorCode.PAYMENT_UPDATE_DENIED);
         }
+    }
+
+    public Boolean checkAlreadyPaid() {
+        return this.isPaid && (this.payAppId != null);
     }
 }

--- a/src/main/java/com/example/sharemind/post/application/PostService.java
+++ b/src/main/java/com/example/sharemind/post/application/PostService.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface PostService {
 
-    void createPost(PostCreateRequest postCreateRequest, Long customerId);
+    Long createPost(PostCreateRequest postCreateRequest, Long customerId);
 
     List<Post> getAllPosts();
 

--- a/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
+++ b/src/main/java/com/example/sharemind/post/application/PostServiceImpl.java
@@ -51,10 +51,11 @@ public class PostServiceImpl implements PostService {
 
     @Transactional
     @Override
-    public void createPost(PostCreateRequest postCreateRequest, Long customerId) {
+    public Long createPost(PostCreateRequest postCreateRequest, Long customerId) {
         Customer customer = customerService.getCustomerByCustomerId(customerId);
 
-        postRepository.save(postCreateRequest.toEntity(customer));
+        Post post = postRepository.save(postCreateRequest.toEntity(customer));
+        return post.getPostId();
     }
 
     @Override

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -81,7 +81,7 @@ public class Post extends BaseEntity {
     private LocalDateTime finishedAt;
 
     @Builder
-    public Post(Customer customer, Long cost, Boolean isPublic) {
+    public Post(Customer customer, Long cost, Boolean isPublic, String customerPhoneNumber) {
         this.customer = customer;
         this.cost = cost;
         this.isPublic = isPublic;
@@ -89,6 +89,7 @@ public class Post extends BaseEntity {
         this.totalLike = 0L;
         this.totalComment = 0L;
         this.totalScrap = 0L;
+        this.customerPhoneNumber = customerPhoneNumber;
         setIsPaid(isPublic);
     }
 

--- a/src/main/java/com/example/sharemind/post/domain/Post.java
+++ b/src/main/java/com/example/sharemind/post/domain/Post.java
@@ -16,6 +16,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -68,6 +69,19 @@ public class Post extends BaseEntity {
     @Column(name = "total_scrap", nullable = false)
     private Long totalScrap;
 
+    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 하이픈(-)을 포함한 10~11자리이어야 합니다.")
+    @Column(name = "customer_phone_number")
+    private String customerPhoneNumber;
+
+    @Column(name = "pay_app_id")
+    private String payAppId;
+
+    @Column(name = "method")
+    private String method;
+
+    @Column(name = "approved_at")
+    private String approvedAt;
+
     @Column(name = "is_paid", nullable = false)
     private Boolean isPaid;
 
@@ -91,6 +105,16 @@ public class Post extends BaseEntity {
         this.totalScrap = 0L;
         this.customerPhoneNumber = customerPhoneNumber;
         setIsPaid(isPublic);
+    }
+
+    public void updatePayAppId(String payAppId) {
+        this.payAppId = payAppId;
+    }
+
+    public void updateMethodAndIsPaidAndApprovedAt(String method, String approvedAt) {
+        this.method = method;
+        this.isPaid = true;
+        this.approvedAt = approvedAt;
     }
 
     public void updateIsPaid() {
@@ -185,5 +209,9 @@ public class Post extends BaseEntity {
         if (this.isCompleted != null && this.isCompleted.equals(true)) {
             throw new PostException(PostErrorCode.POST_ALREADY_COMPLETED);
         }
+    }
+
+    public Boolean checkAlreadyPaid() {
+        return this.isPaid && (this.payAppId != null);
     }
 }

--- a/src/main/java/com/example/sharemind/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/sharemind/post/dto/request/PostCreateRequest.java
@@ -3,6 +3,7 @@ package com.example.sharemind.post.dto.request;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -17,11 +18,16 @@ public class PostCreateRequest {
     @NotNull(message = "상담 공개 여부는 공백일 수 없습니다.")
     private Boolean isPublic;
 
+    @Schema(description = "전화번호(하이픈 필수)", example = "010-1234-5678")
+    @NotBlank(message = "전화번호는 공백일 수 없습니다.")
+    private String phoneNumber;
+
     public Post toEntity(Customer customer) {
         return Post.builder()
                 .customer(customer)
                 .cost(cost)
                 .isPublic(isPublic)
+                .customerPhoneNumber(phoneNumber)
                 .build();
     }
 }

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -49,14 +49,19 @@ public class PostController {
             )
     })
     @PostMapping
-    public ResponseEntity<String> createPost(
+    public ResponseEntity<?> createPost(
             @Valid @RequestBody PostCreateRequest postCreateRequest,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long postId = postService.createPost(postCreateRequest,
                 customUserDetails.getCustomer().getCustomerId());
-        String payUrl = payAppService.payPost(postId);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(payUrl);
+        if (postCreateRequest.getIsPublic()) {
+            return ResponseEntity.status(HttpStatus.CREATED).build();
+        } else {
+            String payUrl = payAppService.payPost(postId);
+
+            return ResponseEntity.status(HttpStatus.CREATED).body(payUrl);
+        }
     }
 
     @Operation(summary = "일대다 상담 질문 내용 작성", description = "일대다 상담 질문 내용 작성")

--- a/src/main/java/com/example/sharemind/post/presentation/PostController.java
+++ b/src/main/java/com/example/sharemind/post/presentation/PostController.java
@@ -2,6 +2,7 @@ package com.example.sharemind.post.presentation;
 
 import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
+import com.example.sharemind.payApp.application.PayAppService;
 import com.example.sharemind.post.application.PostService;
 import com.example.sharemind.post.dto.request.PostCreateRequest;
 import com.example.sharemind.post.dto.request.PostUpdateRequest;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
 
     private final PostService postService;
+    private final PayAppService payAppService;
 
     @Operation(summary = "일대다 상담 질문 신청", description = "일대다 상담 질문 신청")
     @ApiResponses({
@@ -47,10 +49,14 @@ public class PostController {
             )
     })
     @PostMapping
-    public ResponseEntity<Void> createPost(@Valid @RequestBody PostCreateRequest postCreateRequest,
+    public ResponseEntity<String> createPost(
+            @Valid @RequestBody PostCreateRequest postCreateRequest,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        postService.createPost(postCreateRequest, customUserDetails.getCustomer().getCustomerId());
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        Long postId = postService.createPost(postCreateRequest,
+                customUserDetails.getCustomer().getCustomerId());
+        String payUrl = payAppService.payPost(postId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(payUrl);
     }
 
     @Operation(summary = "일대다 상담 질문 내용 작성", description = "일대다 상담 질문 내용 작성")


### PR DESCRIPTION
## 📄구현 내용
- solving #244 
- 외부 api 관련 로직을 두는 payApp 패키지를 새로 만들었습니다.
  - payAppService에는 4가지 로직이 존재합니다
    - payConsult : 편지와 채팅에 대한 결제 url을 요청
    - payPost : 비공개 상담에 대한 결제 url을 요청
    - confirmConsult : 편지와 채팅에 대한 결제 승인을 확인
    - confirmPost : 비공개 상담에 대한 결제 승인을 확인
- 주요 로직은 다음과 같습니다.
  1. postController/consultController에서 상담 신청에 해당하는 api가 요청됨 (프론트 -> 백)
  2. postService/consultService에서 post/consult 정보 생성해 postId/paymentId 반환 (백 내부)
  3. postId/paymentId를 가지고 외부 api로 결제 url 요청 (백 -> 페이앱) : 이때 payConsult/payPost 서비스 로직 사용
  4. 결제 url 받아서 프론트에 반환 (페이앱 -> 백 -> 프론트)
  5. 결제 이루어짐 (프론트)
  6. 셰어마인드 화면으로 리다이렉트 (프론트) : 이 부분은 3의 요청 시 queryParameter 중 returnurl에 해당합니다. 현재는 임시로 셰어마인드 메인 url로 설정해두었습니다.
  7. 결제 승인에 대한 api 요청됨 (페이앱 -> 백) : 이 부분은 3의 요청 시 queryParameter 중 feedbackurl에 해당하는 저희 서버 api로 요청됩니다. 이때 confirmConsult/confirmPost 서비스 로직 사용
- 6번까지는 로컬에서도 테스트해볼 수 있는 부분입니다. 그런데 7의 경우, feedbackurl을 localhost:8080으로 설정해두면 페이앱에서 제대로 요청을 보낼 수 없기 때문에 테스트 서버 배포 후에는 7을 위주로 테스트 진행될 예정입니다.
- 기존 엔티티들에 추가된 필드들이 있습니다.
  - 사용자 전화번호 (이번주 회의내용 반영)
  - 페이앱에 결제 요청 시 생성되는 고유 아이디
  - 결제 승인 일시
    - payment에는 결제 승인 일시를 저장하는 approvedAt이 이미 존재하고 있으나 페이앱에서 결제 승인 일시를 어떠한 형식으로 넘겨주는지 아직 확인할 수 없어 임시로 새 필드를 추가하였습니다. 확인 후 수정하겠습니다.
  - 결제 방법

## 📝기타 알림사항
- 외부 api 요청 시 restClient 사용을 위해 스프링부트 버전을 업그레이드하였습니다.
  - restClient는 스프링부트 3.2부터 지원됩니다. 
  - 외부 api 호출을 위한 여러 옵션이 있는데, 주로 많이 사용되는 restTemplate, webClient, restClient를 고려하였습니다. 
  이 중 webClient는 webflux 라이브러리를 추가해야하는 부담이 있어 가장 먼저 제외하였고, restTemplate과 restClient 중 공식 문서 상에서 사용이 더 권고되는 restClient를 선택하였습니다.
- 외부 api 호출 관련 여러 값들을 환경변수로 처리해주었는데, 로컬에서 테스트 했을 때는 payAppUrl 값이 제대로 처리되지 않는 문제가 있었습니다. 반드시 숨겨야하는 민감정보는 아니라 테스트 서버에서 같은 문제 발생 시 하드코딩으로 전환할 예정입니다. yml 파일은 노션에 업데이트 해두었습니다.
- 결제 api를 붙인 후 admin을 사용한 결제 확인은 어떻게 되는 것인지 아직 정해진 바가 없어 일단 지금까지 해온 것처럼 어드민에서도 결제 승인을 할 수 있도록 감안해서 로직을 구현했습니다.
이 과정에서 createChat 로직이 약간 수정되었습니다. 이전에는 createChat 내부에서 결제 여부를 수정해주었는데, 이렇게 되면 페이앱 결제 시 추가로 저장하는 정보들까지 저장하는 메서드를 실행할 방법이 없어 결제 여부 수정 로직을 밖으로 빼주게 되었습니다.