### PR TITLE
feat: 상담사 프로필 업데이트 거절 시 사유 알려주는 란 추가

### DIFF
--- a/src/main/java/com/example/sharemind/admin/application/AdminService.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminService.java
@@ -19,7 +19,7 @@ public interface AdminService {
     SmsGetResponse updateConsultIsPaid(Long consultId);
     List<CounselorGetProfileResponse> getPendingCounselors();
 
-    void updateProfileStatus(Long counselorId, Boolean isPassed);
+    void updateProfileStatus(Long counselorId, Boolean isPassed, String reason);
 
     List<PaymentGetRefundWaitingResponse> getRefundWaitingPayments();
 

--- a/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/example/sharemind/admin/application/AdminServiceImpl.java
@@ -106,7 +106,7 @@ public class AdminServiceImpl implements AdminService {
 
     @Transactional
     @Override
-    public void updateProfileStatus(Long counselorId, Boolean isPassed) {
+    public void updateProfileStatus(Long counselorId, Boolean isPassed, String reason) {
         Counselor counselor = counselorService.getCounselorByCounselorId(counselorId);
         if ((counselor.getProfileStatus() == null) ||
                 (!counselor.getProfileStatus().equals(ProfileStatus.EVALUATION_PENDING))) {
@@ -124,6 +124,7 @@ public class AdminServiceImpl implements AdminService {
             emailService.sendEmail(email, EmailType.COUNSELOR_PROFILE_FAIL, "");
         }
         counselor.updateProfileStatusAndProfileUpdatedAt(profileStatus);
+        counselor.updateProfileReason(reason);
 
         if (counselor.getProfileStatus().equals(ProfileStatus.EVALUATION_COMPLETE)) {
             Customer customer = customerService.getCustomerByCounselor(counselor);

--- a/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/sharemind/admin/presentation/AdminController.java
@@ -73,8 +73,11 @@ public class AdminController {
     }
 
     @Operation(summary = "상담사 프로필 심사 상태 수정",
-            description = "상담사 프로필 심사 상태 수정(최초 심사 통과 시 COUNSELOR 권한 부여), " +
-                    "주소 형식: /api/v1/admins/pending-profiles/{counselorId}?isPassed=true")
+            description =
+                    "상담사 프로필 심사 상태 수정(최초 심사 통과 시 COUNSELOR 권한 부여), reason의 경우 리젝시에만 보내주면 되는 optional한 값입니다."
+                            +
+                            "주소 형식: /api/v1/admins/pending-profiles/{counselorId}?isPassed=true&reason='test'")
+
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "심사 중이 아닌 상담사 프로필에 대한 요청",
@@ -88,12 +91,13 @@ public class AdminController {
     })
     @Parameters({
             @Parameter(name = "counselorId", description = "상담사 아이디"),
-            @Parameter(name = "isPassed", description = "심사 통과 여부")
+            @Parameter(name = "isPassed", description = "심사 통과 여부"),
+            @Parameter(name = "reason", description = "리젝 사유")
     })
     @PatchMapping("/pending-profiles/{counselorId}")
     public ResponseEntity<Void> updateProfileStatus(@PathVariable Long counselorId,
-            @RequestParam Boolean isPassed) {
-        adminService.updateProfileStatus(counselorId, isPassed);
+            @RequestParam Boolean isPassed, @RequestParam(required = false) String reason) {
+        adminService.updateProfileStatus(counselorId, isPassed, reason);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorService.java
@@ -71,4 +71,6 @@ public interface CounselorService {
             String sortType, int index);
 
     List<CounselorGetRandomListResponse> getAllRandomCounselors(String sortType, int index);
+
+    String getCounselorFailureReason(Long counselorId);
 }

--- a/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
+++ b/src/main/java/com/example/sharemind/counselor/application/CounselorServiceImpl.java
@@ -394,6 +394,14 @@ public class CounselorServiceImpl implements CounselorService {
         return counselorRepository.findAllByNicknameOrEmail(keyword);
     }
 
+    @Override
+    public String getCounselorFailureReason(Long customerId) {
+        Counselor counselor = getCounselorByCustomerId(customerId);
+        if (counselor.getProfileStatus() == ProfileStatus.EVALUATION_FAIL)
+            return counselor.getFailureReason();
+        return "";
+    }
+
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void updateRealtimeCounselors() {
         List<Counselor> counselors = counselorRepository.findAllByProfileStatusIsEvaluationCompleteAndIsActivatedIsTrue();

--- a/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Counselor.java
@@ -53,6 +53,9 @@ public class Counselor extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProfileStatus profileStatus;
 
+    @Column(name = "failure_reason")
+    private String failureReason;
+
     @ElementCollection(targetClass = ConsultCost.class, fetch = FetchType.LAZY)
     @JoinTable(name = "consult_costs", joinColumns = @JoinColumn(name = "counselor_id"))
     @Column(name = "consult_costs")
@@ -172,6 +175,10 @@ public class Counselor extends BaseEntity {
         } else {
             this.level = COUNSELOR_BASIC_LEVEL;
         }
+    }
+
+    public void updateProfileReason(String reason) {
+        this.failureReason = reason;
     }
 
     public void updateTotalReviewAndRatingAverage(Integer rating) {

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -324,6 +324,11 @@ public class CounselorController {
                         .getCustomerId()).getCounselorId());
     }
 
+    @Operation(summary = "프로필 리젝 사유 조회",
+            description = "프로필 리젝 사유 리턴하는 함수, 프로필 상태가 실패가 아니면 빈 문자열이 리턴됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping("/reason")
     public ResponseEntity<String> getCounselorFailureReason(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(counselorService.getCounselorFailureReason(customUserDetails.getCustomer()

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -323,4 +323,10 @@ public class CounselorController {
                 counselorService.getCounselorByCustomerId(customUserDetails.getCustomer()
                         .getCustomerId()).getCounselorId());
     }
+
+    @GetMapping("/reason")
+    public ResponseEntity<String> getCounselorFailureReason(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(counselorService.getCounselorFailureReason(customUserDetails.getCustomer()
+                .getCustomerId()));
+    }
 }

--- a/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
+++ b/src/main/java/com/example/sharemind/counselor/presentation/CounselorController.java
@@ -329,7 +329,7 @@ public class CounselorController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
-    @GetMapping("/reason")
+    @GetMapping("/profile-rejection")
     public ResponseEntity<String> getCounselorFailureReason(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(counselorService.getCounselorFailureReason(customUserDetails.getCustomer()
                 .getCustomerId()));


### PR DESCRIPTION
## 📄구현 내용
- #257 

## 📝기타 알림사항
- 리젝 사유의 경우, 실패시에만 넣어줘도 되게 optional한 값으로 두었습니다.
- 통과인 경우, 리젝 사유를 빈 문자열로 업데이트되게 하였습니다.