### PR TITLE
fix: 상담 수수료 로직 및 DB 테이블 구조 수정

### DIFF
--- a/src/main/java/com/example/sharemind/counselor/domain/Settlement.java
+++ b/src/main/java/com/example/sharemind/counselor/domain/Settlement.java
@@ -86,7 +86,7 @@ public class Settlement {
     }
 
     public void updateCompleteAll(Long amount) {
-        this.completeAll = amount;
+        this.completeAll += amount;
     }
 
     public void clearAll() {

--- a/src/main/java/com/example/sharemind/global/constants/Constants.java
+++ b/src/main/java/com/example/sharemind/global/constants/Constants.java
@@ -19,7 +19,7 @@ public class Constants {
     public static final Boolean IS_CHAT = true;
     public static final Boolean IS_LETTER = false;
 
-    public static final Long FEE = 1000L;
+    public static final Double FEE = 0.2;
 
     public static final Long MAX_COMMENTS = 5L;
 }

--- a/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/example/sharemind/payment/application/PaymentServiceImpl.java
@@ -28,8 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.example.sharemind.global.constants.Constants.FEE;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -213,7 +211,7 @@ public class PaymentServiceImpl implements PaymentService {
         paymentRepository.findAllByConsultCounselorAndCounselorStatusAndIsActivatedIsTrue(counselor,
                         PaymentCounselorStatus.SETTLEMENT_WAITING)
                 .forEach(payment -> {
-                    Long amount = payment.getConsult().getCost() - FEE;
+                    Long amount = payment.getConsult().getCost() - payment.getFee();
                     settlement.updateWaitingAll(amount);
                     if (payment.getUpdatedAt().isAfter(LocalDateTime.now().minusWeeks(1))) {
                         settlement.updateWaitingWeek(amount);
@@ -225,7 +223,7 @@ public class PaymentServiceImpl implements PaymentService {
         paymentRepository.findAllByConsultCounselorAndCounselorStatusAndIsActivatedIsTrue(counselor,
                         PaymentCounselorStatus.SETTLEMENT_ONGOING)
                 .forEach(payment -> {
-                    Long amount = payment.getConsult().getCost() - FEE;
+                    Long amount = payment.getConsult().getCost() - payment.getFee();
                     settlement.updateOngoingAll(amount);
                     if (payment.getUpdatedAt().isAfter(LocalDateTime.now().minusWeeks(1))) {
                         settlement.updateOngoingWeek(amount);
@@ -237,7 +235,7 @@ public class PaymentServiceImpl implements PaymentService {
         paymentRepository.findAllByConsultCounselorAndCounselorStatusAndIsActivatedIsTrue(counselor,
                         PaymentCounselorStatus.SETTLEMENT_COMPLETE)
                 .forEach(payment -> {
-                    Long amount = payment.getConsult().getCost() - FEE;
+                    Long amount = payment.getConsult().getCost() - payment.getFee();
                     settlement.updateCompleteAll(amount);
                     if (payment.getUpdatedAt().isAfter(LocalDateTime.now().minusWeeks(1))) {
                         settlement.updateCompleteWeek(amount);

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -39,6 +39,9 @@ public class Payment extends BaseEntity {
     @Column
     private String method;
 
+    @Column(nullable = false)
+    private Long fee;
+
     @Column(name = "is_paid", nullable = false)
     private Boolean isPaid;
 
@@ -63,6 +66,7 @@ public class Payment extends BaseEntity {
     public Payment(String customerPhoneNumber, Consult consult) {
         this.customerPhoneNumber = customerPhoneNumber;
         this.consult = consult;
+        this.fee = Math.round(consult.getCost() * FEE);
         this.isPaid = false;
         updateBothStatusNone();
     }

--- a/src/main/java/com/example/sharemind/payment/domain/Payment.java
+++ b/src/main/java/com/example/sharemind/payment/domain/Payment.java
@@ -117,7 +117,7 @@ public class Payment extends BaseEntity {
 
     public void updateCounselorStatusSettlementOngoing() {
         Settlement settlement = this.consult.getCounselor().getSettlement();
-        long amount = this.consult.getCost() - FEE;
+        long amount = this.consult.getCost() - this.fee;
         if (this.getUpdatedAt().isAfter(LocalDateTime.now().minusWeeks(1))) {
             settlement.updateWaitingWeek(-amount);
         }
@@ -134,7 +134,7 @@ public class Payment extends BaseEntity {
 
     public void updateCounselorStatusSettlementComplete() {
         Settlement settlement = this.consult.getCounselor().getSettlement();
-        long amount = this.consult.getCost() - FEE;
+        long amount = this.consult.getCost() - this.fee;
         if (this.getUpdatedAt().isAfter(LocalDateTime.now().minusWeeks(1))) {
             settlement.updateOngoingWeek(-amount);
         }

--- a/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCounselorResponse.java
+++ b/src/main/java/com/example/sharemind/payment/dto/response/PaymentGetCounselorResponse.java
@@ -4,16 +4,12 @@ import com.example.sharemind.consult.domain.Consult;
 import com.example.sharemind.payment.domain.Payment;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
-import static com.example.sharemind.global.constants.Constants.FEE;
-
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentGetCounselorResponse {
 
     @Schema(description = "payment 아이디")
@@ -45,13 +41,36 @@ public class PaymentGetCounselorResponse {
     @Schema(description = "지급 계좌")
     private final String account;
 
+    @Builder
+    public PaymentGetCounselorResponse(Long paymentId, String nickname, Boolean isChat, Long profit,
+            Long cost, Long fee, LocalDateTime consultedAt, LocalDateTime settledAt,
+            String account) {
+        this.paymentId = paymentId;
+        this.nickname = nickname;
+        this.isChat = isChat;
+        this.profit = profit;
+        this.cost = cost;
+        this.fee = fee;
+        this.consultedAt = consultedAt;
+        this.settledAt = settledAt;
+        this.account = account;
+    }
+
+
     public static PaymentGetCounselorResponse of(Payment payment) {
         Consult consult = payment.getConsult();
         Boolean isChat = consult.getChat() != null;
 
-        return new PaymentGetCounselorResponse(payment.getPaymentId(),
-                consult.getCustomer().getNickname(), isChat, consult.getCost() - FEE,
-                consult.getCost(), FEE, consult.getConsultedAt(), payment.getSettledAt(),
-                consult.getCounselor().getAccount());
+        return PaymentGetCounselorResponse.builder()
+                .paymentId(payment.getPaymentId())
+                .nickname(consult.getCustomer().getNickname())
+                .isChat(isChat)
+                .profit(consult.getCost() - payment.getFee())
+                .cost(consult.getCost())
+                .fee(payment.getFee())
+                .consultedAt(consult.getConsultedAt())
+                .settledAt(payment.getSettledAt())
+                .account(consult.getCounselor().getAccount())
+                .build();
     }
 }


### PR DESCRIPTION
## 📄구현 내용
- Resolved #271 
- 이번주 회의에서 수수료율이 수정 여지가 있는 값임을 고려해서 Payment에 수수료 필드를 추가해 당시의 수수료율을 적용한 수수료를 저장해두기로 이야기되었습니다.

## 📝기타 알림사항
- 수수료 필드를 nullable false로 설정해두어 머지 후 DB에서 필드에 값을 채우는 작업이 필요합니다. 현재 테스트 서버에는 적용되어있습니다.