### PR TITLE
fix: 마인더 수익 관리 dto 필드 오류 수정

### DIFF
--- a/src/main/java/com/example/sharemind/payment/application/PaymentService.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentService.java
@@ -4,7 +4,7 @@ import com.example.sharemind.counselor.domain.Counselor;
 import com.example.sharemind.customer.domain.Customer;
 import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.dto.response.PaymentGetCounselorHomeResponse;
-import com.example.sharemind.payment.dto.response.PaymentGetCounselorResponse;
+import com.example.sharemind.payment.dto.response.PaymentGetCounselorResponses;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 
 import java.util.List;
@@ -20,7 +20,7 @@ public interface PaymentService {
 
     List<Payment> getRefundWaitingPayments();
 
-    List<PaymentGetCounselorResponse> getPaymentsByCounselor(Long paymentId, String status, String sort, Long customerId);
+    PaymentGetCounselorResponses getPaymentsByCounselor(Long paymentId, String status, String sort, Long customerId);
 
     void updateSettlementOngoingByCounselor(Long paymentId, Long customerId);
 

--- a/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.sharemind.payment.content.PaymentSortType;
 import com.example.sharemind.payment.domain.Payment;
 import com.example.sharemind.payment.dto.response.PaymentGetCounselorHomeResponse;
 import com.example.sharemind.payment.dto.response.PaymentGetCounselorResponse;
+import com.example.sharemind.payment.dto.response.PaymentGetCounselorResponses;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import com.example.sharemind.payment.exception.PaymentErrorCode;
 import com.example.sharemind.payment.exception.PaymentException;
@@ -97,7 +98,7 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    public List<PaymentGetCounselorResponse> getPaymentsByCounselor(Long paymentId, String status,
+    public PaymentGetCounselorResponses getPaymentsByCounselor(Long paymentId, String status,
             String sort, Long customerId) {
         Counselor counselor = counselorService.getCounselorByCustomerId(customerId);
         PaymentCounselorStatus counselorStatus = PaymentCounselorStatus.getPaymentCounselorStatusByName(
@@ -147,7 +148,7 @@ public class PaymentServiceImpl implements PaymentService {
                                 paymentId, counselor, counselorStatus, sortTime, pageable))
                         .map(payment -> PaymentGetCounselorResponse.of(payment, finalTotal));
 
-        return page.getContent();
+        return PaymentGetCounselorResponses.of(total, page.getContent());
     }
 
     @Transactional

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -53,6 +53,9 @@ public class Payment extends BaseEntity {
     @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 
+    @Column(name = "settled_at")
+    private LocalDateTime settledAt;
+
     @OneToOne(mappedBy = "payment", optional = false)
     private Consult consult;
 
@@ -140,6 +143,7 @@ public class Payment extends BaseEntity {
         settlement.updateCompleteAll(amount);
 
         this.counselorStatus = PaymentCounselorStatus.SETTLEMENT_COMPLETE;
+        this.settledAt = LocalDateTime.now();
     }
 
     public void checkUpdateAuthorityByCustomer(Long customerId) {

--- a/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCounselorResponse.java
+++ b/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCounselorResponse.java
@@ -34,9 +34,13 @@ public class PaymentGetCounselorResponse {
     @Schema(description = "수수료")
     private final Long fee;
 
+    @Schema(description = "상담 일자", example = "2023.12.29", type = "string")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+    private final LocalDateTime consultedAt;
+
     @Schema(description = "지급 일자", example = "2023.12.23", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
-    private final LocalDateTime approvedAt;
+    private final LocalDateTime settledAt;
 
     @Schema(description = "지급 계좌")
     private final String account;
@@ -48,8 +52,9 @@ public class PaymentGetCounselorResponse {
         Consult consult = payment.getConsult();
         Boolean isChat = consult.getChat() != null;
 
-        return new PaymentGetCounselorResponse(payment.getPaymentId(), consult.getCustomer().getNickname(), isChat,
-                consult.getCost() - FEE, consult.getCost(), FEE, payment.getApprovedAt(),
+        return new PaymentGetCounselorResponse(payment.getPaymentId(),
+                consult.getCustomer().getNickname(), isChat, consult.getCost() - FEE,
+                consult.getCost(), FEE, consult.getConsultedAt(), payment.getSettledAt(),
                 consult.getCounselor().getAccount(), total);
     }
 }

--- a/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCounselorResponses.java
+++ b/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCounselorResponses.java
@@ -1,0 +1,29 @@
+package com.example.sharemind.payment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PaymentGetCounselorResponses {
+
+    @Schema(description = "금액 합계")
+    private final Long total;
+
+    @Schema(description = "정산 정보 목록")
+    private final List<PaymentGetCounselorResponse> paymentGetCounselorResponses;
+
+    @Builder
+    public PaymentGetCounselorResponses(Long total, List<PaymentGetCounselorResponse> paymentGetCounselorResponses) {
+        this.total = total;
+        this.paymentGetCounselorResponses = paymentGetCounselorResponses;
+    }
+
+    public static PaymentGetCounselorResponses of (Long total, List<PaymentGetCounselorResponse> paymentGetCounselorResponses) {
+        return PaymentGetCounselorResponses.builder()
+                .total(total)
+                .paymentGetCounselorResponses(paymentGetCounselorResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCustomerResponse.java
+++ b/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCustomerResponse.java
@@ -45,6 +45,6 @@ public class PaymentGetCustomerResponse {
 
         return new PaymentGetCustomerResponse(payment.getPaymentId(), consult.getCounselor().getNickname(),
                 consult.getConsultStatus().getDisplayName(), consult.getConsultType().getDisplayName(),
-                consult.getConsultedAt(), consult.getCost(), payment.getCreatedAt(), payment.getMethod());
+                consult.getConsultedAt(), consult.getCost(), payment.getApprovedAt(), payment.getMethod());
     }
 }

--- a/src/main/java/com/example/sharemind/payment/presentation/PaymentController.java
+++ b/src/main/java/com/example/sharemind/payment/presentation/PaymentController.java
@@ -4,7 +4,7 @@ import com.example.sharemind.global.exception.CustomExceptionResponse;
 import com.example.sharemind.global.jwt.CustomUserDetails;
 import com.example.sharemind.payment.application.PaymentService;
 import com.example.sharemind.payment.dto.response.PaymentGetCounselorHomeResponse;
-import com.example.sharemind.payment.dto.response.PaymentGetCounselorResponse;
+import com.example.sharemind.payment.dto.response.PaymentGetCounselorResponses;
 import com.example.sharemind.payment.dto.response.PaymentGetCustomerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -100,7 +100,7 @@ public class PaymentController {
                     2. 2번째 요청부터 paymentId는 직전 요청의 조회 결과 3개 중 마지막 paymentId""")
     })
     @GetMapping("/counselors")
-    public ResponseEntity<List<PaymentGetCounselorResponse>> getPaymentsByCounselor(@RequestParam String status,
+    public ResponseEntity<PaymentGetCounselorResponses> getPaymentsByCounselor(@RequestParam String status,
                                                                                     @RequestParam String sort,
                                                                                     @RequestParam Long paymentId,
                                                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {


### PR DESCRIPTION
## 📄구현 내용
- Resolved #270 
- PaymentGetCounselorResponse 수정
  - 지급일자 필드에 상담 결제 일자 값이 들어가고 있던 문제
    - Payment에 지급일자 필드(settledAt) 추가 및 dto에 적용
  - 상담사가 어떤 상담에 대한 정산 정보인지 파악할 수 있도록 상담 일자 필드 추가
  - 구조 수정
    - 정산 총금액 필드인 total이 모든 PaymentGetCounselorResponse에 반복적으로 들어가있어 PaymentGetCounselorResponse를 리스트로 가지는 dto 추가 생성하고 거기서 total 값 가지고 있도록 수정
- PaymentGetCustomerResponse 수정
  - 상담 결제 일자가 Payment 생성일자(createdAt)로 들어가있어 approvedAt으로 들어가도록 수정

## 📝기타 알림사항
